### PR TITLE
ci-automation: Use plain AMI image for uploads

### DIFF
--- a/ci-automation/vendor-testing/aws.sh
+++ b/ci-automation/vendor-testing/aws.sh
@@ -21,12 +21,12 @@ set -o noglob # there shouldn't be any instance types with asterisks
 more_aws_instance_types=( ${!more_aws_instance_types_var} )
 set +o noglob
 
-vmdk='flatcar_production_ami_vmdk_image.vmdk'
-tarball="${vmdk}.bz2"
+image_file='flatcar_production_ami_image.bin'
+tarball="${image_file}.bz2"
 
 if [[ "${AWS_AMI_ID}" == "" ]]; then
-    if [[ -f "${vmdk}" ]]; then
-        echo "++++ ${CIA_TESTSCRIPT}: using existing ${vmdk} for ${CIA_VERNUM} (${CIA_ARCH}) ++++"
+    if [[ -f "${image_file}" ]]; then
+        echo "++++ ${CIA_TESTSCRIPT}: using existing ${image_file} for ${CIA_VERNUM} (${CIA_ARCH}) ++++"
     else
         echo "++++ ${CIA_TESTSCRIPT}: downloading ${tarball} for ${CIA_VERNUM} (${CIA_ARCH}) ++++"
         copy_from_buildcache "images/${CIA_ARCH}/${CIA_VERNUM}/${tarball}" .
@@ -35,9 +35,9 @@ if [[ "${AWS_AMI_ID}" == "" ]]; then
 
     aws_bucket="flatcar-kola-ami-import-${AWS_REGION}"
     aws_s3_path="s3://${aws_bucket}/${escaped_vernum}/${board}/"
-    trap 'ore -d aws delete --region="${AWS_REGION}" --board="${board}" --name="${image_name}" --ami-name="${image_name}" --file="${vmdk}" --bucket "${aws_s3_path}"' EXIT
+    trap 'ore -d aws delete --region="${AWS_REGION}" --board="${board}" --name="${image_name}" --ami-name="${image_name}" --file="${image_file}" --bucket "${aws_s3_path}"' EXIT
     ore aws initialize --region="${AWS_REGION}" --bucket "${aws_bucket}"
-    AWS_AMI_ID=$(ore aws upload --force --region="${AWS_REGION}" --board="${board}" --name="${image_name}" --ami-name="${image_name}" --ami-description="Flatcar Test ${image_name}" --file="${vmdk}" --bucket "${aws_s3_path}" | jq -r .HVM)
+    AWS_AMI_ID=$(ore aws upload --force --region="${AWS_REGION}" --board="${board}" --name="${image_name}" --ami-name="${image_name}" --ami-description="Flatcar Test ${image_name}" --file="${image_file}" --object-format=RAW --force --bucket "${aws_s3_path}" | jq -r .HVM)
     echo "++++ ${CIA_TESTSCRIPT}: created new AMI ${AWS_AMI_ID} (will be removed after testing) ++++"
 fi
 


### PR DESCRIPTION
Recently we ran into sporadic corruption issues for AWS EC2 AMIs. We use the streamOptimized VMDK format and it seems to cause problems at the AWS side, regardless if created by qemu-img or vmdk-convert. Switch to using the plain AMI images for uploading as workaround.

## How to use

If it helps, backport to all branches, retag the new releases

## Testing done

Verified that the Alpha arm64 issue goes away when this patch is used (prepared git ref `kai/aws-ami-plain-test`, [rebuild link](http://jenkins.infra.kinvolk.io:8080/job/container/job/test/3975/console)).

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
