### PR TITLE
*: Try to silence the warnings

### DIFF
--- a/build_library/dev_container_util.sh
+++ b/build_library/dev_container_util.sh
@@ -34,8 +34,6 @@ CHOST=$(get_board_chost $BOARD)
 DISTDIR="/var/lib/portage/distfiles"
 PKGDIR="/var/lib/portage/pkgs"
 PORT_LOGDIR="/var/log/portage"
-PORTDIR="/var/lib/portage/portage-stable"
-PORTDIR_OVERLAY="/var/lib/portage/coreos-overlay"
 PORTAGE_BINHOST="$(get_binhost_url "$2" "$3" 'pkgs')
 $(get_binhost_url "$2" "$3" 'toolchain')"
 EOF
@@ -57,8 +55,6 @@ EOF
 
     # Now set the correct profile
     sudo PORTAGE_CONFIGROOT="$1" ROOT="$1" \
-        PORTDIR="$1/var/lib/portage/portage-stable" \
-        PORTDIR_OVERLAY="$1/var/lib/portage/coreos-overlay" \
         eselect profile set --force $(get_board_profile $BOARD)/dev
 }
 

--- a/build_library/dev_container_util.sh
+++ b/build_library/dev_container_util.sh
@@ -14,18 +14,22 @@ get_binhost_url() {
 }
 
 configure_dev_portage() {
+    local root_fs_dir="${1}"; shift
+    local binhost="${1}"; shift
+    local update_group="${1}"; shift
+
     # Need profiles at the bare minimum
     local repo
     for repo in portage-stable coreos-overlay; do
-        sudo mkdir -p "$1/var/lib/portage/${repo}"
+        sudo mkdir -p "${root_fs_dir}/var/lib/portage/${repo}"
         sudo rsync -rtl --exclude=md5-cache \
             "${SRC_ROOT}/third_party/${repo}/metadata" \
             "${SRC_ROOT}/third_party/${repo}/profiles" \
-            "$1/var/lib/portage/${repo}"
+            "${root_fs_dir}/var/lib/portage/${repo}"
     done
 
-    sudo mkdir -p "$1/etc/portage/repos.conf"
-    sudo_clobber "$1/etc/portage/make.conf" <<EOF
+    sudo mkdir -p "${root_fs_dir}/etc/portage/repos.conf"
+    sudo_clobber "${root_fs_dir}/etc/portage/make.conf" <<EOF
 # make.conf for Flatcar dev images
 ARCH=$(get_board_arch $BOARD)
 CHOST=$(get_board_chost $BOARD)
@@ -34,11 +38,11 @@ CHOST=$(get_board_chost $BOARD)
 DISTDIR="/var/lib/portage/distfiles"
 PKGDIR="/var/lib/portage/pkgs"
 PORT_LOGDIR="/var/log/portage"
-PORTAGE_BINHOST="$(get_binhost_url "$2" "$3" 'pkgs')
-$(get_binhost_url "$2" "$3" 'toolchain')"
+PORTAGE_BINHOST="$(get_binhost_url "${binhost}" "${update_group}" 'pkgs')
+$(get_binhost_url "${binhost}" "${update_group}" 'toolchain')"
 EOF
 
-sudo_clobber "$1/etc/portage/repos.conf/coreos.conf" <<EOF
+    sudo_clobber "${root_fs_dir}/etc/portage/repos.conf/coreos.conf" <<EOF
 [DEFAULT]
 main-repo = portage-stable
 
@@ -53,9 +57,18 @@ sync-type = git
 sync-uri = https://github.com/flatcar/portage-stable.git
 EOF
 
-    # Now set the correct profile
-    sudo PORTAGE_CONFIGROOT="$1" ROOT="$1" \
-        eselect profile set --force $(get_board_profile $BOARD)/dev
+    # Now set the correct profile, we do not use the eselect tool - it
+    # does not seem to be usable outside of the chroot without using
+    # deprecated PORTDIR and PORTDIR_OVERLAY environment variables.
+    local profile_name=$(get_board_profile "${BOARD}")
+    # Turn coreos:coreos/amd64/generic into coreos/amd64/generic/dev
+    profile_name="${profile_name#*:}/dev"
+    local profile_directory="${root_fs_dir}/var/lib/portage/coreos-overlay/profiles/${profile_name}"
+    if [[ ! -d "${profile_directory}" ]]; then
+        die "Not a valid profile: ${profile_name}"
+    fi
+    local profile_link="${root_fs_dir}/etc/portage/make.profile"
+    sudo ln -sfrT "${profile_directory}" "${profile_link}"
 }
 
 create_dev_container() {

--- a/build_library/toolchain_util.sh
+++ b/build_library/toolchain_util.sh
@@ -291,9 +291,6 @@ _configure_sysroot() {
     echo "Writing make.conf for the sysroot ${SYSROOT}, root ${ROOT}"
     "${sudo[@]}" tee "${ROOT}/etc/portage/make.conf" <<EOF
 $(portageq envvar -v CHOST CBUILD ROOT DISTDIR PKGDIR)
-# TODO: These are deprecated, drop them eventually.
-PORTDIR="$(portageq get_repo_path "${ROOT}" portage-stable)"
-PORTDIR_OVERLAY="${coreos_path} $(portageq get_repo_path "${ROOT}" x-crossdev)"
 HOSTCC=\${CBUILD}-gcc
 PKG_CONFIG_PATH="\${SYSROOT}/usr/lib/pkgconfig/"
 # Enable provenance reporting by default. Produced files are in /usr/share/SLSA

--- a/setup_board
+++ b/setup_board
@@ -253,8 +253,6 @@ sudo_clobber "${BOARD_ETC}/portage/make.conf" <<EOF
 # Settings derived from the host environment
 CBUILD="$(portageq envvar CHOST)"
 HOSTCC="$(portageq envvar CHOST)-gcc"
-PORTDIR="$(portageq envvar PORTDIR)"
-PORTDIR_OVERLAY="$(portageq envvar PORTDIR_OVERLAY)"
 DISTDIR="$(portageq envvar DISTDIR)"
 MAKEOPTS="$(portageq envvar MAKEOPTS)"
 PORTAGE_USERNAME="$(portageq envvar PORTAGE_USERNAME)"

--- a/update_chroot
+++ b/update_chroot
@@ -88,8 +88,6 @@ sudo touch /etc/portage/make.conf.user
 
 sudo_clobber "/etc/portage/make.conf" <<EOF
 # Created by update_chroot
-PORTDIR="${PORTAGE_STABLE_OVERLAY}"
-PORTDIR_OVERLAY="${CROSSDEV_OVERLAY} ${COREOS_OVERLAY}"
 DISTDIR="${REPO_CACHE_DIR}/distfiles"
 PKGDIR="/var/lib/portage/pkgs"
 PORT_LOGDIR="/var/log/portage"


### PR DESCRIPTION
We were getting a lot of repeated warnings like listed below. It would be nice to quiet them down.

```
WARNING: 'portageq envvar PORTDIR' is deprecated. Use any of 'get_repos, get_repo_path, repos_config' instead.
WARNING: 'portageq envvar PORTDIR_OVERLAY' is deprecated. Use any of 'get_repos, get_repo_path, repos_config' instead.
```

CI: http://jenkins.infra.kinvolk.io:8080/job/container/job/sdk/649/cldsv/