### PR TITLE
jenkins/kola/container: fix verify-key sharing in systemd container

### DIFF
--- a/jenkins/kola/dev-container.sh
+++ b/jenkins/kola/dev-container.sh
@@ -29,7 +29,7 @@ sudo systemd-nspawn $PIPEARG \
     --bind-ro=/lib/modules \
     --bind-ro="$PWD/flatcar_production_image_kernel_config.txt:/boot/config" \
     --bind-ro="${GOOGLE_APPLICATION_CREDENTIALS}:/opt/credentials.json" \
-    --bind-ro="${verify_key}:/opt/verify.asc" \
+    --bind-ro="$PWD/verify.asc:/opt/verify.asc" \
     --image=flatcar_developer_container.bin \
     --machine=flatcar-developer-container-$(uuidgen) \
     --tmpfs=/usr/src \


### PR DESCRIPTION
`$verify_key` actually holds `--verify-key=verify.asc` so of course
`systemd-nspawn` fails since it does not expect `--verify-key` value.

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

