### PR TITLE
Drop a symlink-fixing hack

### DIFF
--- a/build_library/build_image_util.sh
+++ b/build_library/build_image_util.sh
@@ -189,8 +189,6 @@ emerge_to_image() {
   # Make sure profile.env has been generated
   sudo -E ROOT="${root_fs_dir}" env-update --no-ldconfig
 
-  fixup_gcc_config_softlinks "${root_fs_dir}"
-
   # TODO(marineam): just call ${BUILD_LIBRARY_DIR}/check_root directly once
   # all tests are fatal, for now let the old function skip soname errors.
   ROOT="${root_fs_dir}" PORTAGE_CONFIGROOT="${BUILD_DIR}"/configroot \

--- a/build_library/check_root
+++ b/build_library/check_root
@@ -301,7 +301,7 @@ def check_symlink():
 
                 if os.path.islink(path) and not os.path.exists(path):
                     ok = False
-                    error("broken link: %s", path)
+                    error("broken link: %s -> %s", path, os.readlink(path))
 
     return ok
 

--- a/build_packages
+++ b/build_packages
@@ -295,8 +295,6 @@ fi
 
 eclean-$BOARD -d packages
 
-fixup_gcc_config_softlinks "${BOARD_ROOT}"
-
 info "Checking build root"
 test_image_content "${BOARD_ROOT}"
 

--- a/common.sh
+++ b/common.sh
@@ -975,38 +975,3 @@ clean_qemu_static() {
     *) die "Unsupported arch" ;;
   esac
 }
-
-# Fix up various softlinks created by gcc-config
-fixup_gcc_config_softlinks() {
-    # root without trailing slashes, for / it will be empty
-    local root="${1%%*(/)}"
-
-    info "fixup_gcc_config_softlinks: Looking for broken softlinks in '${root}/'"
-
-    (
-        shopt -s nullglob
-        local files=(
-            "${root}"/usr/*/binutils-bin/lib/bfd-plugins/liblto_plugin.so
-            "${root}"/usr/*/*/binutils-bin/lib/bfd-plugins/liblto_plugin.so
-            "${root}"/usr/bin/*-cc
-        )
-        local file
-        local target
-        local new_target
-        for file in "${files[@]}"; do
-            if [[ ! -L "${file}" ]]; then
-                # not a symlink, ignore
-                continue
-            fi
-            target=$(readlink "${file}")
-            new_target=${target/#${root}}
-            if [[ "${target}" == "${new_target}" ]]; then
-                # nothing to fix, ignore
-                continue
-            fi
-            info "   Fixing up broken symlink '${file}' -> '${target}'"
-            info "   sudo ln -sf '${new_target}' '${file}'"
-            sudo ln -sf "${new_target}" "${file}"
-        done
-    )
-}


### PR DESCRIPTION
It is not necessary - we carry a patch for gcc-config that makes gcc-config to create proper, relative links. The patch is upstreamed, so it will be eventually dropped.

Should be merged together with https://github.com/flatcar/coreos-overlay/pull/2380.

CI passed: http://jenkins.infra.kinvolk.io:8080/job/container/job/sdk/525/cldsv/