### PR TITLE
ci-automation: Implement a stricter image version check

### DIFF
--- a/ci-automation/ci_automation_common.sh
+++ b/ci-automation/ci_automation_common.sh
@@ -32,8 +32,8 @@ function update_submodule() {
 function check_version_string() {
     local version="$1"
 
-    if ! echo "${version}" | grep -qE '^(main-|alpha-|beta-|stable-|lts-)' ; then
-        echo "ERROR: invalid version '${version}', must start with 'main-', 'alpha-', 'beta-', 'stable-', or 'lts-'"
+    if [[ ! "${version}" =~ ^(main|alpha|beta|stable|lts)-[0-9]+\.[0-9]+\.[0-9]+(-.+)?$ ]]; then
+        echo "ERROR: invalid version '${version}', must start with 'main', 'alpha', 'beta', 'stable' or 'lts', followed by a dash and three dot-separated numbers, optionally followed by a dash and a non-empty build ID"
         exit 1
     fi
 }


### PR DESCRIPTION
I made a mistake and wrote a version like main-3363-0.0-stuff (note a dash instead of a dot after the first number). Surprisingly the build chugged along just fine almost until the end of the image job - it detected invalid version string when the job wanted to create a version.txt file:

```
ERROR   build_image: script called: build_image '--board=amd64-usr' '--group=developer' '--output_root=/home/sdk/build/images' '--only_store_compressed' '--torcx_root=/home/sdk/build/torcx' 'prodtar' 'container'
ERROR   build_image: Backtrace:  (most recent call is last)
ERROR   build_image:   file build_image, line 196, called: split_ver '3363' 'SPLIT'
ERROR   build_image:   file common.sh, line 192, called: die 'Invalid version string '3363''
ERROR   build_image:
ERROR   build_image: Error was:
ERROR   build_image:   Invalid version string '3363'
```

Let's have a stricted version check in the beginning, so the build fails earlier rather than later.

The build in question was http://jenkins.infra.kinvolk.io:8080/job/container/job/sdk/250/cldsv/

Tested manually by sourcing ci-automation/ci_automation_common.sh and invoking `check_version_string` with various inputs.