### PR TITLE
.github: Use lts-info

### DIFF
--- a/.github/workflows/mantle-releases-main.yml
+++ b/.github/workflows/mantle-releases-main.yml
@@ -18,24 +18,45 @@ jobs:
       - name: Figure out branch
         id: figure-out-branch
         run: |
+          skip=0
+          branch=''
           if [ ${{ matrix.branch }} = "main" ]; then
-            echo ::set-output name=BRANCH::main
+            branch='main'
           elif [[ ${{ matrix.branch }} = 'lts-old' ]]; then
-            echo ::set-output name=BRANCH::flatcar-lts-2605
+            curl -fsSLO --retry-delay 1 --retry 60 --retry-connrefused --retry-max-time 60 --connect-timeout 20 'https://lts.release.flatcar-linux.net/lts-info'
+            if [[ $(grep -e ':supported' lts-info | wc -l) -le 1 ]]; then
+              # Only one supported LTS, skip this workflow run
+              # as 'lts' matrix branch will handle updating the only
+              # supported LTS.
+              skip=1
+            else
+              major=$(grep -e ':supported' lts-info | sort -V | head -n 1 | awk -F: '{print $1}')
+              branch="flatcar-${major}"
+              # Drop this corner case when 2605 is not supported.
+              if [[ ${major} -eq 2605 ]]; then
+                branch='flatcar-lts-2605'
+              fi
+            fi
+            rm -f lts-info
           else
             major=$(curl -sSL https://${{ matrix.branch }}.release.flatcar-linux.net/amd64-usr/current/version.txt | awk -F= '/FLATCAR_BUILD=/{ print $2 }')
-            echo ::set-output name=BRANCH::flatcar-${major}
+            branch="flatcar-${major}"
           fi
+          echo ::set-output "name=BRANCH::${branch}"
+          echo ::set-output "name=SKIP::${skip}"
       - uses: actions/checkout@v2
+        if: ${{ steps.figure-out-branch.outputs.SKIP == 0 }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ steps.figure-out-branch.outputs.BRANCH }}
       - name: Fetch latest mantle hash
+        if: ${{ steps.figure-out-branch.outputs.SKIP == 0 }}
         id: fetch-latest-mantle
         run: |
           commit=$(git ls-remote  https://github.com/flatcar/mantle refs/heads/flatcar-master | cut -f1)
           echo ::set-output name=COMMIT::${commit}
       - name: Try to apply patch
+        if: ${{ steps.figure-out-branch.outputs.SKIP == 0 }}
         run: |
           set -x
           commit=${{ steps.fetch-latest-mantle.outputs.COMMIT }}
@@ -44,6 +65,7 @@ jobs:
             git add sdk_container/.repo/manifests/mantle-container
           fi
       - name: Create pull request for branch
+        if: ${{ steps.figure-out-branch.outputs.SKIP == 0 }}
         uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We can use lts-info to optionally update mantle container in old LTS branch too.
