### PR TITLE
jenkins/kola: fix qemu test execution

### DIFF
--- a/jenkins/kola/qemu_common.sh
+++ b/jenkins/kola/qemu_common.sh
@@ -83,8 +83,10 @@ source .repo/manifests/version.txt
 
 [ -s verify.asc ] && verify_key=--verify-key=verify.asc || verify_key=
 
-script update_chroot \
-    --toolchain_boards="${BOARD}" --dev_builds_sdk="${DOWNLOAD_ROOT_SDK}"
+if ! native_arm64; then
+  script update_chroot \
+      --toolchain_boards="${BOARD}" --dev_builds_sdk="${DOWNLOAD_ROOT_SDK}"
+fi
 
 mkdir -p tmp
 bin/cork download-image \


### PR DESCRIPTION
since there is no ARM64 SDK, we need to rely on the context of the test:
native ARM64 or not in order to submit the correct paths for the `script`
function.

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

Otherwise, it fails with:
```
+ script update_chroot --toolchain_boards=arm64-usr --dev_builds_sdk=gs://flatcar-jenkins/developer/sdk
+ enter /mnt/host/source/src/scripts/update_chroot --toolchain_boards=arm64-usr --dev_builds_sdk=gs://flatcar-jenkins/developer/sdk
+ /mnt/host/source/src/scripts/update_chroot --toolchain_boards=arm64-usr --dev_builds_sdk=gs://flatcar-jenkins/developer/sdk
flatcar-scripts/jenkins/kola/qemu_common.sh: line 37: /mnt/host/source/src/scripts/update_chroot: No such file or directory
```

it's quite sneaky too, because it seems to rely on the previous test result, so you don't see that there is an issue http://jenkins.infra.kinvolk.io:8080/job/os/job/kola/job/qemu_uefi/5018/ 
