### PR TITLE
changelog: use a specific project name in the example

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -15,7 +15,7 @@ The file should contain a markdown bullet point entry (`- TEXT...`).
 Example for the bugfix section:
 
 ```
-- The Torcx profile `docker-1.12-no` got fixed to reference the current Docker version instead of 19.03 which wasn't found on the image, causing Torcx to fail to provide Docker [PR#1456](https://github.com/flatcar-linux/coreos-overlay/pull/1456)
+- The Torcx profile `docker-1.12-no` got fixed to reference the current Docker version instead of 19.03 which wasn't found on the image, causing Torcx to fail to provide Docker [scripts#1456](https://github.com/flatcar-linux/scripts/pull/1456)
 ```
 
 The contents of the file should describe the changes in a concise manner,


### PR DESCRIPTION
To be able to distinguish changelog entries from each other, we should write a specific project name, e.g. `scripts`, instead of `PR`.
Changelog entries with a simple `PR` usually cause so much additional rework when doing actual releases.