### PR TITLE
add support for running tests on Azure Gen2 VMs

### DIFF
--- a/jenkins/formats-amd64-usr.txt
+++ b/jenkins/formats-amd64-usr.txt
@@ -2,6 +2,7 @@ ami
 ami_vmdk
 ami_vmdk_pro
 azure
+azure_gen2
 azure_pro
 gce
 gce_pro

--- a/jenkins/kola/azure.sh
+++ b/jenkins/kola/azure.sh
@@ -43,5 +43,6 @@ timeout --signal=SIGQUIT 20h bin/kola run \
     --tapfile="${JOB_NAME##*/}.tap" \
     --torcx-manifest=torcx_manifest.json \
     ${AZURE_MACHINE_SIZE_OPT} \
+    ${AZURE_HYPER_V_GENERATION:+--azure-hyper-v-generation=${AZURE_HYPER_V_GENERATION}} \
     ${KOLA_TESTS}
 set +o noglob

--- a/jenkins/vms.sh
+++ b/jenkins/vms.sh
@@ -85,6 +85,15 @@ if [[ "${FORMATS}" = "" ]]
 then
   FORMATS="${FORMAT}"
 fi
+
+if [[ "${FORMATS}" == *"azure_gen2"* ]] ; then
+  # azure_gen2 shares an image with azure
+  if [[ " ${FORMATS} " != *" azure "* ]]; then
+    FORMATS+=" azure"
+  fi
+  FORMATS=${FORMATS/azure_gen2/}
+fi
+
 for FORMAT in ${FORMATS}; do
   # If the format variable ends with _pro it's a Flatcar Pro image and it should
   # be uploaded to the private bucket.


### PR DESCRIPTION
# add support for running tests on Azure Gen2 VMs

This adds support for passing `--azure-hyper-v-generation=V2` to Kola based on job parameters.
azure_gen2 is supported using the same VHD file as generation 1 azure VMs.

## Testing done

None yet.
