### PR TITLE
ci-automation: Get two files to build vms instead of a whole directory

### DIFF
--- a/ci-automation/vms.sh
+++ b/ci-automation/vms.sh
@@ -109,7 +109,8 @@ function _vm_build_impl() {
 
     local images_in="images-in/"
     rm -rf "${images_in}"
-    copy_dir_from_buildcache "images/${arch}/${vernum}/" "${images_in}"
+    copy_from_buildcache "images/${arch}/${vernum}/flatcar_production_image.bin.bz2" "${images_in}"
+    copy_from_buildcache "images/${arch}/${vernum}/version.txt" "${images_in}"
     lbunzip2 "${images_in}/flatcar_production_image.bin.bz2"
     ./run_sdk_container -x ./ci-cleanup.sh -n "${vms_container}" -C "${packages_image}" \
             -v "${vernum}" \


### PR DESCRIPTION
Getting the contents of the directory in the buildcache involves using rsync with some ssh invocation to log in as a bincache user. It's not a thing that will work locally unless the user gets ahold of the SSH key allowing the user to log in to buildcache as a bincache user.

Replace it by downloading two files that are actually needed for building vms: an image file and the version file. This just uses curl and is accessible for everyone.

CI: http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/1239/cldsv

Will backport it to other channels.