### PR TITLE
ci-automation: Allow git to work on directory owned by other user

### DIFF
--- a/ci-automation/release.sh
+++ b/ci-automation/release.sh
@@ -208,7 +208,7 @@ function _release_build_impl() {
 
     touch sdk_container/.env # This file should already contain the required credentials as env vars
     docker run --pull always --rm --name="${container_name}" --net host \
-      -w /work -v "$PWD":/work "${mantle_ref}" bash -c "source ci-automation/release.sh; _inside_mantle"
+      -w /work -v "$PWD":/work "${mantle_ref}" bash -c "git config --global --add safe.directory /work && source ci-automation/release.sh && _inside_mantle"
     # Push flatcar_production_ami_*txt and flatcar_production_ami_*json to the right bincache folder
     for arch in amd64 arm64; do
       sudo chown -R "$USER:$USER" "aws-${arch}"

--- a/ci-automation/test.sh
+++ b/ci-automation/test.sh
@@ -186,7 +186,7 @@ function _test_run_impl() {
         touch sdk_container/.env
         docker run --pull always --rm --name="${container_name}" --privileged --net host -v /dev:/dev \
           -w /work -v "$PWD":/work "${mantle_ref}" \
-         bash -c "set -o noglob && source sdk_container/.env && ci-automation/vendor-testing/${image}.sh \
+         bash -c "set -o noglob && git config --global --add safe.directory /work && source sdk_container/.env && ci-automation/vendor-testing/${image}.sh \
                 \"${work_dir}\" \
                 \"${tests_dir}\" \
                 \"${arch}\" \
@@ -196,6 +196,7 @@ function _test_run_impl() {
         set -e
         rm -f "${work_dir}/first_run"
 
+        # Note: git safe.directory is not set in this run as it does not use git
         docker run --pull always --rm --name="${container_name}" --privileged --net host -v /dev:/dev \
           -w /work -v "$PWD":/work "${mantle_ref}" \
             ci-automation/test_update_reruns.sh \


### PR DESCRIPTION
The get_git_channel function failed to work which resulted in the Alpha release job skipping the AWS publishing for the Alpha channel because it defaulted to the developer channel as fallback when git rejected to work on the directory owned by the build user while running as root user. A new version of git caused this behavior change and also prints an error message that explains to have to set safe.directory.

Set the git config entry safe.directory for the /work path when entering the mantle container where git runs as root while working on the directory owned by the build user.


## How to use

Either test it by creating a new Alpha release tag that has this change and then rerun the release job from that git tag, or merge, cherry-pick the change, and retag Alpha and rerun the release job from that git tag.

## Testing done

None
