### PR TITLE
jenkins: fix PACKET_REGION to DC for more servers available

### DIFF
--- a/jenkins/kola/packet.sh
+++ b/jenkins/kola/packet.sh
@@ -29,11 +29,13 @@ if [[ "${KOLA_TESTS}" == "" ]]; then
 fi
 
 # Equinix Metal ARM server are not yet hourly available in the default `sv15` region
-# so we override the `PACKET_REGION` to `Dallas` since it's available in this region.
+# so we override the `PACKET_REGION` to `DC`. ARM servers are available in metro
+# either DA (Dallas) or DC (Washington), but DC has more servers available.
+# See also https://metal.equinix.com/developers/docs/locations/capacity/.
 # We do not override `PACKET_REGION` for both board on top level because we need to keep proximity
 # for PXE booting.
 if [[ "${BOARD}" == "arm64-usr" ]]; then
-  PACKET_REGION="DA"
+  PACKET_REGION="DC"
 fi
 
 # Run the cl.internet test on multiple machine types only if it should run in general


### PR DESCRIPTION
`c3.large.arm64` instances of Equinix Metal are available in metro either `DA` or `DC`.
However, recently arm64 CI builds started to fail due to too few servers available in the DA metro.
As the DC metro has more servers available, let's change metro to DC.

How to check how many servers are available in a specific metro:

```
curl -X POST \
  -H "Content-Type: application/json" -H "X-Auth-Token: ..." \
  https://api.equinix.com/metal/v1/capacity/metros \
  -d '{"servers": [ { \
    "metro": "dc", \
    "plan": "c3.large.arm64", \
    "quantity": 34 \
  } ] }'

curl -X POST \
  -H "Content-Type: application/json" -H "X-Auth-Token: ..." \
  https://api.equinix.com/metal/v1/capacity/metros \
  -d '{"servers": [ { \
    "metro": "da", \
    "plan": "c3.large.arm64", \
    "quantity": 17 \
  } ] }'
```

- Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update) (not needed)
