### PR TITLE
jenkins/sdk: add default `DOWNLOAD_ROOT`

### DIFF
--- a/jenkins/sdk.sh
+++ b/jenkins/sdk.sh
@@ -27,6 +27,7 @@ then
 	fi
 fi
 
+DOWNLOAD_ROOT=${DOWNLOAD_ROOT:-"gs://flatcar-jenkins"}
 DOWNLOAD_ROOT_SDK="${DOWNLOAD_ROOT}/sdk"
 
 # We do not use a nightly SDK as seed for bootstrapping because the next major Alpha SDK release would also have to use the last published Alpha release SDK as seed.


### PR DESCRIPTION
Otherwise, the variable is empty and it creates errors later. Default
value is `gs://flatcar-jenkins`. Not `GS_DEVEL_ROOT` because if we check
the previous behavior, `DOWNLOAD_ROOT` was hardcoded with:
```shell
DOWNLOAD_ROOT_SDK=https://storage.googleapis.com/flatcar-jenkins/sdk
```

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

Jenkins error output:
```
!!!Invalid Portage BINHOST value '/sdk/amd64/3005.0.0/toolchain/Packages'.
See make.conf(5) for more info.
ERROR   update_chroot: script called: update_chroot '--dev_builds_sdk=/sdk'
ERROR   update_chroot: Backtrace:  (most recent call is last)
ERROR   update_chroot:   file update_chroot, line 210, called: die_err_trap 'sudo -E ${EMERGE_CMD} --quiet "${EMERGE_FLAGS[@]}" sys-apps/portage sys-devel/crossdev sys-devel/sysroot-wrappers sys-libs/nss-usrfiles "${TOOLCHAIN_PKGS[@]}"' '1'
```