### PR TITLE
update_chroot: introduce '--setuponly' flag

### DIFF
--- a/jenkins/sdk.sh
+++ b/jenkins/sdk.sh
@@ -48,7 +48,7 @@ bin/cork update \
     --sdk-url storage.googleapis.com \
     --sdk-url-path "/flatcar-jenkins/sdk" \
     --manifest-name "${MANIFEST_NAME}" \
-    --manifest-url "${MANIFEST_URL}"  -- --dev_builds_sdk="${DOWNLOAD_ROOT_SDK}"
+    --manifest-url "${MANIFEST_URL}"  -- --dev_builds_sdk="${DOWNLOAD_ROOT_SDK}" --setuponly
 
 if [[ ${FULL_BUILD} == "false" ]]; then
     export FORCE_STAGES="stage4"

--- a/jenkins/toolchains.sh
+++ b/jenkins/toolchains.sh
@@ -69,7 +69,7 @@ export FLATCAR_BUILD_ID
 enter gangue get --verify-key /opt/verify.asc --json-key /etc/portage/gangue.json "${DOWNLOAD_ROOT_SDK}/amd64/${FLATCAR_SDK_VERSION}/flatcar-sdk-amd64-${FLATCAR_SDK_VERSION}.tar.bz2.DIGESTS" /mnt/host/source/.cache/sdks/
 
 script update_chroot \
-    --toolchain_boards="${BOARD}" --dev_builds_sdk="${DOWNLOAD_ROOT_SDK}"
+    --toolchain_boards="${BOARD}" --dev_builds_sdk="${DOWNLOAD_ROOT_SDK}" --setuponly
 
 # Set up GPG for signing uploads.
 gpg --import "${GPG_SECRET_KEY_FILE}"

--- a/update_chroot
+++ b/update_chroot
@@ -24,6 +24,8 @@ DEFINE_boolean workon "${FLAGS_TRUE}" \
   "Automatically rebuild updated cros-workon packages."
 DEFINE_boolean skip_toolchain_update "${FLAGS_FALSE}" \
   "Don't update the toolchains."
+DEFINE_boolean setuponly "${FLAGS_FALSE}" \
+  "Only configure portage, without updating packages. Useful when only boostrap_sdk/build_toolchains will be called"
 DEFINE_string toolchain_boards "" \
   "Extra toolchains to setup for the specified boards."
 DEFINE_string dev_builds_sdk "" \
@@ -215,6 +217,11 @@ sudo -E ${EMERGE_CMD} --quiet "${EMERGE_FLAGS[@]}" \
     "${TOOLCHAIN_PKGS[@]}"
 
 gcc_set_latest_profile "$(portageq envvar CHOST)"
+
+if [[ "${FLAGS_setuponly}" -eq "${FLAGS_TRUE}" ]]; then
+  command_completed
+  exit 0
+fi
 
 if [[ "${FLAGS_skip_toolchain_update}" -eq "${FLAGS_FALSE}" && \
       -n "${FLAGS_toolchain_boards}" ]]; then


### PR DESCRIPTION
# add setuponly mode to update_chroot

`update_chroot` is called at the beginning of all of our jobs, but not all of them need an updated chroot. `sdk` and `toolchains` jobs use catalyst, and run in a nested chroot from a fresh extracted tarball. It can take even an hour to update the chroot. Use the `--setuponly` flag to only configure portage and repos.

## Testing done

Started two builds for comparison.

CI with this branch:
http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/3949/
CI without this branch:
http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/3950/