### PR TITLE
vm_image_util: Use qemu-img for streamOptimized VMDKs

### DIFF
--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -587,12 +587,7 @@ _write_hdd_disk() {
 }
 
 _write_vmdk_stream_disk() {
-    # requires two pass conversion, qemu-img doesn't properly support the
-    # stream-optimized VMDK format. The special vmdk-convert tool only takes
-    # VMDK images as an import format.
-    local tmpvmdk="${VM_TMP_DIR}/tmp.vmdk"
-    qemu-img convert -f raw "$1" -O vmdk -o adapter_type=lsilogic "${tmpvmdk}"
-    vmdk-convert "${tmpvmdk}" "$2"
+    qemu-img convert -f raw "$1" -O vmdk -o subformat=streamOptimized,adapter_type=lsilogic "$2"
     assert_image_size "$2" vmdk
 }
 


### PR DESCRIPTION
To create the streamOptimized VMDK format we use the vmdk-convert
    utility. Nowadays qemu-img can also create this format directly,
    for supported formats see:
    https://www.qemu.org/docs/master/system/qemu-block-drivers.html


## How to use


## Testing done

http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/653/cldsv/

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
