### PR TITLE
kola/dev-container: override binhost to use private GCS

### DIFF
--- a/jenkins/kola/dev-container.sh
+++ b/jenkins/kola/dev-container.sh
@@ -28,11 +28,15 @@ fi
 sudo systemd-nspawn $PIPEARG \
     --bind-ro=/lib/modules \
     --bind-ro="$PWD/flatcar_production_image_kernel_config.txt:/boot/config" \
+    --bind-ro="${GOOGLE_APPLICATION_CREDENTIALS}:/opt/credentials.json" \
+    --bind-ro="${verify_key}:/opt/verify.asc" \
     --image=flatcar_developer_container.bin \
     --machine=flatcar-developer-container-$(uuidgen) \
     --tmpfs=/usr/src \
     --tmpfs=/var/tmp \
     /bin/bash -eux << 'EOF'
+export PORTAGE_BINHOST="${PORTAGE_BINHOST}"
+export {FETCH,RESUME}COMMAND_GS="/usr/bin/gangue get --json-key=/opt/credentials.json --verify=true /opt/verify.asc \"\${URI}\" \"\${DISTDIR}/\${FILE}\""
 emerge-gitclone
 . /usr/share/coreos/release
 if [[ $FLATCAR_RELEASE_VERSION =~ master ]]


### PR DESCRIPTION
in this commit we make sure to use GCS bucket for dev container tests by
providing the required credentials and the associated fetch command.

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>
