### PR TITLE
qemu_update: Add update test from an old release

### DIFF
--- a/ci-automation/vendor-testing/qemu_update.sh
+++ b/ci-automation/vendor-testing/qemu_update.sh
@@ -12,7 +12,8 @@ set -euo pipefail
 
 source ci-automation/vendor_test.sh
 
-if [ "$*" != "" ] && [ "$*" != "*" ] && [ "$*" != "cl.update.payload" ]; then
+# The last check is not perfect (if both tests are rerun, it will only look at the name of the second test) but hopefully still good enough to prevent wrong usage
+if [ "$*" != "" ] && [ "$*" != "*" ] && [[ "$*" != *"cl.update.payload" ]]; then
     echo "1..1" > "${CIA_TAPFILE}"
     echo "not ok - all qemu update tests" >> "${CIA_TAPFILE}"
     echo "  ---" >> "${CIA_TAPFILE}"
@@ -30,8 +31,8 @@ else
     copy_from_buildcache "images/${CIA_ARCH}/${CIA_VERNUM}/flatcar_test_update.gz" tmp/
 fi
 
-if [ -f tmp/flatcar_production_image_previous.bin ] ; then
-    echo "++++ ${CIA_TESTSCRIPT}: Using existing ./tmp/flatcar_production_image_previous.bin for testing update to ${CIA_VERNUM} (${CIA_ARCH}) from previous ${CIA_CHANNEL} ++++"
+if [ -f tmp/flatcar_production_image_previous.bin ] && [ -f tmp/flatcar_production_image_first_dual.bin ] ; then
+    echo "++++ ${CIA_TESTSCRIPT}: Using existing ./tmp/flatcar_production_image_{previous,first_dual}.bin for testing update to ${CIA_VERNUM} (${CIA_ARCH}) from previous ${CIA_CHANNEL} and first dual-arch Stable release ++++"
 else
     echo "++++ ${CIA_TESTSCRIPT}: downloading flatcar_production_image_previous.bin from previous ${CIA_CHANNEL} ++++"
     rm -f tmp/flatcar_production_image_previous.bin.bz2
@@ -54,6 +55,11 @@ else
     curl -fsSLO --retry-delay 1 --retry 60 --retry-connrefused --retry-max-time 60 --connect-timeout 20 "https://${CIA_CHANNEL}.release.flatcar-linux.net/${CIA_ARCH}-usr/current${SUFFIX}/flatcar_production_image.bin.bz2"
     mv flatcar_production_image.bin.bz2 tmp/flatcar_production_image_previous.bin.bz2
     lbunzip2 -k -f tmp/flatcar_production_image_previous.bin.bz2
+    echo "++++ ${CIA_TESTSCRIPT}: downloading flatcar_production_image_first_dual.bin from first dual-arch Stable release ++++"
+    # We fix the release version here to emulate an update from a very old instance. We could have went with the first Flatcar release but that lacked arm64 support.
+    curl -fsSLO --retry-delay 1 --retry 60 --retry-connrefused --retry-max-time 60 --connect-timeout 20 "https://stable.release.flatcar-linux.net/${CIA_ARCH}-usr/3033.2.4/flatcar_production_image.bin.bz2"
+    mv flatcar_production_image.bin.bz2 tmp/flatcar_production_image_first_dual.bin.bz2
+    lbunzip2 -k -f tmp/flatcar_production_image_first_dual.bin.bz2
 fi
 
 bios="${QEMU_BIOS}"
@@ -67,14 +73,41 @@ if [ "${CIA_ARCH}" = "arm64" ]; then
     fi
 fi
 
-kola run \
-    --board="${CIA_ARCH}-usr" \
-    --parallel="${QEMU_PARALLEL}" \
-    --platform=qemu \
-    --qemu-bios="${bios}" \
-    --qemu-image=tmp/flatcar_production_image_previous.bin \
-    --tapfile="${CIA_TAPFILE}" \
-    --torcx-manifest="${CIA_TORCX_MANIFEST}" \
-    --update-payload=tmp/flatcar_test_update.gz \
-    --qemu-skip-mangle \
-    cl.update.payload
+query_kola_tests() {
+    shift; # ignore the instance type
+    local arg
+    arg="${*}"
+    if [ "${arg}" != "" ]; then
+      # Empty calls are ok, which mean no tests, but otherwise we restrict the tests to run
+      arg="cl.update.payload"
+    fi
+    kola list --platform=qemu --filter "${arg}"
+}
+
+run_kola_tests() {
+    local instance_type="${1}"; shift;
+    local instance_tapfile="${1}"; shift
+    local image
+    if [ "${instance_type}" = "previous" ]; then
+        image="tmp/flatcar_production_image_previous.bin"
+    elif [ "${instance_type}" = "first_dual" ]; then
+        image="tmp/flatcar_production_image_first_dual.bin"
+    else
+        echo "Wrong instance type ${instance_type}" >&2
+        exit 1
+    fi
+
+    kola run \
+      --board="${CIA_ARCH}-usr" \
+      --parallel="${QEMU_PARALLEL}" \
+      --platform=qemu \
+      --qemu-bios="${bios}" \
+      --qemu-image="${image}" \
+      --tapfile="${instance_tapfile}" \
+      --torcx-manifest="${CIA_TORCX_MANIFEST}" \
+      --update-payload=tmp/flatcar_test_update.gz \
+      --qemu-skip-mangle \
+      cl.update.payload
+}
+
+run_kola_tests_on_instances "previous" "${CIA_TAPFILE}" "${CIA_FIRST_RUN}" first_dual -- cl.update.payload -- "${@}"


### PR DESCRIPTION
To ensure that we can update from very old releases, add a test with a fixed old release, here the Stable release that introduced arm64 support to have the same test logic for both architectures.

## How to use

backport

## Testing done

in http://jenkins.infra.kinvolk.io:8080/job/container/job/test/4880/console

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
