### PR TITLE
build_library: add 202209-12 to GLSA_ALLOWLIST

### DIFF
--- a/build_library/test_image_content.sh
+++ b/build_library/test_image_content.sh
@@ -4,7 +4,7 @@
 
 GLSA_ALLOWLIST=(
 	201412-09 # incompatible CA certificate version numbers
-	202105-22 # samba, not affected, samba has no ldap flag, no smbd.
+	202209-12 # grub 2.06 is still in progress
 )
 
 glsa_image() {


### PR DESCRIPTION
Flatcar has `net-fs/samba` 4.15.4-r3, greater than 4.13.8, so it is not necessary to keep GLSA 202105-22 in `GLSA_ALLOWLIST`.

Allow 202209-12 for now, as update to grub 2.06 is still in progress.

This PR should be merged together with https://github.com/flatcar/portage-stable/pull/387.

## Testing done

CI: http://jenkins.infra.kinvolk.io:8080/job/container/job/sdk/422/cldsv/

- Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update) (not needed)
- Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc. (not needed)
