### PR TITLE
ci-automation: Add an environment variable to skip build shortcuts

### DIFF
--- a/ci-automation/ci-config.env
+++ b/ci-automation/ci-config.env
@@ -31,6 +31,10 @@ CI_GIT_EMAIL="infra+ci@flatcar-linux.org"
 CONTAINER_TORCX_ROOT="/home/sdk/build/torcx"
 CONTAINER_IMAGE_ROOT="/home/sdk/build/images"
 
+# Set it to "1" or "true" or "t" or "y" or "yes" to always run a full
+# nightly build. Any other value will allow build shortcuts.
+: ${AVOID_NIGHTLY_BUILD_SHORTCUTS:=0}
+
 #
 # Image / vendor tests settings
 #

--- a/ci-automation/ci_automation_common.sh
+++ b/ci-automation/ci_automation_common.sh
@@ -507,3 +507,17 @@ function apply_local_patches() {
   done
 }
 # --
+
+# Returns 0 if passed value is either "1" or "true" or "t", otherwise
+# returns 1.
+function bool_is_true() {
+    case "${1}" in
+        1|true|t|yes|y)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+# --

--- a/ci-automation/packages-tag.sh
+++ b/ci-automation/packages-tag.sh
@@ -48,6 +48,9 @@
 #
 #   6. A file ../portage.patch to apply with "git am -3" for the portage-stable sub-module.
 #
+#   7. AVOID_NIGHTLY_BUILD_SHORTCUTS. Environment variable. Tells the script to build the SDK even if nothing has changed since last nightly build.
+#        See the description in ci-config.env.
+#
 # OUTPUT:
 #
 #   1. Updated scripts repository
@@ -98,7 +101,14 @@ function _packages_tag_impl() {
        && [[ "$(git -C sdk_container/src/third_party/portage-stable/ rev-parse --abbrev-ref HEAD)" =~ ^flatcar-[0-9]+$ ]] ; then
         push_branch="true"
         local existing_tag=""
-        existing_tag=$(git tag --points-at HEAD) # exit code is always 0, output may be empty
+        # Check for the existing tag only when we allow shortcutting
+        # the builds. That way we can skip the checks for build
+        # shortcutting.
+        if bool_is_true "${AVOID_NIGHTLY_BUILD_SHORTCUTS}"; then
+            echo "Continuing the build because AVOID_NIGHTLY_BUILD_SHORTCUTS is bool true (${AVOID_NIGHTLY_BUILD_SHORTCUTS})" >&2
+        else
+            existing_tag=$(git tag --points-at HEAD) # exit code is always 0, output may be empty
+        fi
         # If the found tag is a release or nightly tag, we stop this build if there are no changes
         if [[ "${existing_tag}" =~ ^(stable|alpha|beta|lts)-[0-9.]+(|-nightly-[-0-9]+)$ ]]; then
           local ret=0


### PR DESCRIPTION
This will be used for the "run all tests" days in Jenkins. So even if no changes happened since last nightly build, a build will be done and the tests will be run.

## Testing done

CI: http://jenkins.infra.kinvolk.io:8080/job/container/job/nightly/168/cldsv/

Made on [my test branch with some extra changes for testing](https://github.com/flatcar/scripts/tree/flatcar-999999).

Changes made for testing:
- limited nightly builds to alpha (because today is Tuesday and "run all tests" day today is for alpha channel),
- hardcoded flatcar-999999 scripts branch (can't be krnowak/flatcar-3374-test, for example, this gets checked),
- no packages job gets launched, just a message is printed
- packages tag script returns before modifying versionfile and pushing a new tag

