### PR TITLE
.github: Fix mantle update action

### DIFF
--- a/.github/workflows/mantle-releases-main.yml
+++ b/.github/workflows/mantle-releases-main.yml
@@ -54,7 +54,7 @@ jobs:
         id: fetch-latest-mantle
         run: |
           commit=$(git ls-remote  https://github.com/flatcar/mantle refs/heads/flatcar-master | cut -f1)
-          echo "COMMIT=${COMMIT}" >>"${GITHUB_OUTPUT}"
+          echo "COMMIT=${commit}" >>"${GITHUB_OUTPUT}"
       - name: Try to apply patch
         if: ${{ steps.figure-out-branch.outputs.SKIP == 0 }}
         run: |


### PR DESCRIPTION
The variable is actually lowercase. Not sure how I ended up having uppercase variant of it.

Tested on my fork:
- action run (failed for other branches as I cloned only the main branch): https://github.com/krnowak/scripts/actions/runs/3497360325
- PR: https://github.com/krnowak/scripts/pull/1