### PR TITLE
sys-boot/grub: sync with gentoo upstream; updates to 2.06

### DIFF
--- a/build_library/grub.cfg
+++ b/build_library/grub.cfg
@@ -104,13 +104,6 @@ fi
 
 set suf=""
 
-# UEFI uses linuxefi/initrdefi instead of linux/initrd except for arm64
-if [ "$grub_platform" = efi ]; then
-  if [ "$grub_cpu" != arm64 ]; then
-    set suf="efi"
-  fi
-fi
-
 # Assemble the options applicable to all the kernels below
 set linux_cmdline="rootflags=rw mount.usrflags=ro consoleblank=0 $linux_root $linux_console $first_boot $randomize_disk_guid $extra_options $oem $linux_append"
 

--- a/build_library/grub_install.sh
+++ b/build_library/grub_install.sh
@@ -58,14 +58,14 @@ case "${FLAGS_target}" in
         CORE_NAME="core.img"
         ;;
     x86_64-efi)
-	CORE_MODULES+=( serial linuxefi efi_gop getenv smbios efinet verify http tftp )
+	CORE_MODULES+=( serial efi_gop getenv efinet verify http tftp )
         CORE_NAME="core.efi"
         ;;
     x86_64-xen)
         CORE_NAME="core.elf"
         ;;
     arm64-efi)
-        CORE_MODULES+=( serial linux efi_gop getenv smbios efinet verify http tftp )
+        CORE_MODULES+=( serial linux efi_gop getenv efinet verify http tftp )
         CORE_NAME="core.efi"
         BOARD_GRUB=1
         ;;

--- a/build_library/grub_install.sh
+++ b/build_library/grub_install.sh
@@ -58,14 +58,14 @@ case "${FLAGS_target}" in
         CORE_NAME="core.img"
         ;;
     x86_64-efi)
-	CORE_MODULES+=( serial efi_gop getenv efinet verify http tftp )
+	CORE_MODULES+=( serial efi_gop efinet verify http tftp )
         CORE_NAME="core.efi"
         ;;
     x86_64-xen)
         CORE_NAME="core.elf"
         ;;
     arm64-efi)
-        CORE_MODULES+=( serial linux efi_gop getenv efinet verify http tftp )
+        CORE_MODULES+=( serial linux efi_gop efinet verify http tftp )
         CORE_NAME="core.efi"
         BOARD_GRUB=1
         ;;

--- a/build_library/grub_install.sh
+++ b/build_library/grub_install.sh
@@ -58,14 +58,14 @@ case "${FLAGS_target}" in
         CORE_NAME="core.img"
         ;;
     x86_64-efi)
-	CORE_MODULES+=( serial efi_gop efinet verify http tftp )
+	CORE_MODULES+=( serial efi_gop efinet pgp http tftp )
         CORE_NAME="core.efi"
         ;;
     x86_64-xen)
         CORE_NAME="core.elf"
         ;;
     arm64-efi)
-        CORE_MODULES+=( serial linux efi_gop efinet verify http tftp )
+        CORE_MODULES+=( serial linux efi_gop efinet pgp http tftp )
         CORE_NAME="core.efi"
         BOARD_GRUB=1
         ;;


### PR DESCRIPTION
# sys-boot/grub: sync with gentoo upstream; updates to 2.06

to be merged with: https://github.com/flatcar-linux/coreos-overlay/pull/2098

## Testing done
Jenkins CI  http://jenkins.infra.kinvolk.io:8080/job/os/job/manifest/6311/cldsv/

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
