### PR TITLE
jenkins/kola/azure: forward azure private networking parameters to kola

### DIFF
--- a/jenkins/kola/azure.sh
+++ b/jenkins/kola/azure.sh
@@ -48,5 +48,7 @@ timeout --signal=SIGQUIT 20h bin/kola run \
     ${AZURE_USE_GALLERY} \
     ${AZURE_MACHINE_SIZE_OPT} \
     ${AZURE_HYPER_V_GENERATION:+--azure-hyper-v-generation=${AZURE_HYPER_V_GENERATION}} \
+    ${AZURE_VNET_SUBNET_NAME:+--azure-vnet-subnet-name=${AZURE_VNET_SUBNET_NAME}} \
+    ${AZURE_USE_PRIVATE_IPS:+--azure-use-private-ips=${AZURE_USE_PRIVATE_IPS}} \
     ${KOLA_TESTS}
 set +o noglob


### PR DESCRIPTION
# jenkins/kola/azure: forward azure private networking parameters to kola

These allow the configuration of virtual network for the created
instances to join, and tell kola to use the private instance IP for
connectivity.

## How to use

Test with jenkins-os PR: https://github.com/kinvolk/jenkins-os/pull/201

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
