### PR TITLE
ci-automation/vendor-testing/vmware.sh: Fix unbound variable use

### DIFF
--- a/ci-automation/vendor-testing/vmware.sh
+++ b/ci-automation/vendor-testing/vmware.sh
@@ -24,7 +24,7 @@ fi
 
 # Fetch image if not present.
 if [ -f "${VMWARE_ESX_IMAGE_NAME}" ] ; then
-    echo "++++ ${CIA_TESTSCRIPT}: Using existing ${work_dir}/${VMWARE_ESX_IMAGE_NAME} for testing ${CIA_VERNUM} (${CIA_ARCH}) ++++"
+    echo "++++ ${CIA_TESTSCRIPT}: Using existing ${VMWARE_ESX_IMAGE_NAME} for testing ${CIA_VERNUM} (${CIA_ARCH}) ++++"
 else
     echo "++++ ${CIA_TESTSCRIPT}: downloading ${VMWARE_ESX_IMAGE_NAME} for ${CIA_VERNUM} (${CIA_ARCH}) ++++"
     copy_from_buildcache "images/${CIA_ARCH}/${CIA_VERNUM}/${VMWARE_ESX_IMAGE_NAME}" .


### PR DESCRIPTION
This gets triggered when the test is rerun and an existing image is reused.

Spotted here: http://jenkins.infra.kinvolk.io:8080/job/container/job/test/3376/console