### PR TITLE
set_version: Document the bucket cache for packages

### DIFF
--- a/set_version
+++ b/set_version
@@ -41,7 +41,8 @@ Usage: $0 FLAGS...
   --file FILE:                                     Modify another file than ${FILE}, useful if run
                                                    outside of the SDK chroot. If /dev/stdout or
                                                    /dev/stderr is used, only new values are printed.
-  --binhost                                        Use a custom binhost (defaults to '${DEFAULT_BASE_URL}').
+  --binhost                                        Use a custom binhost (defaults to '${DEFAULT_BASE_URL}'),
+                                                   e.g., 'https://bucket.release.flatcar-linux.net/flatcar-jenkins'.
                                                    This will update BOARD and SDK URLs accordingly.
 "
   exit 1


### PR DESCRIPTION
Dev builds need to use the bucket cache instead of the release
    binary package mirror.
    Document how the user can select the bucket cache.


## How to use

With using the bucket from a released new SDK or a nightly SDK it should be possible to fetch binary packages for nightly builds and release builds which were not yet copied to the mirror server.

## Testing done

Tested a dev build SDK with a dev build board from a release SDK:
```
./set_version --binhost https://bucket.release.flatcar-linux.net/flatcar-jenkins --dev-board --board-version amd64-usr/main-nightly --dev-sdk --sdk-version sdk-main-nightly
```

Setup a nightly SDK with:
```
…/mantle/bin/cork create --sdk-url bucket.release.flatcar-linux.net --sdk-url-path flatcar-jenkins/developer/sdk --sdk-version 2021.10.27+dev-main-nightly-3990
# Then after cork enter:
./set_version --board-version 3033.0.0 --no-dev-board --sdk-version 3033.0.0 --no-dev-sdk
```