### PR TITLE
gc: pass OPENSTACK_CREDS to mantle container

### DIFF
--- a/ci-automation/garbage_collect.sh
+++ b/ci-automation/garbage_collect.sh
@@ -151,6 +151,7 @@ function _garbage_collect_impl() {
       --env EQUINIXMETAL_KEY --env EQUINIXMETAL_PROJECT \
       --env GCP_JSON_KEY \
       --env VMWARE_ESX_CREDS \
+      --env OPENSTACK_CREDS \
       -w /work -v "$PWD":/work "${mantle_ref}" /work/ci-automation/garbage_collect_cloud.sh
 }
 # --


### PR DESCRIPTION
Signed-off-by: Mathieu Tortuyaux <mtortuyaux@microsoft.com>

<hr>

Otherwise, it fails with:
```
/work/ci-automation/garbage_collect_cloud.sh: line 20: OPENSTACK_CREDS: unbound variable
```