### PR TITLE
.github: Use lxc containers for amd64 kola tests, too

### DIFF
--- a/.github/workflows/run-kola-tests.yaml
+++ b/.github/workflows/run-kola-tests.yaml
@@ -54,25 +54,6 @@ jobs:
           sudo iptables -I FORWARD -o $DEFAULT_ROUTE_DEVICE -j ACCEPT
           sudo iptables -I FORWARD -i $DEFAULT_ROUTE_DEVICE -j ACCEPT
 
-          # ARM64 tests run inside an LXD container instead of an LXD Virtual machine
-          # There are some limitations in terms of what we can customize.
-          if [ "${{ matrix.arch }}" == "amd64" ];then
-            # Enable IP forward
-            echo 'net.ipv4.ip_forward=1' | sudo tee /etc/sysctl.d/ip_forward.conf
-
-            # Enable unprivileged bpf
-            echo 'kernel.unprivileged_bpf_disabled=0' | sudo tee /etc/sysctl.d/enable_unprivileged_bpf.conf
-
-            sudo sysctl --system
-            sysctl -p
-
-            # Enable extra SWAP
-            sudo fallocate /swap.img -l 8GiB
-            sudo chmod 600 /swap.img
-            sudo mkswap /swap.img
-            sudo swapon /swap.img
-          fi
-
       - uses: actions/checkout@v3
         with:
           path: scripts
@@ -112,11 +93,7 @@ jobs:
           pushd scripts
           source ci-automation/test.sh
 
-          PARALLEL_ARCH=2
-          if [ "${{ matrix.arch }}" == "arm64" ];then
-            # ARM64 servers have more memory and CPUs
-            PARALLEL_ARCH=10
-          fi
+          PARALLEL_ARCH=10
 
           cat > sdk_container/.env <<EOF
           # export the QEMU_IMAGE_NAME to avoid to download it.


### PR DESCRIPTION
While we moved the arm64 tests to lxc containers, amd64 stayed on VMs
which were not easy to scale up.
Now the GitHub Action runner is running on lxc containers and we can
spawn more VMs in parallel because it has no memory limit.
