### PR TITLE
.github: Modernize mantle update action

### DIFF
--- a/.github/workflows/mantle-releases-main.yml
+++ b/.github/workflows/mantle-releases-main.yml
@@ -42,9 +42,9 @@ jobs:
             major=$(curl -sSL https://${{ matrix.branch }}.release.flatcar-linux.net/amd64-usr/current/version.txt | awk -F= '/FLATCAR_BUILD=/{ print $2 }')
             branch="flatcar-${major}"
           fi
-          echo ::set-output "name=BRANCH::${branch}"
-          echo ::set-output "name=SKIP::${skip}"
-      - uses: actions/checkout@v2
+          echo "BRANCH=${branch}" >>"${GITHUB_OUTPUT}"
+          echo "SKIP=${skip}" >>"${GITHUB_OUTPUT}"
+      - uses: actions/checkout@v3
         if: ${{ steps.figure-out-branch.outputs.SKIP == 0 }}
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -54,7 +54,7 @@ jobs:
         id: fetch-latest-mantle
         run: |
           commit=$(git ls-remote  https://github.com/flatcar/mantle refs/heads/flatcar-master | cut -f1)
-          echo ::set-output name=COMMIT::${commit}
+          echo "COMMIT=${COMMIT}" >>"${GITHUB_OUTPUT}"
       - name: Try to apply patch
         if: ${{ steps.figure-out-branch.outputs.SKIP == 0 }}
         run: |
@@ -66,7 +66,7 @@ jobs:
           fi
       - name: Create pull request for branch
         if: ${{ steps.figure-out-branch.outputs.SKIP == 0 }}
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           base: ${{ steps.figure-out-branch.outputs.BRANCH }}


### PR DESCRIPTION
This is to avoid warnings about deprecated node 12 actions and deprecated save-state and set-output commands.