### PR TITLE
jenkins/kola/packet: Remove c3.small.x86 to try running cl.internet

### DIFF
--- a/jenkins/kola/packet.sh
+++ b/jenkins/kola/packet.sh
@@ -34,7 +34,7 @@ fi
 # Run the cl.internet test on multiple machine types only if it should run in general
 cl_internet_included="$(set -o noglob; bin/kola list --platform=packet --filter ${KOLA_TESTS} | { grep cl.internet || true ; } )"
 if [[ "${BOARD}" == "amd64-usr" ]] && [[ "${cl_internet_included}" != ""  ]]; then
-  for INSTANCE in c3.small.x86 c3.medium.x86 m3.large.x86 s3.xlarge.x86 n2.xlarge.x86; do
+  for INSTANCE in c3.medium.x86 m3.large.x86 s3.xlarge.x86 n2.xlarge.x86; do
     (
     OUTPUT=$(timeout --signal=SIGQUIT "${timeout}" bin/kola run \
     --basename="${NAME}" \


### PR DESCRIPTION
We are moving to use `sv15` and `c3.small.x86` as the default facility and the capacity for the test.
Don't try running the `cl.internet` on the instance.

Signed-off-by: Sayan Chowdhury <schowdhury@microsoft.com>


