### PR TITLE
ci-automation: Ensure to use latest container image

### DIFF
--- a/run_sdk_container
+++ b/run_sdk_container
@@ -113,6 +113,12 @@ if [ -z "$stat" ] ; then
             source ci-automation/ci_automation_common.sh
             docker_image_from_registry_or_buildcache "flatcar-sdk-${arch}" "${docker_sdk_vernum}"
 	)
+    else
+        # We could split the container_image_name in parts to call docker_image_from_registry_or_buildcache
+        # bur for now just try to ensure that we use the latest image if using a container registry,
+        # for the tar-ball-imported images we rely on the ci-automation scripts to call
+        # docker_image_from_registry_or_buildcache explicitly.
+        $docker pull "${container_image_name}" || true
     fi
 
     $docker create $tty -i \


### PR DESCRIPTION
The container image was only created if it didn't exist locally. This
    would result in fixes not being in a downstream job that is scheduled
    to a different worker node on Jenkins that has a stale copy.
    For the build automation we will now always download the latest
    container tar ball based on comparing the image ID from a new artifact,
    and for registry images we pull the container image to make sure that
    we don't use a stale copy when we rebuild.

## How to use

Backport

## Testing done

[started](http://jenkins.infra.kinvolk.io:8080/job/container/job/sdk/292/cldsv/)

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
