### PR TITLE
ci-automation: add openstack to tested vendors

### DIFF
--- a/ci-automation/ci-config.env
+++ b/ci-automation/ci-config.env
@@ -129,3 +129,7 @@ AWS_PARALLEL="${PARALLEL_TESTS:-8}"
 : ${AZURE_VNET_SUBNET_NAME:="jenkins-vnet-westeurope"}
 AZURE_PARALLEL="${PARALLEL_TESTS:-20}"
 AZURE_LOCATION="${AZURE_LOCATION:-westeurope}"
+
+# -- Openstack --
+: ${OPENSTACK_IMAGE_NAME:='flatcar_production_openstack_image.img.gz'}
+OPENSTACK_PARALLEL="${PARALLEL_TESTS:-3}"

--- a/ci-automation/garbage_collect_cloud.sh
+++ b/ci-automation/garbage_collect_cloud.sh
@@ -17,3 +17,5 @@ timeout --signal=SIGQUIT 60m ore azure gc --duration 6h \
   --azure-profile="/proc/$$/fd/${azure_profile}" --azure-auth="/proc/$$/fd/${azure_auth}"
 timeout --signal=SIGQUIT 60m ore equinixmetal gc --duration 6h \
   --project="${EQUINIXMETAL_PROJECT}" --gs-json-key=<(echo "${GCP_JSON_KEY}" | base64 --decode) --api-key="${EQUINIXMETAL_KEY}"
+timeout --signal=SIGQUIT 60m ore openstack gc --duration 6h \
+  --config-file=<(echo "${OPENSTACK_CREDS}" | base64 --decode)

--- a/ci-automation/vendor-testing/openstack.sh
+++ b/ci-automation/vendor-testing/openstack.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Copyright (c) 2022 The Flatcar Maintainers.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+set -euo pipefail
+
+# Test execution script for the Openstack vendor image.
+# This script is supposed to run in the mantle container.
+
+source ci-automation/vendor_test.sh
+
+# ARM64 does not seem to be supported yet with devstack, so for now fail it as an
+# unsupported option.
+if [[ "${CIA_ARCH}" == "arm64" ]]; then
+    echo "1..1" > "${CIA_TAPFILE}"
+    echo "not ok - all qemu tests" >> "${CIA_TAPFILE}"
+    echo "  ---" >> "${CIA_TAPFILE}"
+    echo "  ERROR: ARM64 tests not supported on Openstack (devstack)." | tee -a "${CIA_TAPFILE}"
+    echo "  ..." >> "${CIA_TAPFILE}"
+    break_retest_cycle
+    exit 1
+fi
+
+# OPENSTACK_CREDS, OPENSTACK_USER, OPENSTACK_HOST, OPENSTACK_KEYFILE should be provided by sdk_container/.env
+config_file=''
+secret_to_file config_file "${OPENSTACK_CREDS}"
+
+openstack_keyfile=''
+secret_to_file openstack_keyfile "${OPENSTACK_KEYFILE}"
+
+# Upload the image on OpenStack dev instance.
+IMAGE_ID=$(ore openstack create-image \
+  --name=flatcar-"${CIA_VERNUM}" \
+  --file="https://${BUILDCACHE_SERVER}/images/${CIA_ARCH}/${CIA_VERNUM}/${OPENSTACK_IMAGE_NAME}" \
+  --config-file="${config_file}"
+)
+
+# Delete the image once we exit.
+trap 'ore --config-file "${config_file}" openstack delete-image --id "${IMAGE_ID}" || true' EXIT
+
+kola_test_basename="ci-${CIA_VERNUM//+/-}"
+kola_test_basename="${kola_test_basename//[+.]/-}"
+
+set -x
+
+timeout --signal=SIGQUIT 2h kola run \
+  --board="${CIA_ARCH}-usr" \
+  --parallel="${OPENSTACK_PARALLEL}" \
+  --tapfile="${CIA_TAPFILE}" \
+  --channel="${CIA_CHANNEL}" \
+  --torcx-manifest="${CIA_TORCX_MANIFEST}" \
+  --basename="${kola_test_basename}" \
+  --platform=openstack \
+  --openstack-network=public \
+  --openstack-domain=default \
+  --openstack-flavor=flatcar-flavor \
+  --openstack-user="${OPENSTACK_USER}" \
+  --openstack-host="${OPENSTACK_HOST}" \
+  --openstack-keyfile="${openstack_keyfile}" \
+  --openstack-image="${IMAGE_ID}" \
+  --openstack-config-file="${config_file}" \
+  "${@}"
+
+set +x


### PR DESCRIPTION
Missing link to enable the tests in the Flatcar test suite.

Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

<hr>

Closes: https://github.com/flatcar/Flatcar/issues/785

CI :green_circle: : http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/412/cldsv/

Requires:
- https://github.com/flatcar/mantle/pull/382
