### PR TITLE
*: Fix user-patches setup

### DIFF
--- a/build_library/catalyst.sh
+++ b/build_library/catalyst.sh
@@ -243,7 +243,7 @@ write_configs() {
     info "    stage4.spec"
     catalyst_stage4 > "$TEMPDIR/stage4.spec"
     info "Putting a symlink to user patches..."
-    ln -sf '/var/gentoo/repos/local/coreos/user-patches' \
+    ln -sfT '/var/gentoo/repos/local/coreos/user-patches' \
         "$TEMPDIR/portage/patches"
 }
 

--- a/setup_board
+++ b/setup_board
@@ -233,7 +233,7 @@ fi
 
 info "Configuring portage in ${BOARD_ROOT}"
 sudo mkdir -p "${BOARD_ETC}/portage/"{profile,repos.conf}
-sudo ln -sf "$(portageq get_repo_path / coreos)/coreos/user-patches" \
+sudo ln -sfT "$(portageq get_repo_path / coreos)/coreos/user-patches" \
    "${BOARD_ETC}/portage/patches"
 sudo cp /etc/portage/repos.conf/* "${BOARD_ETC}"/portage/repos.conf/
 sudo ROOT="${BOARD_ROOT}" eselect profile set --force "${PORTAGE_PROFILE}"

--- a/update_chroot
+++ b/update_chroot
@@ -83,7 +83,7 @@ info "Setting up portage..."
 sudo mkdir -p "${REPO_CACHE_DIR}/distfiles"
 sudo chown "${PORTAGE_USERNAME}:portage" "${REPO_CACHE_DIR}/distfiles"
 sudo mkdir -p /etc/portage/repos.conf /var/lib/portage/pkgs
-sudo ln -sf "${COREOS_OVERLAY}/coreos/user-patches" '/etc/portage/patches'
+sudo ln -sfT "${COREOS_OVERLAY}/coreos/user-patches" '/etc/portage/patches'
 sudo touch /etc/portage/make.conf.user
 
 sudo_clobber "/etc/portage/make.conf" <<EOF


### PR DESCRIPTION
Normally `ln -sf path/to/target at/name` will create a symlink at `at/name` that points to `path/to/target`. But if `at/name` already exists and is a directory or a symlink to some other directory, then this command will create a symlink at `at/name/target` pointing to `path/to/target`. There is an ambiguity between 1st and 3rd form of `ln` (please refer to `man ln` for the available invocation forms). It can be disambiguated by using the `-T` flag to force the 1st form.

In our case, if `/etc/portage/patches` symlink already existed and was pointing to `<coreos-overlay>/coreos/user-patches`, we ended up with a useless symlink at `<coreos-overlay>/coreos/user-patches/user-patches` pointing to `<coreos-overlay>/coreos/user-patches`.


Nothing was really broken, just a useless and harmless symlink was created.

Will backport it to flatcar-3493.