### PR TITLE
ci-automation: use --batch when importing gpg key

### DIFF
--- a/ci-automation/gpg_setup.sh
+++ b/ci-automation/gpg_setup.sh
@@ -22,7 +22,7 @@ mkdir --mode=0700 "${GNUPGHOME}"
 # workaround.
 mkdir -p --mode=0700 "${GNUPGHOME}/private-keys-v1.d/"
 if [[ -n "${SIGNING_KEY}" ]] && [[ -n "${SIGNER}" ]]; then
-    gpg --import "${SIGNING_KEY}"
+    gpg --batch --import "${SIGNING_KEY}"
 else
     SIGNER=''
 fi


### PR DESCRIPTION
# ci-automation: use --batch when importing gpg key

Add `--batch` to `gpg --import` invocation to unblock arm64 sdk bootstrap job. Without this change, the job fails with:
```
gpg: cannot open '/dev/tty': No such device or address
```
because it wants to print a warning/suggestion to the tty.

## How to use

Run container/arm64_sdk_bootstrap job.

## Testing done

Successfully ran container/arm64_sdk_boostrap job.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
