### PR TITLE
bootstrap_sdk: Allow running hooks to modify stage1 repos

### DIFF
--- a/bootstrap_sdk
+++ b/bootstrap_sdk
@@ -158,6 +158,20 @@ stage_repo() {
             && git fetch --all \
             && git checkout "$gitref" )
     fi
+    (
+        set -euo pipefail
+        local repo_var hook name
+
+        # FLAGS_coreos_overlay for gitname coreos-overlay
+        repo_var="FLAGS_${gitname//-/_}"
+        shopt -s nullglob
+        for hook in "${FLAGS_coreos_overlay}/coreos/stage1_hooks/"*"-${gitname}.sh"; do
+            name=${hook##*/}
+            name=${name%"-${gitname}.sh"}
+            info "Invoking stage1 ${gitname} hook ${name} on ${dest}/${repo}"
+            "${hook}" "${dest}/${repo}" "${!repo_var}"
+        done
+    )
 }
 
 build_stage1() {


### PR DESCRIPTION
Sometimes the modification to stage1 repos is necessary. For example we will need to update baselayout package in stage1, so we get the cleaned up handling of PATH and ROOTPATH, which will allow a newer portage to succeed in calculating dependencies in stage2.

Needed by https://github.com/flatcar/coreos-overlay/pull/2490 and https://github.com/flatcar/portage-stable/pull/423.

CI: http://jenkins.infra.kinvolk.io:8080/job/container/job/sdk/680/console