### PR TITLE
jenkins/kola/container: pass PORTAGE_BINHOST to container

### DIFF
--- a/jenkins/kola/dev-container.sh
+++ b/jenkins/kola/dev-container.sh
@@ -26,6 +26,7 @@ else
 fi
 
 sudo systemd-nspawn $PIPEARG \
+    --setenv=PORTAGE_BINHOST="${PORTAGE_BINHOST}" \
     --bind-ro=/lib/modules \
     --bind-ro="$PWD/flatcar_production_image_kernel_config.txt:/boot/config" \
     --bind-ro="${GOOGLE_APPLICATION_CREDENTIALS}:/opt/credentials.json" \


### PR DESCRIPTION
Otherwise, it was failing since we check for unbound variable:
```
/bin/bash: line 1: PORTAGE_BINHOST: unbound variable
```

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

