### PR TITLE
common: Extend liblto link fixup function

### DIFF
--- a/build_library/build_image_util.sh
+++ b/build_library/build_image_util.sh
@@ -189,7 +189,7 @@ emerge_to_image() {
   # Make sure profile.env has been generated
   sudo -E ROOT="${root_fs_dir}" env-update --no-ldconfig
 
-  fixup_liblto_softlinks "$root_fs_dir"
+  fixup_gcc_config_softlinks "${root_fs_dir}"
 
   # TODO(marineam): just call ${BUILD_LIBRARY_DIR}/check_root directly once
   # all tests are fatal, for now let the old function skip soname errors.

--- a/build_packages
+++ b/build_packages
@@ -295,7 +295,7 @@ fi
 
 eclean-$BOARD -d packages
 
-fixup_liblto_softlinks "${BOARD_ROOT}"
+fixup_gcc_config_softlinks "${BOARD_ROOT}"
 
 info "Checking build root"
 test_image_content "${BOARD_ROOT}"


### PR DESCRIPTION
We need to fix another symlink created by gcc-config, so extend the function that was doing it for some other links and rename it - it's not about only liblto any more.

Needs to be merged together with https://github.com/flatcar/portage-stable/pull/380 and https://github.com/flatcar/coreos-overlay/pull/2266.

CI: http://jenkins.infra.kinvolk.io:8080/job/container/job/sdk/387/cldsv
