### PR TITLE
*: Allow applying user patches

### DIFF
--- a/build_library/catalyst.sh
+++ b/build_library/catalyst.sh
@@ -245,6 +245,9 @@ write_configs() {
     catalyst_stage3 > "$TEMPDIR/stage3.spec"
     info "    stage4.spec"
     catalyst_stage4 > "$TEMPDIR/stage4.spec"
+    info "Putting a symlink to user patches..."
+    ln -sf '/var/gentoo/repos/local/coreos/user-patches' \
+        "$TEMPDIR/portage/patches"
 }
 
 build_stage() {

--- a/setup_board
+++ b/setup_board
@@ -233,6 +233,8 @@ fi
 
 info "Configuring portage in ${BOARD_ROOT}"
 sudo mkdir -p "${BOARD_ETC}/portage/"{profile,repos.conf}
+sudo ln -sf "$(portageq get_repo_path / coreos)/coreos/user-patches" \
+   "${BOARD_ETC}/portage/patches"
 sudo cp /etc/portage/repos.conf/* "${BOARD_ETC}"/portage/repos.conf/
 sudo ROOT="${BOARD_ROOT}" eselect profile set --force "${PORTAGE_PROFILE}"
 

--- a/update_chroot
+++ b/update_chroot
@@ -83,6 +83,7 @@ info "Setting up portage..."
 sudo mkdir -p "${REPO_CACHE_DIR}/distfiles"
 sudo chown "${PORTAGE_USERNAME}:portage" "${REPO_CACHE_DIR}/distfiles"
 sudo mkdir -p /etc/portage/repos.conf /var/lib/portage/pkgs
+sudo ln -sf "${COREOS_OVERLAY}/coreos/user-patches" '/etc/portage/patches'
 sudo touch /etc/portage/make.conf.user
 
 sudo_clobber "/etc/portage/make.conf" <<EOF


### PR DESCRIPTION
When setting up portage configuration, we set up a symlink in `${ROOT}/etc/portage/patches` that points to the coreos/user-patches directory inside the coreos-overlay. That way, we can add our custom patches to coreos-overlay without the need for moving the packages from portage-stable to coreos-overlay only to apply an extra patch.

Should be merged together with https://github.com/flatcar/coreos-overlay/pull/2335.

Tested in the build http://jenkins.infra.kinvolk.io:8080/job/container/job/sdk/458. The build itself failed during image generation for unrelated reasons (based on my portage move branch), but it managed to build the SDK with a user patch for gentoolkit. I was able to confirm that my patch was actually applied.