### PR TITLE
Make emerge and catalyst verbose by default

### DIFF
--- a/bootstrap_sdk
+++ b/bootstrap_sdk
@@ -185,6 +185,7 @@ build_stage1() {
     # take the "portage directory" (portage-stable copy) snapshot
     catalyst \
         "${DEBUG[@]}" \
+        --verbose \
         --config "$TEMPDIR/catalyst-stage1.conf" \
         --snapshot "$FLAGS_version-stage1"
 

--- a/bootstrap_sdk
+++ b/bootstrap_sdk
@@ -183,7 +183,10 @@ build_stage1() {
     sed -i "s:^portdir.*:portdir=\"$stage1_repos/gentoo\":" \
          "$TEMPDIR/catalyst-stage1.conf"
     # take the "portage directory" (portage-stable copy) snapshot
-    catalyst $DEBUG -c "$TEMPDIR/catalyst-stage1.conf" -s "$FLAGS_version-stage1"
+    catalyst \
+        "${DEBUG[@]}" \
+        --config "$TEMPDIR/catalyst-stage1.conf" \
+        --snapshot "$FLAGS_version-stage1"
 
     # Update the stage 1 spec to use the "known-good" portage-stable snapshot
     #  and coreos-overlay copy repository versions from above.

--- a/build_library/build_image_util.sh
+++ b/build_library/build_image_util.sh
@@ -181,7 +181,7 @@ emerge_to_image() {
   sudo -E ROOT="${root_fs_dir}" \
       FEATURES="-ebuild-locks" \
       PORTAGE_CONFIGROOT="${BUILD_DIR}"/configroot \
-      emerge --root-deps=rdeps --usepkgonly --jobs="${NUM_JOBS}" -v "$@"
+      emerge --root-deps=rdeps --usepkgonly --jobs="${NUM_JOBS}" --verbose "$@"
 
   # Shortcut if this was just baselayout
   [[ "$*" == *sys-apps/baselayout ]] && return
@@ -206,7 +206,7 @@ emerge_to_image_unchecked() {
 
   sudo -E ROOT="${root_fs_dir}" \
       PORTAGE_CONFIGROOT="${BUILD_DIR}"/configroot \
-      emerge --root-deps=rdeps --usepkgonly --jobs="${NUM_JOBS}" -v "$@"
+      emerge --root-deps=rdeps --usepkgonly --jobs="${NUM_JOBS}" --verbose "$@"
 
   # Shortcut if this was just baselayout
   [[ "$*" == *sys-apps/baselayout ]] && return

--- a/build_library/catalyst.sh
+++ b/build_library/catalyst.sh
@@ -19,7 +19,7 @@
 
 # Values set in catalyst_init, don't use till after calling it
 CATALYST_ROOT=
-DEBUG=
+DEBUG=()
 BUILDS=
 BINPKGS=
 DISTDIR=
@@ -178,9 +178,9 @@ catalyst_init() {
         die_notrace "catalyst not found, not installed or bad PATH?"
     fi
 
-    DEBUG=
+    DEBUG=()
     if [[ ${FLAGS_debug} -eq ${FLAGS_TRUE} ]]; then
-        DEBUG="--debug --verbose"
+        DEBUG=( --debug --verbose )
     fi
 
     # Create output dir, expand path for easy comparison later
@@ -262,10 +262,11 @@ build_stage() {
     fi
 
     info "Starting $stage"
-    catalyst $DEBUG \
-        -c "$TEMPDIR/catalyst.conf" \
-        -f "$TEMPDIR/${stage}.spec" \
-        -C "source_subpath=$srcpath"
+    catalyst \
+        "${DEBUG[@]}" \
+        --config "$TEMPDIR/catalyst.conf" \
+        --file "$TEMPDIR/${stage}.spec" \
+        --cli "source_subpath=$srcpath"
     # Catalyst doesn't clean up after itself...
     rm -rf "$TEMPDIR/$stage-${ARCH}-${FLAGS_version}"
     ln -sf "$stage-${ARCH}-${FLAGS_version}.tar.bz2" \
@@ -281,7 +282,10 @@ build_snapshot() {
         info "Skipping snapshot, ${snapshot_path} exists"
     else
         info "Creating snapshot ${snapshot_path}"
-        catalyst $DEBUG -c "$TEMPDIR/catalyst.conf" -s "$FLAGS_version"
+        catalyst \
+            "${DEBUG[@]}" \
+            --config "$TEMPDIR/catalyst.conf" \
+            --snapshot "$FLAGS_version"
     fi
 }
 

--- a/build_library/catalyst.sh
+++ b/build_library/catalyst.sh
@@ -74,7 +74,7 @@ local load=$((NUM_JOBS * 2))
 cat <<EOF
 export TERM='${TERM}'
 export MAKEOPTS='--jobs=${NUM_JOBS} --load-average=${load}'
-export EMERGE_DEFAULT_OPTS="\$MAKEOPTS"
+export EMERGE_DEFAULT_OPTS="--verbose \$MAKEOPTS"
 export PORTAGE_USERNAME=portage
 export PORTAGE_GRPNAME=portage
 export GENTOO_MIRRORS='$(portageq envvar GENTOO_MIRRORS)'
@@ -180,7 +180,7 @@ catalyst_init() {
 
     DEBUG=()
     if [[ ${FLAGS_debug} -eq ${FLAGS_TRUE} ]]; then
-        DEBUG=( --debug --verbose )
+        DEBUG=("--debug")
     fi
 
     # Create output dir, expand path for easy comparison later
@@ -264,6 +264,7 @@ build_stage() {
     info "Starting $stage"
     catalyst \
         "${DEBUG[@]}" \
+        --verbose \
         --config "$TEMPDIR/catalyst.conf" \
         --file "$TEMPDIR/${stage}.spec" \
         --cli "source_subpath=$srcpath"
@@ -284,6 +285,7 @@ build_snapshot() {
         info "Creating snapshot ${snapshot_path}"
         catalyst \
             "${DEBUG[@]}" \
+            --verbose \
             --config "$TEMPDIR/catalyst.conf" \
             --snapshot "$FLAGS_version"
     fi

--- a/build_library/catalyst.sh
+++ b/build_library/catalyst.sh
@@ -174,7 +174,7 @@ catalyst_init() {
         die_notrace "This script must be run as root."
     fi
 
-    if ! which catalyst &>/dev/null; then
+    if ! command -v catalyst >/dev/null 2>&1; then
         die_notrace "catalyst not found, not installed or bad PATH?"
     fi
 

--- a/build_library/grub_install.sh
+++ b/build_library/grub_install.sh
@@ -77,7 +77,7 @@ esac
 if [[ $BOARD_GRUB -eq 1 ]]; then
     info "Updating GRUB in ${BOARD_ROOT}"
     emerge-${BOARD} \
-           --nodeps --select --quiet --update --getbinpkg --usepkgonly --newuse \
+           --nodeps --select --verbose --update --getbinpkg --usepkgonly --newuse \
            sys-boot/grub
     GRUB_SRC="${BOARD_ROOT}/usr/lib/grub/${FLAGS_target}"
 fi

--- a/build_library/grub_install.sh
+++ b/build_library/grub_install.sh
@@ -76,7 +76,9 @@ esac
 
 if [[ $BOARD_GRUB -eq 1 ]]; then
     info "Updating GRUB in ${BOARD_ROOT}"
-    emerge-${BOARD} --nodeps --select -qugKN sys-boot/grub
+    emerge-${BOARD} \
+           --nodeps --select --quiet --update --getbinpkg --usepkgonly --newuse \
+           sys-boot/grub
     GRUB_SRC="${BOARD_ROOT}/usr/lib/grub/${FLAGS_target}"
 fi
 [[ -d "${GRUB_SRC}" ]] || die "GRUB not installed at ${GRUB_SRC}"

--- a/build_library/prod_image_util.sh
+++ b/build_library/prod_image_util.sh
@@ -18,7 +18,7 @@ get_binary_pkg() {
 
     # Nothing? Maybe we can fetch it.
     if [[ -z "${version}" && ${FLAGS_getbinpkg} -eq ${FLAGS_TRUE} ]]; then
-        emerge-${BOARD} --getbinpkg --usepkgonly --fetchonly --nodeps "${name}" >&2
+        emerge-${BOARD} --verbose --getbinpkg --usepkgonly --fetchonly --nodeps "${name}" >&2
         version=$(pkg_version binary "${name}")
     fi
 

--- a/build_library/test_oem_pkgs
+++ b/build_library/test_oem_pkgs
@@ -37,6 +37,6 @@ for oem in "${VALID_OEM_PACKAGES[@]/#/oem-}"; do
   for use in "${uses[@]}"; do
     info "Checking ${oem}${use:+[${use}]}"
     USE="${use}" emerge-${BOARD} --usepkg --getbinpkg \
-        --emptytree --pretend --quiet "coreos-base/${oem}"
+        --emptytree --pretend --verbose "coreos-base/${oem}"
   done
 done

--- a/build_library/update_chroot_util.sh
+++ b/build_library/update_chroot_util.sh
@@ -55,7 +55,7 @@ remove_hard_blocks() {
     done
     if [[ ${#pkgs_to_drop[@]} -gt 0 ]]; then
         info "Dropping the following packages to avoid hard blocks: ${pkgs_to_drop[@]}"
-        "${emerge_cmd}" -C "${pkgs_to_drop[@]}"
+        "${emerge_cmd}" --unmerge "${pkgs_to_drop[@]}"
     else
         info "No hard blockers to remove"
     fi

--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -471,7 +471,7 @@ install_oem_package() {
     info "Building ${oem_pkg}"
     USE="${oem_use}" emerge-${BOARD} \
         --nodeps --buildpkgonly --usepkg n \
-        --quiet "${oem_pkg}"
+        --verbose "${oem_pkg}"
 
     local getbinpkg
     if [[ ${FLAGS_getbinpkg} -eq ${FLAGS_TRUE} ]]; then
@@ -482,7 +482,7 @@ install_oem_package() {
     USE="${oem_use}" emerge-${BOARD} \
         --root="${oem_tmp}" --sysroot="${oem_tmp}" \
         --root-deps=rdeps --usepkgonly ${getbinpkg} \
-        --quiet --jobs=2 "${oem_pkg}"
+        --verbose --jobs=2 "${oem_pkg}"
     sudo rsync -a "${oem_tmp}/usr/share/oem/" "${VM_TMP_ROOT}/usr/share/oem/"
     sudo rm -rf "${oem_tmp}"
 }
@@ -734,7 +734,7 @@ _write_qemu_uefi_conf() {
         arm64-usr)
             # Get edk2 files into local build workspace.
             info "Updating edk2 in /build/${BOARD}"
-            emerge-${BOARD} --nodeps --select --quiet --update --getbinpkg --newuse sys-firmware/edk2-aarch64
+            emerge-${BOARD} --nodeps --select --verbose --update --getbinpkg --newuse sys-firmware/edk2-aarch64
             # Create 64MiB flash device image files.
             dd if=/dev/zero bs=1M count=64 of="$(_dst_dir)/${flash_rw}" \
                 status=none

--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -734,7 +734,7 @@ _write_qemu_uefi_conf() {
         arm64-usr)
             # Get edk2 files into local build workspace.
             info "Updating edk2 in /build/${BOARD}"
-            emerge-${BOARD} --nodeps --select -qugN sys-firmware/edk2-aarch64
+            emerge-${BOARD} --nodeps --select --quiet --update --getbinpkg --newuse sys-firmware/edk2-aarch64
             # Create 64MiB flash device image files.
             dd if=/dev/zero bs=1M count=64 of="$(_dst_dir)/${flash_rw}" \
                 status=none

--- a/build_packages
+++ b/build_packages
@@ -131,7 +131,7 @@ fi
 
 # Setup all the emerge command/flags.
 EMERGE_FLAGS=( --update --deep --newuse --verbose --backtrack=30 --select )
-REBUILD_FLAGS=()
+REBUILD_FLAGS=( --verbose )
 EMERGE_CMD=( "emerge-${FLAGS_board}" )
 if [[ "${FLAGS_fetchonly}" -eq "${FLAGS_TRUE}" ]]; then
   EMERGE_CMD+=( --fetchonly )
@@ -285,7 +285,7 @@ info "Merging board packages now"
 sudo -E "${EMERGE_CMD[@]}" "${EMERGE_FLAGS[@]}" "$@"
 
 info "Removing obsolete packages"
-sudo -E "${EMERGE_CMD[@]}" --quiet --depclean @unavailable
+sudo -E "${EMERGE_CMD[@]}" --verbose --depclean @unavailable
 
 if [[ "${FLAGS_usepkgonly}" -eq "${FLAGS_FALSE}" ]]; then
   if "portageq-${BOARD}" list_preserved_libs "${BOARD_ROOT}" >/dev/null; then

--- a/build_packages
+++ b/build_packages
@@ -130,7 +130,7 @@ fi
 . "${BUILD_LIBRARY_DIR}/test_image_content.sh" || exit 1
 
 # Setup all the emerge command/flags.
-EMERGE_FLAGS=( -uDNv --backtrack=30 --select )
+EMERGE_FLAGS=( --update --deep --newuse --verbose --backtrack=30 --select )
 REBUILD_FLAGS=()
 EMERGE_CMD=( "emerge-${FLAGS_board}" )
 if [[ "${FLAGS_fetchonly}" -eq "${FLAGS_TRUE}" ]]; then

--- a/build_torcx_store
+++ b/build_torcx_store
@@ -80,7 +80,7 @@ function torcx_build() (
             --buildpkgonly \
             --nodeps \
             --oneshot \
-            --quiet \
+            --verbose \
             --root-deps=rdeps \
             "${pkgs[@]}"
 
@@ -89,7 +89,7 @@ function torcx_build() (
             --jobs="${NUM_JOBS}" \
             --nodeps \
             --oneshot \
-            --quiet \
+            --verbose \
             --root="${tmproot}" \
             --root-deps=rdeps \
             --sysroot="${tmproot}" \

--- a/rebuild_packages
+++ b/rebuild_packages
@@ -74,7 +74,7 @@ if [[ "${#rebuild_atoms[@]}" -eq 0 ]]; then
     info "No ebuild changes detected"
 else
     info "Rebuilding ${#rebuild_atoms[@]} packages..."
-    emerge-$BOARD "--jobs=${NUM_JOBS}" "${rebuild_atoms[@]}"
+    emerge-$BOARD --verbose "--jobs=${NUM_JOBS}" "${rebuild_atoms[@]}"
 
     info "Checking build root"
     test_image_content "${BOARD_ROOT}"

--- a/set_official
+++ b/set_official
@@ -34,4 +34,4 @@ else
     sudo rm -f "${BOARD_ROOT}/etc/portage/package.use/official"
 fi
 
-emerge-${BOARD} -v --quiet-build=y --nospinner coreos-base/coreos-au-key
+emerge-${BOARD} --verbose --quiet-build=y --nospinner coreos-base/coreos-au-key

--- a/setup_board
+++ b/setup_board
@@ -297,23 +297,23 @@ ${EMAINT_WRAPPER} --fix moveinst
 ${EMAINT_WRAPPER} --fix world
 
 if [[ ${FLAGS_regen_configs} -eq ${FLAGS_FALSE} ]]; then
-  EMERGE_FLAGS="--select --quiet --root-deps=rdeps"
-  EMERGE_FLAGS+=" --jobs=${NUM_JOBS}"
-  EMERGE_TOOLCHAIN_FLAGS="${EMERGE_FLAGS}"
+  EMERGE_FLAGS=( --select --quiet --root-deps=rdeps )
+  EMERGE_FLAGS+=( "--jobs=${NUM_JOBS}" )
+  EMERGE_TOOLCHAIN_FLAGS=( "${EMERGE_FLAGS[@]}" )
 
   if [[ "${FLAGS_usepkg}" -eq "${FLAGS_TRUE}"  && \
         "${FLAGS_getbinpkg}" -eq "${FLAGS_TRUE}" ]]
   then
     if [[ "${FLAGS_usepkgonly}" -eq "${FLAGS_TRUE}" ]]; then
-      EMERGE_FLAGS+=" --usepkgonly --rebuilt-binaries n"
+      EMERGE_FLAGS+=( --usepkgonly --rebuilt-binaries n )
     else
-      EMERGE_FLAGS+=" --usepkg"
+      EMERGE_FLAGS+=( --usepkg )
     fi
-    EMERGE_FLAGS+=" --getbinpkg"
+    EMERGE_FLAGS+=( --getbinpkg )
   fi
 
   info "Installing baselayout"
-  "${EMERGE_WRAPPER}" ${EMERGE_FLAGS} --nodeps sys-apps/baselayout
+  "${EMERGE_WRAPPER}" "${EMERGE_FLAGS[@]}" --nodeps sys-apps/baselayout
 
   if [[ "${FLAGS_usepkg}" -ne "${FLAGS_TRUE}" ||
         "${FLAGS_getbinpkg}" -ne "${FLAGS_TRUE}" ]]
@@ -321,22 +321,22 @@ if [[ ${FLAGS_regen_configs} -eq ${FLAGS_FALSE} ]]; then
     # When binary packages are disabled we need to make sure the cross
     # sysroot includes any build dependencies for the toolchain.
     info "Installing toolchain build dependencies"
-    install_cross_libs "${BOARD_CHOST}" ${EMERGE_FLAGS} --buildpkg=n
+    install_cross_libs "${BOARD_CHOST}" "${EMERGE_FLAGS[@]}" --buildpkg=n
 
     info "Building toolchain dependencies"
     "${EMERGE_WRAPPER}" --buildpkg --buildpkgonly \
         --root="/usr/${BOARD_CHOST}" --sysroot="/usr/${BOARD_CHOST}" \
-        ${EMERGE_TOOLCHAIN_FLAGS} $(< "/usr/${BOARD_CHOST}/etc/portage/cross-${BOARD_CHOST}-depends")
+        "${EMERGE_TOOLCHAIN_FLAGS[@]}" $(< "/usr/${BOARD_CHOST}/etc/portage/cross-${BOARD_CHOST}-depends")
     info "Building toolchain"
     "${EMERGE_WRAPPER}" --buildpkg --buildpkgonly \
         --root="/usr/${BOARD_CHOST}" --sysroot="/usr/${BOARD_CHOST}" \
-	${EMERGE_TOOLCHAIN_FLAGS} "${TOOLCHAIN_PKGS[@]}"
+	"${EMERGE_TOOLCHAIN_FLAGS[@]}" "${TOOLCHAIN_PKGS[@]}"
   fi
 
   info "Installing toolchain"
   "${EMERGE_WRAPPER}" \
       --usepkgonly --getbinpkg --rebuilt-binaries n \
-      ${EMERGE_TOOLCHAIN_FLAGS} "${TOOLCHAIN_PKGS[@]}"
+      "${EMERGE_TOOLCHAIN_FLAGS[@]}" "${TOOLCHAIN_PKGS[@]}"
 fi
 
 if [[ ${FLAGS_regen_configs_only} -eq ${FLAGS_FALSE} ]]; then

--- a/setup_board
+++ b/setup_board
@@ -269,7 +269,7 @@ PORTAGE_BINHOST="${BOARD_BINHOST}"
 
 # Generally there isn't any need to add packages to @world by default.
 # You can use --select to override this.
-EMERGE_DEFAULT_OPTS="--oneshot"
+EMERGE_DEFAULT_OPTS="--oneshot --verbose"
 
 # Enable provenance reporting by default. Produced files are in /usr/share/SLSA
 GENERATE_SLSA_PROVENANCE="true"
@@ -297,7 +297,7 @@ ${EMAINT_WRAPPER} --fix moveinst
 ${EMAINT_WRAPPER} --fix world
 
 if [[ ${FLAGS_regen_configs} -eq ${FLAGS_FALSE} ]]; then
-  EMERGE_FLAGS=( --select --quiet --root-deps=rdeps )
+  EMERGE_FLAGS=( --select --verbose --root-deps=rdeps )
   EMERGE_FLAGS+=( "--jobs=${NUM_JOBS}" )
   EMERGE_TOOLCHAIN_FLAGS=( "${EMERGE_FLAGS[@]}" )
 

--- a/update_chroot
+++ b/update_chroot
@@ -99,7 +99,7 @@ MAKEOPTS="--jobs=${NUM_JOBS} --load-average=$((NUM_JOBS * 2))"
 
 # Generally there isn't any need to add packages to @world by default.
 # You can use --select to override this.
-EMERGE_DEFAULT_OPTS="--oneshot"
+EMERGE_DEFAULT_OPTS="--verbose --oneshot"
 
 # Allow the user to override or define additional settings.
 source "/etc/portage/make.conf.user"
@@ -184,7 +184,7 @@ done
 "${BUILD_LIBRARY_DIR}/set_lsb_release" --root /
 
 EMERGE_FLAGS=( --update --newuse --verbose --with-bdeps=y --select )
-REBUILD_FLAGS=()
+REBUILD_FLAGS=( --verbose )
 if [ "${FLAGS_usepkg}" -eq "${FLAGS_TRUE}" ]; then
   EMERGE_FLAGS+=( --usepkg )
   if [[ "${FLAGS_usepkgonly}" -eq "${FLAGS_TRUE}" ]]; then
@@ -208,7 +208,7 @@ EMERGE_CMD="emerge"
 # In first pass, update portage and toolchains. Lagged updates of both
 # can cause serious issues later.
 info "Updating basic system packages"
-sudo -E ${EMERGE_CMD} --quiet "${EMERGE_FLAGS[@]}" \
+sudo -E ${EMERGE_CMD} "${EMERGE_FLAGS[@]}" \
     sys-apps/portage \
     sys-devel/crossdev \
     sys-devel/sysroot-wrappers \
@@ -230,7 +230,7 @@ if [[ "${FLAGS_skip_toolchain_update}" -eq "${FLAGS_FALSE}" && \
 
   for cross_chost in "${CROSS_CHOSTS[@]}"; do
     info "Updating cross ${cross_chost} toolchain"
-    install_cross_toolchain "${cross_chost}" --quiet "${EMERGE_FLAGS[@]}"
+    install_cross_toolchain "${cross_chost}" "${EMERGE_FLAGS[@]}"
   done
 fi
 
@@ -259,7 +259,7 @@ sudo -E ${EMERGE_CMD} "${EMERGE_FLAGS[@]}" \
     coreos-devel/sdk-depends world
 
 info "Removing obsolete packages"
-sudo -E ${EMERGE_CMD} --quiet --depclean @unavailable
+sudo -E ${EMERGE_CMD} --verbose --depclean @unavailable
 
 if portageq list_preserved_libs / >/dev/null; then
   info "Rebuilding packages linked against old libraries"

--- a/update_chroot
+++ b/update_chroot
@@ -183,7 +183,7 @@ done
 
 "${BUILD_LIBRARY_DIR}/set_lsb_release" --root /
 
-EMERGE_FLAGS=( -uNv --with-bdeps=y --select )
+EMERGE_FLAGS=( --update --newuse --verbose --with-bdeps=y --select )
 REBUILD_FLAGS=()
 if [ "${FLAGS_usepkg}" -eq "${FLAGS_TRUE}" ]; then
   EMERGE_FLAGS+=( --usepkg )


### PR DESCRIPTION
I'd like to see emerge to print the report about what's going to be done and the use flags being enabled/disabled.

There are also some cleanups:
- expand the flags for emerge and catalyst
  - even if the long flags for emerge are also quite cryptic, the short ones are still even more so
- changed variables that were used as unquoted strings to arrays

Needs https://github.com/flatcar/portage-stable/pull/416 to be merged first.

CI: http://jenkins.infra.kinvolk.io:8080/job/container/job/sdk/632/cldsv