### PR TITLE
jenkins: publish github status 'pending' at beginning of manifest job

### DIFF
--- a/jenkins/manifest.sh
+++ b/jenkins/manifest.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -ex
+BASE=$(dirname $(readlink -f "$0"))
 git -C manifest config user.name "${GIT_AUTHOR_NAME}"
 git -C manifest config user.email "${GIT_AUTHOR_EMAIL}"
 
@@ -100,7 +101,9 @@ set_manifest_ref() {
 
 if [[ -n "${SCRIPTS_REF}" ]]
 then
-        set_manifest_ref scripts "refs/heads/${SCRIPTS_REF}"
+        ref="refs/heads/${SCRIPTS_REF}"
+        set_manifest_ref scripts "${ref}"
+        ${BASE}/post-github-status.sh --repo flatcar-linux/scripts --ref "${ref}" --status pending
 fi
 if [[ -n "${OVERLAY_REF}" ]]
 then
@@ -111,7 +114,9 @@ then
                 prefix="refs/pull/"
                 suffix="/head"
         fi
-        set_manifest_ref coreos-overlay "$prefix${OVERLAY_REF}$suffix"
+        ref="${prefix}${OVERLAY_REF}${suffix}"
+        set_manifest_ref coreos-overlay "${ref}"
+        ${BASE}/post-github-status.sh --repo flatcar-linux/coreos-overlay --ref "${ref}" --status pending
 fi
 if [[ -n "${PORTAGE_REF}" ]]
 then
@@ -122,7 +127,9 @@ then
                 prefix="refs/pull/"
                 suffix="/head"
         fi
-        set_manifest_ref portage-stable "$prefix${PORTAGE_REF}$suffix"
+        ref="${prefix}${PORTAGE_REF}${suffix}"
+        set_manifest_ref portage-stable "${ref}"
+        ${BASE}/post-github-status.sh --repo flatcar-linux/portage-stable --ref "${ref}" --status pending
 fi
 
 ln -fns "${FLATCAR_BUILD_ID}.xml" manifest/default.xml

--- a/jenkins/post-github-status.sh
+++ b/jenkins/post-github-status.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+SHFLAGS=$(dirname $(readlink -f "$0"))/../lib/shflags/shflags
+. "${SHFLAGS}" || exit 1
+
+DEFINE_string repo "" "Name of the repository to which to post status"
+DEFINE_string ref "" "Reference from which to figure out commit"
+DEFINE_string github_token "${GITHUB_TOKEN}" "Github Personal Access Token used to submit the commit status"
+DEFINE_string status "pending" "Status to submit for commit. [failure,pending,success,error]"
+DEFINE_string context "ci/jenkins" "Context to use for commit status."
+DEFINE_boolean verbose "${FLAGS_FALSE}" "Show curl output"
+
+# Parse command line
+FLAGS "$@" || exit 1
+eval set -- "${FLAGS_ARGV}"
+
+if [ -z "${FLAGS_repo}" ]; then
+  echo >&2 "Error: --repo is required"
+  exit 1
+fi
+if [ -z "${FLAGS_ref}" ]; then
+  echo >&2 "Error: --ref is required"
+  exit 1
+fi
+if [ -z "${FLAGS_github_token}" ]; then
+  echo >&2 "Error: --github_token is required"
+  exit 1
+fi
+
+CURLOPTS="-sS"
+if [[ "${FLAGS_verbose}" -eq "${FLAGS_true}" ]]; then
+  CURLOPTS=""
+fi
+
+GITHUB_API="https://api.github.com"
+# BUILD_URL = JENKINS_URL + JOB_NAME + BUILD_NUMBER
+target_url="${BUILD_URL}cldsv"
+commit=$(git ls-remote "https://github.com/${FLAGS_repo}" "${FLAGS_ref}"| cut -f1)
+if [ -z "${commit}" ]; then
+  echo >&2 "Can't figure out commit for repo ${FLAGS_repo} ref ${FLAGS_ref}"
+  exit 2
+fi
+
+curl ${CURLOPTS} "${GITHUB_API}/repos/${FLAGS_repo}/statuses/${commit}" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: token ${FLAGS_github_token}" \
+    -X POST -d @- <<EOF
+{
+  "state":"${FLAGS_status}",
+  "context": "${FLAGS_context}",
+  "target_url":"${target_url}"
+}
+EOF


### PR DESCRIPTION
# add publishing of github commit status from jenkins

The status is published with the `ci/jenkins` context and a URL to the downstream view of the manifest job.

## How to use

Start a manifest job with `SCRITPS_REF=jepio/github-status` and `PIPELINE_BRANCH=jepio/github-status`.

## Testing done

Tested that commit status gets published.