### PR TITLE
Prepare github org rename to flatcar

### DIFF
--- a/.github/workflows/mantle-releases-main.yml
+++ b/.github/workflows/mantle-releases-main.yml
@@ -31,14 +31,14 @@ jobs:
       - name: Fetch latest mantle hash
         id: fetch-latest-mantle
         run: |
-          commit=$(git ls-remote  https://github.com/flatcar-linux/mantle refs/heads/flatcar-master | cut -f1)
+          commit=$(git ls-remote  https://github.com/flatcar/mantle refs/heads/flatcar-master | cut -f1)
           echo ::set-output name=COMMIT::${commit}
       - name: Try to apply patch
         run: |
           set -x
           commit=${{ steps.fetch-latest-mantle.outputs.COMMIT }}
-          if ! grep -q "ghcr.io/flatcar-linux/mantle:git-${commit}" sdk_container/.repo/manifests/mantle-container; then
-            echo "ghcr.io/flatcar-linux/mantle:git-${commit}" > sdk_container/.repo/manifests/mantle-container
+          if ! grep -q "ghcr.io/flatcar/mantle:git-${commit}" sdk_container/.repo/manifests/mantle-container; then
+            echo "ghcr.io/flatcar/mantle:git-${commit}" > sdk_container/.repo/manifests/mantle-container
             git add sdk_container/.repo/manifests/mantle-container
           fi
       - name: Create pull request for branch

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "sdk_container/src/third_party/coreos-overlay"]
 	path = sdk_container/src/third_party/coreos-overlay
-	url = https://github.com/flatcar-linux/coreos-overlay.git
+	url = https://github.com/flatcar/coreos-overlay.git
 [submodule "sdk_container/src/third_party/portage-stable"]
 	path = sdk_container/src/third_party/portage-stable
-	url = https://github.com/flatcar-linux/portage-stable.git
+	url = https://github.com/flatcar/portage-stable.git

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The SDK can be used to
 # Using the scripts repository: submodules and tags
 
 The repository is meant to be the entry point for Flatcar builds and development.
-For building packages, there are 2 additional repositories, [coreos-overlay](https://github.com/flatcar/) and [portage-stable](https://github.com/flatcar/portage-stable), which contain all packages' `ebuild` (build configuration) files.
+For building packages, there are 2 additional repositories, [coreos-overlay](https://github.com/flatcar/coreos-overlay) and [portage-stable](https://github.com/flatcar/portage-stable), which contain all packages' `ebuild` (build configuration) files.
 These repositories are included in `scripts` via git submodules and are used by the SDK container wrapper scripts detailed on further below.
 The submodules reside in:
 ```

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ In standalone mode, the SDK is just another Docker container. Interaction with t
 * Check the list of available versions and pick a version to use. The SDK Major versions correspond to Flatcar Major release versions.
   List of images: `https://github.com/orgs/flatcar-linux/packages/container/package/flatcar-sdk-all`
   For the purpose of this example we'll use version `3033.0.0`.
-* Fetch the container image: `docker pull ghcr.io/flatcar-linux/flatcar-sdk-all:3033.0.0`
-* Start the image in interactive (tty) mode: `docker run -ti ghcr.io/flatcar-linux/flatcar-sdk-all:3033.0.0`
+* Fetch the container image: `docker pull ghcr.io/flatcar/flatcar-sdk-all:3033.0.0`
+* Start the image in interactive (tty) mode: `docker run -ti ghcr.io/flatcar/flatcar-sdk-all:3033.0.0`
   You are now inside the SDK container (the hostname will likely differ):
   `sdk@f236fda982a4 ~/trunk/src/scripts $`
 * Initialise the SDK in self-contained mode. This needs to be done once per container and will check out the scripts, coreos-overlay, and portage-stable repositories into the container.
@@ -78,7 +78,7 @@ In order to build OS images (via `./build_image` and `./image_to_vm`) the SDK to
 This is necessary because the SDK currently employs loop devices to create and to partition OS images.
 
 To start a container in privileged mode with `/dev` available use:
-* `docker run -ti  --privileged -v /dev:/dev ghcr.io/flatcar-linux/flatcar-sdk-all:3033.0.0`
+* `docker run -ti  --privileged -v /dev:/dev ghcr.io/flatcar/flatcar-sdk-all:3033.0.0`
 
 ## Integrated mode
 
@@ -107,7 +107,7 @@ Subsequent calls to `./run_sdk_container` will re-use the container (as long as 
 Check out `docker container ls --all` and you'll see something like
 ```
 CONTAINER ID   IMAGE                                            COMMAND                  CREATED       STATUS                         PORTS     NAMES
-19ea3b6d00ad   ghcr.io/flatcar-linux/flatcar-sdk-all:3033.0.0   "/bin/sh -c /home/sd…"   4 hours ago   Exited (0) About an hour ago             flatcar-sdk-all-3033.0.0_os-3033.0.0
+19ea3b6d00ad   ghcr.io/flatcar/flatcar-sdk-all:3033.0.0   "/bin/sh -c /home/sd…"   4 hours ago   Exited (0) About an hour ago             flatcar-sdk-all-3033.0.0_os-3033.0.0
 ```
 
 Re-use of containers happens on a per-name basis. The above example's container name `flatcar-sdk-all-3033.0.0_os-3033.0.0` is generated automatically. Using `docker container rm` the container can be discarded - a subsequent call to `./run_sdk_container` will create a new one.  Custom containers can be created by use of the `-n <name>` command line option; these will be re-used in subsequent calls to `./run_sdk_container` when using the same `<name>`.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The SDK can be used to
 * Build OS images for a variety of targets (qemu, bare metal, AWS, Azure, VMWare, etc.)
 * And lastly, the SDK can be used to upgrade SDK packages and to build new SDKs
 
-[flatcar-docs]: https://docs.flatcar-linux.org/os/sdk-modifying-flatcar/
+[flatcar-docs]: https://www.flatcar.org/docs/latest/reference/developer-guides/sdk-modifying-flatcar/
 
 # Using the scripts repository: submodules and tags
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The SDK can be used to
 # Using the scripts repository: submodules and tags
 
 The repository is meant to be the entry point for Flatcar builds and development.
-For building packages, there are 2 additional repositories, [coreos-overlay](https://github.com/flatcar-linux/) and [portage-stable](https://github.com/flatcar-linux/portage-stable), which contain all packages' `ebuild` (build configuration) files.
+For building packages, there are 2 additional repositories, [coreos-overlay](https://github.com/flatcar/) and [portage-stable](https://github.com/flatcar/portage-stable), which contain all packages' `ebuild` (build configuration) files.
 These repositories are included in `scripts` via git submodules and are used by the SDK container wrapper scripts detailed on further below.
 The submodules reside in:
 ```
@@ -28,7 +28,7 @@ scripts
 
 When working with the scripts repo always make sure to initialise and to update these submodules; otherwise builds will break because build configuration is missing:
 ```bash
-$ git clone --recurse-submodules https://github.com/flatcar-linux/scripts.git
+$ git clone --recurse-submodules https://github.com/flatcar/scripts.git
 ```
 
 The `scripts` repository makes ample use of tags to mark releases.
@@ -46,13 +46,13 @@ $ git pull --all --tags --prune --prune-tags --force
 
 # Using the SDK container
 
-We provide a containerised SDK via https://github.com/orgs/flatcar-linux/packages. The container comes in 3 flavours:
+We provide a containerised SDK via https://github.com/orgs/flatcar/packages. The container comes in 3 flavours:
 * Full SDK initialised with both architectures supported by Flatcar (amd64 and arm64). This is the largest container, it's about 8GB in size (~3 GB compressed).
 * AMD64 SDK initialised for building AMD64 OS images. About 6GB in size (2GB compressed).
 * ARM64 SDK initialised for building ARM64 OS images on AMD64 hosts. Also about 6GB in size.
 While work on a native ARM64 native SDK is ongoing, it's unfortunately not ready yet. If you want to help, patches are welcome!
 
-The container can be run in one of two ways - "standalone", or integrated with the [scripts](https://github.com/flatcar-linux/scripts) repo:
+The container can be run in one of two ways - "standalone", or integrated with the [scripts](https://github.com/flatcar/scripts) repo:
 * Standalone mode will use no host volumes and will allow you to play with the SDK in a sandboxed throw-away environment. In standalone mode, you interface with Docker directly to use the SDK container.
 * Integrated mode will closely integrate with the scripts repo directory and bind-mount it as well as the portage-stable and coreos-overlay gitmodules into the container. Integrated mode uses wrapper scripts to interact with the SDK container. This is the recommended way for developing patches for Flatcar.
 
@@ -61,7 +61,7 @@ The container can be run in one of two ways - "standalone", or integrated with t
 In standalone mode, the SDK is just another Docker container. Interaction with the container happens via use of `docker` directly. Use for experimenting and for throw-away work only, otherwise please use integrated mode (see below).
 
 * Check the list of available versions and pick a version to use. The SDK Major versions correspond to Flatcar Major release versions.
-  List of images: `https://github.com/orgs/flatcar-linux/packages/container/package/flatcar-sdk-all`
+  List of images: `https://github.com/orgs/flatcar/packages/container/package/flatcar-sdk-all`
   For the purpose of this example we'll use version `3033.0.0`.
 * Fetch the container image: `docker pull ghcr.io/flatcar/flatcar-sdk-all:3033.0.0`
 * Start the image in interactive (tty) mode: `docker run -ti ghcr.io/flatcar/flatcar-sdk-all:3033.0.0`
@@ -88,7 +88,7 @@ Both the host's scripts repo as well as its submodules (portage-stable and coreo
 The wrapper scripts will re-use existing containers instead of creating new ones to preserve your work in the container, enabling consistency.
 
 To clone the scripts repo and pick a version:
-* Clone the scripts repo: `git clone https://github.com/flatcar-linux/scripts.git`
+* Clone the scripts repo: `git clone https://github.com/flatcar/scripts.git`
 * Optionally, check out a release tag to base your work on
   * list releases (e.g. all Alpha releases): `git tag -l alpha-*`
   * check out the release version, e.g. `3033.0.0`: `git checkout 3033.0.0`

--- a/bootstrap_sdk
+++ b/bootstrap_sdk
@@ -154,7 +154,7 @@ stage_repo() {
         info "Using git ref '$gitref' for ebuild repo '$repo' ('$gitname') in stage 1."
         mkdir "$dest/$repo"
         (   cd "$dest/$repo" \
-            && git clone "https://github.com/flatcar-linux/$gitname.git" . \
+            && git clone "https://github.com/flatcar/$gitname.git" . \
             && git fetch --all \
             && git checkout "$gitref" )
     fi

--- a/build_library/build_image_util.sh
+++ b/build_library/build_image_util.sh
@@ -499,7 +499,7 @@ https://github.com/flatcar-linux/coreos-overlay/
 https://github.com/flatcar-linux/portage-stable/
 https://github.com/flatcar-linux/scripts/
 Information on how to build Flatcar Container Linux can be found under:
-https://docs.flatcar-linux.org/os/sdk-modifying-flatcar/
+https://www.flatcar.org/docs/latest/reference/developer-guides/sdk-modifying-flatcar/
 EOF
     sudo cp "${json_input}" "${root_fs_dir}"/usr/share/licenses/licenses.json
     # Compress the file from 2.1 MB to 0.39 MB

--- a/build_library/build_image_util.sh
+++ b/build_library/build_image_util.sh
@@ -351,7 +351,7 @@ get_metadata() {
     if [ "${key}" = "SRC_URI" ]; then
         local package_name="$(echo "${pkg%%:*}" | cut -d / -f 2)"
         local ebuild_path="${prefix}/var/db/pkg/${pkg%%:*}/${package_name}.ebuild"
-        # SRC_URI is empty for the special github.com/flatcar-linux projects
+        # SRC_URI is empty for the special github.com/flatcar projects
         if [ -z "${val}" ]; then
             # The grep invocation gives errors when the ebuild file is not present.
             # This can happen if a "scripts" branch does not match the "coreos-overlay" branch
@@ -359,7 +359,7 @@ get_metadata() {
             val="$(grep "CROS_WORKON_PROJECT=" "${ebuild_path}" | cut -d '"' -f 2)"
             if [ -n "${val}" ]; then
                 val="https://github.com/${val}"
-                # All github.com/flatcar-linux projects specify their commit
+                # All github.com/flatcar projects specify their commit
                 local commit=""
                 commit="$(grep "CROS_WORKON_COMMIT=" "${ebuild_path}" | cut -d '"' -f 2)"
                 if [ -n "${commit}" ]; then
@@ -399,7 +399,7 @@ get_metadata() {
 #       "licenses": ["GPL-2", "LGPL-2.1", "MIT", "public-domain"],
 #       "description": "System and service manager for Linux",
 #       "homepage": "https://www.freedesktop.org/wiki/Software/systemd",
-#       "source": "https://github.com/flatcar-linux/systemd ",
+#       "source": "https://github.com/systemd/systemd ",
 #       "files": "somefile 63a5736879fa647ac5a8d5317e7cb8b0\nsome -> link\n"
 #     }
 #   ]
@@ -495,9 +495,9 @@ You can read it with "less licenses.json.bz2" or convert it to a text format wit
 bzcat licenses.json.bz2 | jq -r '.[] | "\(.project):\nDescription: \(.description)\nLicenses: \(.licenses)\nHomepage: \(.homepage)\nSource code: \(.source)\nFiles:\n\(.files)\n"'
 The license texts are available under /usr/share/licenses/common/ and can be read with "less NAME.gz".
 Build system files and patches used to build these projects are located at:
-https://github.com/flatcar-linux/coreos-overlay/
-https://github.com/flatcar-linux/portage-stable/
-https://github.com/flatcar-linux/scripts/
+https://github.com/flatcar/coreos-overlay/
+https://github.com/flatcar/portage-stable/
+https://github.com/flatcar/scripts/
 Information on how to build Flatcar Container Linux can be found under:
 https://www.flatcar.org/docs/latest/reference/developer-guides/sdk-modifying-flatcar/
 EOF

--- a/build_library/dev_container_util.sh
+++ b/build_library/dev_container_util.sh
@@ -50,12 +50,12 @@ disabled = true
 [coreos]
 location = /var/lib/portage/coreos-overlay
 sync-type = git
-sync-uri = https://github.com/flatcar-linux/coreos-overlay.git
+sync-uri = https://github.com/flatcar/coreos-overlay.git
 
 [portage-stable]
 location = /var/lib/portage/portage-stable
 sync-type = git
-sync-uri = https://github.com/flatcar-linux/portage-stable.git
+sync-uri = https://github.com/flatcar/portage-stable.git
 EOF
 
     # Now set the correct profile

--- a/build_library/grub.cfg
+++ b/build_library/grub.cfg
@@ -130,7 +130,7 @@ function gptprio {
         echo
         echo "Reading or updating the GPT failed!"
         echo "Please file a bug with any messages above to Flatcar:"
-        echo " https://issues.flatcar-linux.org"
+        echo " https://issues.flatcar.org"
         abort
     fi
 

--- a/build_library/set_lsb_release
+++ b/build_library/set_lsb_release
@@ -55,8 +55,8 @@ BUILD_ID=$FLATCAR_BUILD_ID
 SYSEXT_LEVEL=1.0
 PRETTY_NAME="$OS_PRETTY_NAME"
 ANSI_COLOR="38;5;75"
-HOME_URL="https://flatcar-linux.org/"
-BUG_REPORT_URL="https://issues.flatcar-linux.org"
+HOME_URL="https://flatcar.org/"
+BUG_REPORT_URL="https://issues.flatcar.org"
 FLATCAR_BOARD="$FLAGS_board"
 CPE_NAME="cpe:2.3:o:${OS_ID}-linux:${OS_ID}_linux:${FLATCAR_VERSION}:*:*:*:*:*:*:*"
 EOF

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -15,7 +15,7 @@ The file should contain a markdown bullet point entry (`- TEXT...`).
 Example for the bugfix section:
 
 ```
-- The Torcx profile `docker-1.12-no` got fixed to reference the current Docker version instead of 19.03 which wasn't found on the image, causing Torcx to fail to provide Docker [scripts#1456](https://github.com/flatcar-linux/scripts/pull/1456)
+- The Torcx profile `docker-1.12-no` got fixed to reference the current Docker version instead of 19.03 which wasn't found on the image, causing Torcx to fail to provide Docker [scripts#1456](https://github.com/flatcar/scripts/pull/1456)
 ```
 
 The contents of the file should describe the changes in a concise manner,

--- a/ci-automation/README.md
+++ b/ci-automation/README.md
@@ -121,7 +121,7 @@ Optionally, patterns matching a group of tests can be supplied (or simply a list
 
 Testing is implemented in two layers:
 1. `ci-automation/test.sh` is a generic test wrapper / stub to be called from CI.
-2. `ci-automation/vendor-testing/` contains low-level vendor-specific test wrappers around [`kola`](https://github.com/flatcar-linux/mantle/tree/flatcar-master/kola/), our test scenario orchestrator.
+2. `ci-automation/vendor-testing/` contains low-level vendor-specific test wrappers around [`kola`](https://github.com/flatcar/mantle/tree/flatcar-master/kola/), our test scenario orchestrator.
 
 Testing relies on the SDK container and will use tools / test suites from the SDK.
 The low-level vendor / image specific script (layer 2. in the list above) runs inside the SDK.

--- a/ci-automation/README.md
+++ b/ci-automation/README.md
@@ -43,7 +43,7 @@ image_build amd64
    This step updates the versionfile, recording the SDK container version just built.
    It will generate and push a new version tag to the scripts repo.
 2. SDK container build (`sdk_container.sh`) : use SDK tarball to build an SDK container image.
-   The resulting image will come in "amd64", "arm64", and "all" flavours, with support for respective OS target architectures. This step builds the Flatcar SDK container images published at ghcr.io/flatcar-linux.
+   The resulting image will come in "amd64", "arm64", and "all" flavours, with support for respective OS target architectures. This step builds the Flatcar SDK container images published at ghcr.io/flatcar.
 
 ```
          .---------.                    .------------.          .--------.

--- a/ci-automation/ci-config.env
+++ b/ci-automation/ci-config.env
@@ -13,7 +13,7 @@ BUILDCACHE_PATH_PREFIX="/srv/bincache"
 BUILDCACHE_USER="bincache"
 
 RELEASES_SERVER="mirror.release.flatcar-linux.net"
-CONTAINER_REGISTRY="ghcr.io/flatcar-linux"
+CONTAINER_REGISTRY="ghcr.io/flatcar"
 
 GC_BUCKET="flatcar-linux"
 
@@ -21,7 +21,7 @@ DEFAULT_HTTP_IMAGE_URL_TEMPLATE="@PROTO@://${BUILDCACHE_SERVER}/images/@ARCH@/@V
 
 if ! command -v pigz > /dev/null; then
   # No PIGZ on Flatcar
-  PIGZ="docker run --rm -i ghcr.io/flatcar-linux/pigz --fast"
+  PIGZ="docker run --rm -i ghcr.io/flatcar/pigz --fast"
 fi
 
 CI_GIT_AUTHOR="flatcar-ci"

--- a/ci-automation/image_changes.sh
+++ b/ci-automation/image_changes.sh
@@ -91,7 +91,7 @@ function _image_changes_impl() {
     NEW_VERSION=$(git tag --points-at HEAD)
     cd ..
     rm -rf flatcar-build-scripts
-    git clone "https://github.com/flatcar-linux/flatcar-build-scripts"
+    git clone "https://github.com/flatcar/flatcar-build-scripts"
     # Don't fail the job
     set +e
     echo "Package updates, compared to ${CHANNEL_A} ${VERSION_A}:"

--- a/ci-automation/packages-tag.sh
+++ b/ci-automation/packages-tag.sh
@@ -16,7 +16,7 @@
 #
 #   1. SDK version is recorded in sdk_container/.repo/manifests/version.txt
 #   2. SDK container is either
-#       - available via ghcr.io/flatcar-linux/flatcar-sdk-[ARCH]:[VERSION] (official SDK release)
+#       - available via ghcr.io/flatcar/flatcar-sdk-[ARCH]:[VERSION] (official SDK release)
 #       OR
 #       - available via build cache server "/containers/[VERSION]/flatcar-sdk-[ARCH]-[VERSION].tar.gz"
 #         (dev SDK)

--- a/ci-automation/packages.sh
+++ b/ci-automation/packages.sh
@@ -16,7 +16,7 @@
 #   1. SDK version and OS image version are recorded in sdk_container/.repo/manifests/version.txt
 #   2. Scripts repo version tag of OS image version to be built is available and checked out.
 #   3. SDK container is either
-#       - available via ghcr.io/flatcar-linux/flatcar-sdk-[ARCH]:[VERSION] (official SDK release)
+#       - available via ghcr.io/flatcar/flatcar-sdk-[ARCH]:[VERSION] (official SDK release)
 #       OR
 #       - available via build cache server "/containers/[VERSION]/flatcar-sdk-[ARCH]-[VERSION].tar.gz"
 #         (dev SDK)

--- a/ci-automation/release.sh
+++ b/ci-automation/release.sh
@@ -19,7 +19,7 @@
 #   4. Vendor image and torcx docker tarball + manifest to run tests for are available on buildcache
 #         ( images/[ARCH]/[FLATCAR_VERSION]/ )
 #   5. SDK container is either
-#       - available via ghcr.io/flatcar-linux/flatcar-sdk-[ARCH]:[VERSION] (official SDK release)
+#       - available via ghcr.io/flatcar/flatcar-sdk-[ARCH]:[VERSION] (official SDK release)
 #       OR
 #       - available via build cache server "/containers/[VERSION]/flatcar-sdk-[ARCH]-[VERSION].tar.gz"
 #         (dev SDK)

--- a/ci-automation/sdk_bootstrap.sh
+++ b/ci-automation/sdk_bootstrap.sh
@@ -17,7 +17,7 @@
 #   1. Version of the SEED SDK to use (string).
 #       The seed SDK tarball must be available on https://mirror.release.flatcar-linux.net/sdk/ ...
 #       The seed SDK container must be available from https://github.com/orgs/flatcar-linux/packages
-#          (via ghcr.io/flatcar-linux/flatcar-sdk-all:[VERSION]).
+#          (via ghcr.io/flatcar/flatcar-sdk-all:[VERSION]).
 #
 #   2. Version of the TARGET SDK to build (string).
 #       The version pattern 'MMMM.m.p' (e.g. '3051.0.0') denotes a "official" build, i.e. a release build to be published.

--- a/ci-automation/sdk_bootstrap.sh
+++ b/ci-automation/sdk_bootstrap.sh
@@ -16,7 +16,7 @@
 #
 #   1. Version of the SEED SDK to use (string).
 #       The seed SDK tarball must be available on https://mirror.release.flatcar-linux.net/sdk/ ...
-#       The seed SDK container must be available from https://github.com/orgs/flatcar-linux/packages
+#       The seed SDK container must be available from https://github.com/orgs/flatcar/packages
 #          (via ghcr.io/flatcar/flatcar-sdk-all:[VERSION]).
 #
 #   2. Version of the TARGET SDK to build (string).

--- a/contrib/create-coreos-vdi
+++ b/contrib/create-coreos-vdi
@@ -12,7 +12,7 @@ This tool creates a Flatcar VDI image to be used with VirtualBox.
 "
 
 # Image signing key: buildbot@flatcar-linux.org
-GPG_KEY_URL="https://flatcar-linux.org/security/image-signing-key/Flatcar_Image_Signing_Key.pem"
+GPG_KEY_URL="https://www.flatcar.org/security/image-signing-key/Flatcar_Image_Signing_Key.pem"
 GPG_LONG_ID="E25D9AED0593B34A"
 GPG_KEY="$(wget -qO- $GPG_KEY_URL)"
 

--- a/sdk_container/.repo/manifests/mantle-container
+++ b/sdk_container/.repo/manifests/mantle-container
@@ -1,1 +1,1 @@
-ghcr.io/flatcar-linux/mantle:git-fb7bbf6e2c863c0bcfb9dcba4c090e45eb8c4742
+ghcr.io/flatcar/mantle:git-fb7bbf6e2c863c0bcfb9dcba4c090e45eb8c4742

--- a/sdk_container/.repo/manifests/os-release
+++ b/sdk_container/.repo/manifests/os-release
@@ -2,5 +2,5 @@ NAME="Flatcar Container Linux by Kinvolk"
 ID=flatcar
 ID_LIKE=coreos
 ANSI_COLOR="38;5;75"
-HOME_URL="https://flatcar-linux.org/"
-BUG_REPORT_URL="https://issues.flatcar-linux.org"
+HOME_URL="https://flatcar.org/"
+BUG_REPORT_URL="https://issues.flatcar.org"

--- a/sdk_lib/sdk_container_common.sh
+++ b/sdk_lib/sdk_container_common.sh
@@ -8,7 +8,7 @@
 # globals
 #
 sdk_container_common_versionfile="sdk_container/.repo/manifests/version.txt"
-sdk_container_common_registry="ghcr.io/flatcar-linux"
+sdk_container_common_registry="ghcr.io/flatcar"
 sdk_container_common_env_file="sdk_container/.sdkenv"
 
 # Check for podman and docker; use docker if present, podman alternatively.

--- a/sdk_lib/sdk_init_selfcontained.sh
+++ b/sdk_lib/sdk_init_selfcontained.sh
@@ -2,7 +2,7 @@
 
 echo "This script will initialise your Flatcar SDK container as a self-contained SDK."
 echo "Please note that the preferred way of using the Flatcar SDK container is by cloning"
-echo "   https://github.com/flatcar-linux/scripts"
+echo "   https://github.com/flatcar/scripts"
 echo "and using the ./run_sdk_container script."
 
 echo
@@ -19,7 +19,7 @@ function clone_version() {
     local dest="$2"
     local version="$3"
 
-    git clone https://github.com/flatcar-linux/$repo "$dest"
+    git clone https://github.com/flatcar/$repo "$dest"
     git -C "${dest}" fetch --all
     local tag=$(git -C "${dest}" tag -l | grep "${version}")
     git -C "${dest}" checkout "$tag"


### PR DESCRIPTION
The "flatcar-linux" org will be renamed to "flatcar". For renames, there are no redirections in place and we have to update all links.
I've also found references to the old website domain and broken docs links which I also fixed.

## How to use

Merge when org rename is done.

(The links in the changelog files are not changed, these must be fixed in the website data, not here because it would trigger them to be included in the next release)