### PR TITLE
update_chroot, build_library: Drop repos.conf customization

### DIFF
--- a/build_library/catalyst.sh
+++ b/build_library/catalyst.sh
@@ -87,9 +87,6 @@ cat <<EOF
 [DEFAULT]
 main-repo = portage-stable
 
-[gentoo]
-disabled = true
-
 [coreos]
 location = /var/gentoo/repos/local
 

--- a/build_library/dev_container_util.sh
+++ b/build_library/dev_container_util.sh
@@ -44,9 +44,6 @@ sudo_clobber "$1/etc/portage/repos.conf/coreos.conf" <<EOF
 [DEFAULT]
 main-repo = portage-stable
 
-[gentoo]
-disabled = true
-
 [coreos]
 location = /var/lib/portage/coreos-overlay
 sync-type = git

--- a/update_chroot
+++ b/update_chroot
@@ -109,9 +109,6 @@ sudo_clobber "/etc/portage/repos.conf/coreos.conf" <<EOF
 [DEFAULT]
 main-repo = portage-stable
 
-[gentoo]
-disabled = true
-
 [coreos]
 location = ${COREOS_OVERLAY}
 


### PR DESCRIPTION
Should be merged together with https://github.com/flatcar/portage-stable/pull/398 and https://github.com/flatcar/coreos-overlay/pull/2325.

CI: http://jenkins.infra.kinvolk.io:8080/job/container/job/sdk/513/cldsv/

The "disabled" option was a Flatcar customization in sys-apps/portage. We are trying to move to vanilla portage, so let's see if this will work.