### PR TITLE
ci-automation/release: Only upload SDK if a new one was built

### DIFF
--- a/ci-automation/release.sh
+++ b/ci-automation/release.sh
@@ -216,7 +216,9 @@ function _release_build_impl() {
       sign_artifacts "${SIGNER}" "aws-${arch}/flatcar_production_ami_"*txt "aws-${arch}/flatcar_production_ami_"*json
       copy_to_buildcache "images/${arch}/${vernum}/" "aws-${arch}/flatcar_production_ami_"*txt* "aws-${arch}/flatcar_production_ami_"*json*
     done
-    publish_sdk "${docker_sdk_vernum}"
+    if [ "${vernum}" = "${sdk_version}" ]; then
+      publish_sdk "${docker_sdk_vernum}"
+    fi
     echo "===="
     echo "Done, now you can copy the images to Origin"
     echo "===="


### PR DESCRIPTION
A release includes an SDK if its SDK version is the release version. Only then we need to upload a new SDK container image.

CC @tormath1 

## How to use

Backport (to avoid unnecessary tar ball import, the upload gets skipped anyway)

## Testing done

none
