### PR TITLE
jenkins/kola/aws.sh: use larger arm64 instance type for kubeadm

### DIFF
--- a/jenkins/kola/aws.sh
+++ b/jenkins/kola/aws.sh
@@ -8,7 +8,7 @@ NAME="jenkins-${JOB_NAME##*/}-${BUILD_NUMBER}"
 if [[ "${AWS_INSTANCE_TYPE}" != "" ]]; then
   instance_type="${AWS_INSTANCE_TYPE}"
 elif [[ "${BOARD}" == "arm64-usr" ]]; then
-  instance_type="a1.medium"
+  instance_type="a1.large"
 elif [[ "${BOARD}" == "amd64-usr" ]]; then
   instance_type="t3.small"
 fi


### PR DESCRIPTION
Currently the kubeadm tests fail on arm64 because the instance type
only offers 1 vCPU:
cluster.go:117: error execution phase preflight: [preflight] Some fatal errors occurred:
cluster.go:117: [ERROR NumCPU]: the number of available CPUs 1 is less than the required 2

Switch to the next larger instance type which has 2 vCPUS.

## How to use

Port to Alpha branch.

## Testing done

None