### PR TITLE
ci-automation: Don't skip nightly build when the previous one failed

### DIFF
--- a/ci-automation/ci_automation_common.sh
+++ b/ci-automation/ci_automation_common.sh
@@ -161,7 +161,7 @@ function image_exists_locally() {
 # --
 
 # Derive docker-safe image version string from vernum.
-#
+# Keep in sync with sdk_lib/sdk_container_common.sh
 function vernum_to_docker_image_version() {
     local vernum="$1"
     echo "$vernum" | sed 's/[+]/-/g'

--- a/ci-automation/packages-tag.sh
+++ b/ci-automation/packages-tag.sh
@@ -98,9 +98,13 @@ function _packages_tag_impl() {
           local ret=0
           git diff --exit-code "${existing_tag}" || ret=$?
           if [[ ret -eq 0 ]]; then
-            touch ./skip-build
-            echo "Creating ./skip-build flag file, indicating that the build must not to continue because no new tag got created as there are no changes since tag ${existing_tag}" >&2
-            return 0
+            if curl --head --fail --silent --show-error --location "https://${BUILDCACHE_SERVER}/images/amd64/${FLATCAR_VERSION}/flatcar_production_image.bin.bz2"
+              && curl --head --fail --silent --show-error --location "https://${BUILDCACHE_SERVER}/images/arm64/${FLATCAR_VERSION}/flatcar_production_image.bin.bz2"; then
+                touch ./skip-build
+                echo "Creating ./skip-build flag file, indicating that the build must not to continue because no new tag got created as there are no changes since tag ${existing_tag} and the Flatcar images exist" >&2
+                return 0
+            fi
+            echo "No changes but continuing build because Flatcar images do not exist"
           elif [[ ret -eq 1 ]]; then
             echo "Found changes since last tag ${existing_tag}" >&2
           else

--- a/sdk_lib/sdk_container_common.sh
+++ b/sdk_lib/sdk_container_common.sh
@@ -134,7 +134,7 @@ function strip_version_prefix() {
 # --
 
 # Derive docker-safe image version string from vernum.
-#
+# Keep in sync with ci-automation/ci_automation_common.sh
 function vernum_to_docker_image_version() {
     local vernum="$1"
     echo "$vernum" | sed 's/[+]/-/g'


### PR DESCRIPTION
Currently we skip the nightly build if there are no changes. This
    didn't work well because a new run doesn't fix any failure because the
    rerun became a no-op.
    Check if the main artifacts we expect from a step are found, as simple
    heuristic on whether a rerun is needed.

## How to use

backport

## Testing done

None
