### PR TITLE
ci-automation: Fallback also to the mirror for container download

### DIFF
--- a/ci-automation/ci_automation_common.sh
+++ b/ci-automation/ci_automation_common.sh
@@ -212,11 +212,16 @@ function docker_image_from_buildcache() {
         return
     fi
 
+    # First try bincache then release to allow a bincache overwrite
     local url="https://${BUILDCACHE_SERVER}/containers/${version}/${tgz}"
+    local url_release="https://mirror.release.flatcar-linux.net/containers/${version}/${tgz}"
 
     curl --fail --silent --show-error --location --retry-delay 1 --retry 60 \
         --retry-connrefused --retry-max-time 60 --connect-timeout 20 \
-        --remote-name "${url}"
+        --remote-name "${url}" \
+        || curl --fail --silent --show-error --location --retry-delay 1 --retry 60 \
+        --retry-connrefused --retry-max-time 60 --connect-timeout 20 \
+        --remote-name "${url_release}"
 
     cat "${tgz}" | $PIGZ -d -c | $docker load
 


### PR DESCRIPTION
When there is no SDK container image in the registry, the fallback looks at bincache but bincache isn't backed up and may be cleaned of old releases. While this won't be the regular case, the container image registry may be unavailable (or renamed as happened now), or people would like to rerun the image job which relies on the packages container.

## How to use


## Testing done

None
