### PR TITLE
jenkins: use the SDK_URL_PATH path for DOWNLOAD_ROOT_SDK

### DIFF
--- a/jenkins/images.sh
+++ b/jenkins/images.sh
@@ -14,7 +14,8 @@ gpg --import verify.asc
 # key imports fail, let's create it here as a workaround
 mkdir -p --mode=0700 "${GNUPGHOME}/private-keys-v1.d/"
 
-DOWNLOAD_ROOT_SDK="${DOWNLOAD_ROOT}/sdk"
+# since /flatcar-jenkins/developer/sdk starts with a / we only use one
+DOWNLOAD_ROOT_SDK="gs:/${SDK_URL_PATH}"
 
 SCRIPTS_PATCH_ARG=""
 OVERLAY_PATCH_ARG=""

--- a/jenkins/kola/qemu_common.sh
+++ b/jenkins/kola/qemu_common.sh
@@ -56,7 +56,8 @@ gpg --import verify.asc
 # key imports fail, let's create it here as a workaround
 mkdir -p --mode=0700 "${GNUPGHOME}/private-keys-v1.d/"
 
-DOWNLOAD_ROOT_SDK="${DOWNLOAD_ROOT}/sdk"
+# since /flatcar-jenkins/developer/sdk starts with a / we only use one
+DOWNLOAD_ROOT_SDK="gs:/${SDK_URL_PATH}"
 
 if native_arm64 ; then
   mkdir -p .repo/

--- a/jenkins/packages.sh
+++ b/jenkins/packages.sh
@@ -10,7 +10,8 @@ set -ex
 if [[ "${RELEASE_BASE_IS_DEV}" = "false" && "${GROUP}" = "developer" && "${RELEASE_BASE}" != "" ]]; then
     DOWNLOAD_ROOT=$(echo ${DOWNLOAD_ROOT} | sed 's,/developer,,');
 fi
-DOWNLOAD_ROOT_SDK="${DOWNLOAD_ROOT}/sdk"
+# since /flatcar-jenkins/developer/sdk starts with a / we only use one
+DOWNLOAD_ROOT_SDK="gs:/${SDK_URL_PATH}"
 
 # Set up GPG for verifying tags.
 export GNUPGHOME="${PWD}/.gnupg"

--- a/jenkins/sdk.sh
+++ b/jenkins/sdk.sh
@@ -28,7 +28,8 @@ then
 fi
 
 DOWNLOAD_ROOT=${DOWNLOAD_ROOT:-"gs://flatcar-jenkins"}
-DOWNLOAD_ROOT_SDK="${DOWNLOAD_ROOT}/sdk"
+# The seed SDK is always a release SDK
+DOWNLOAD_ROOT_SDK="gs://flatcar-jenkins/sdk"
 
 # We do not use a nightly SDK as seed for bootstrapping because the next major Alpha SDK release would also have to use the last published Alpha release SDK as seed.
 # Also, we don't want compiler bugs to propagate from one nightly SDK to the next even though the commit in question was reverted.

--- a/jenkins/toolchains.sh
+++ b/jenkins/toolchains.sh
@@ -18,7 +18,8 @@ gpg --import verify.asc
 mkdir -p --mode=0700 "${GNUPGHOME}/private-keys-v1.d/"
 
 DOWNLOAD_ROOT=${DOWNLOAD_ROOT:-"${UPLOAD_ROOT}"}
-DOWNLOAD_ROOT_SDK="${DOWNLOAD_ROOT}/sdk"
+# since /flatcar-jenkins/developer/sdk starts with a / we only use one
+DOWNLOAD_ROOT_SDK="gs:/${SDK_URL_PATH}"
 
 SCRIPTS_PATCH_ARG=""
 OVERLAY_PATCH_ARG=""

--- a/jenkins/vms.sh
+++ b/jenkins/vms.sh
@@ -14,7 +14,8 @@ gpg --import verify.asc
 # key imports fail, let's create it here as a workaround
 mkdir -p --mode=0700 "${GNUPGHOME}/private-keys-v1.d/"
 
-DOWNLOAD_ROOT_SDK="${DOWNLOAD_ROOT}/sdk"
+# since /flatcar-jenkins/developer/sdk starts with a / we only use one
+DOWNLOAD_ROOT_SDK="gs:/${SDK_URL_PATH}"
 
 SCRIPTS_PATCH_ARG=""
 OVERLAY_PATCH_ARG=""


### PR DESCRIPTION
The SDK can either be a release SDK or a dev build SDK which are stored
in different paths. DOWNLOAD_ROOT_SDK should be based on the
SDK_URL_PATH value which indicates whether it's a release or dev build
path.

## How to use
Pick for all channels.

## Testing done

