### PR TITLE
export portage db, oem sysext utils, sysext for azure

### DIFF
--- a/build_library/disk_util
+++ b/build_library/disk_util
@@ -743,18 +743,29 @@ def Tune(options):
   config, partitions = LoadPartitionConfig(options)
   GetPartitionTableFromImage(options, config, partitions)
   part = GetPartition(partitions, options.partition)
+  action_done = False
 
   if not part['image_compat']:
     raise InvalidLayout("Disk layout is incompatible with existing image")
 
   if options.disable2fs_rw is not None:
+    action_done = True
     if part.get('fs_type', None) in ('ext2', 'ext4'):
       Tune2fsReadWrite(options, part, options.disable2fs_rw)
     elif part.get('fs_type', None) == 'btrfs':
       ReadWriteSubvol(options, part, options.disable2fs_rw)
     else:
       raise Exception("Partition %s is not a ext2 or ext4 or btrfs" % options.partition)
-  else:
+
+  if options.randomize_uuid is not None:
+    action_done = True
+    if part.get('fs_type', None) == 'btrfs':
+      with PartitionLoop(options, part) as loop_dev:
+        Sudo(['btrfstune', '-m', loop_dev])
+    else:
+      raise Exception("Partition %s is not btrfs" % options.partition)
+
+  if not action_done:
     raise Exception("No options specified!")
 
 
@@ -1059,6 +1070,8 @@ def main(argv):
           help='disable mounting ext2 filesystems read-write')
   a.add_argument('--enable2fs_rw', action='store_false', dest='disable2fs_rw',
           help='re-enable mounting ext2 filesystems read-write')
+  a.add_argument('--randomize_uuid', action='store_true', default=None,
+                 help='randomize btrfs UUIDs in the partition')
   a.add_argument('disk_image', help='path to disk image file')
   a.add_argument('partition', help='number or label of partition to edit')
   a.set_defaults(func=Tune)

--- a/build_library/oem_sysext_util.sh
+++ b/build_library/oem_sysext_util.sh
@@ -1,0 +1,201 @@
+#!/bin/bash
+#
+# Copyright (c) 2023 The Flatcar Maintainers.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+source "${BUILD_LIBRARY_DIR}/reports_util.sh" || exit 1
+
+_generate_listing() {
+    local rootfs="${1%/}"; shift
+    local listing="${1}"; shift
+
+    local slashes="${rootfs//[^\/]}"
+    local slash_count="${#slashes}"
+
+    # Invoking find with sudo as it's used for traversing root-owned
+    # rootfs, which means that some places may be unreachable by the
+    # sdk user.
+    sudo find "${rootfs}//" | cut -d/ -f$((slash_count + 2))- | sort >"${listing}"
+}
+
+_prepend_action () {
+    local -n prepend_array="${1}"; shift
+
+    prepend_array=( "${#}" "${@}" "${prepend_array[@]}" )
+}
+
+_invoke_actions () {
+    local arg_count
+    local command
+    while [[ "${#}" -gt 0 ]]; do
+        arg_count="${1}"
+        shift
+        command=( "${@:1:${arg_count}}" )
+        shift "${arg_count}"
+        "${command[@]}" || :
+    done
+}
+
+# Architecture values are taken from systemd.unit(5).
+declare -A SYSEXT_ARCHES
+SYSEXT_ARCHES['amd64-usr']='x86-64'
+SYSEXT_ARCHES['arm64-usr']='arm64'
+
+declare -r SYSEXT_ARCHES
+
+# Usage: _get_sysext_arch board [board...]
+_get_sysext_arch() {
+    local board
+    for board in "$@"; do
+        if [[ ${#SYSEXT_ARCHES["${board}"]} -ne 0 ]]; then
+            echo "${SYSEXT_ARCHES["${board}"]}"
+        else
+            die "Unknown board '${board}'"
+        fi
+    done
+}
+
+oem_sysext_create() {
+    local oem="${1}"; shift
+    local board="${1}"; shift
+    local version_id="${1}"; shift
+    local prod_image="${1}"; shift
+    local prod_pkgdb="${1}"; shift
+    local work_dir="${1}"; shift
+
+    local base_pkg="coreos-base/${oem}"
+    local sysext_work_dir="${work_dir}/sysext-${oem}"
+    local prod_rw_image="${sysext_work_dir}/prod_for_sysext.bin"
+    local prod_rw_rootfs="${sysext_work_dir}/prod_rw_rootfs"
+
+    local cleanup_actions=()
+    trap '_invoke_actions "${cleanup_actions[@]}"' EXIT
+
+    _prepend_action cleanup_actions rmdir "${sysext_work_dir}"
+    mkdir -p "${sysext_work_dir}"
+
+    info 'Creating a production image copy for work rootfs'
+    _prepend_action cleanup_actions rm -f "${prod_rw_image}"
+    cp --sparse=always "${prod_image}" "${prod_rw_image}"
+
+    info 'Preparing work image for mounting'
+    "${BUILD_LIBRARY_DIR}/disk_util" --disk_layout=base \
+        tune --randomize_uuid "${prod_rw_image}" OEM
+    "${BUILD_LIBRARY_DIR}/disk_util" --disk_layout=base \
+        tune --enable2fs_rw "${prod_rw_image}" USR-A
+
+    info "Mounting work image to ${prod_rw_rootfs}"
+    _prepend_action cleanup_actions rmdir "${prod_rw_rootfs}"
+    _prepend_action cleanup_actions "${BUILD_LIBRARY_DIR}/disk_util" --disk_layout=base \
+        umount "${prod_rw_rootfs}"
+    "${BUILD_LIBRARY_DIR}/disk_util" --disk_layout=base \
+        mount --writable_verity "${prod_rw_image}" "${prod_rw_rootfs}"
+
+    local initial_files="${sysext_work_dir}/initial_files"
+    info "Generating list of initial files in work image"
+    _prepend_action cleanup_actions rm -f "${initial_files}"
+    _generate_listing "${prod_rw_rootfs}" "${initial_files}"
+
+    info "Stuffing package database into into ${prod_rw_rootfs}"
+    sudo tar -xf "${prod_pkgdb}" -C "${prod_rw_rootfs}"
+
+    # Split into two steps because we want to always install
+    # $${base_pkg} from the ebuild (build_packages doesn't handle it)
+    # *but* we never want to build anything else from source
+    # here. emerge doesn't have a way to enforce this in a single
+    # command.
+    info "Building ${base_pkg}"
+    "emerge-${board}" --nodeps --buildpkgonly --usepkg n --verbose "${base_pkg}"
+
+    info "Installing ${base_pkg} to ${prod_rw_rootfs}"
+    sudo emerge \
+         --config-root="/build/${board}" \
+         --root="${prod_rw_rootfs}" \
+         --sysroot="${prod_rw_rootfs}" \
+         --root-deps=rdeps \
+         --usepkgonly \
+         --verbose \
+         "${base_pkg}"
+
+    info "Removing portage db from ${prod_rw_rootfs}"
+    sudo rm -rf \
+       "${prod_rw_rootfs}/var/cache/edb" \
+       "${prod_rw_rootfs}/var/db/pkg"
+
+    local all_files="${sysext_work_dir}/all_files"
+    local sysext_files="${sysext_work_dir}/sysext_files"
+
+    info "Generating list of files in work image after installing OEM package"
+    _prepend_action cleanup_actions rm -f "${all_files}"
+    _generate_listing "${prod_rw_rootfs}" "${all_files}"
+
+    info "Generating list of files for sysext image"
+    _prepend_action cleanup_actions rm -f "${sysext_files}"
+    comm -1 -3 "${initial_files}" "${all_files}" >"${sysext_files}"
+
+    info "Copying files for sysext image"
+    local sysext_rootfs="${sysext_work_dir}/sysext_rootfs"
+    _prepend_action cleanup_actions rm -rf "${sysext_rootfs}"
+    rsync --links --files-from="${sysext_files}" "${prod_rw_rootfs}" "${sysext_rootfs}"
+
+    info "Mangling files for sysext image"
+    local overlay_path mangle_fs
+    overlay_path=$(portageq get_repo_path / coreos)
+    mangle_fs="${overlay_path}/${base_pkg}/files/manglefs.sh"
+    if [[ -x "${mangle_fs}" ]]; then
+        "${mangle_fs}" "${sysext_rootfs}"
+    fi
+
+    local entry
+    info "Removing non-/usr directories from sysext image"
+    for entry in "${sysext_rootfs}"/*; do
+        if [[ "${entry}" = */usr ]]; then
+            continue
+        fi
+        info "  Removing ${entry##*/}"
+        rm -rf "${entry}"
+    done
+
+    local metadata metadata_file
+    info "Adding sysext metadata"
+    mkdir -p "${sysext_rootfs}/usr/lib/extension-release.d"
+    metadata=(
+        'ID=flatcar'
+        "VERSION_ID=${version_id}"
+        "ARCHITECTURE=$(_get_sysext_arch "${board}")"
+    )
+    metadata_file="${sysext_rootfs}/usr/lib/extension-release.d/extension-release.${oem}"
+    printf '%s\n' "${metadata[@]}" >"${metadata_file}"
+
+    info "Generating a squashfs image"
+    local sysext_raw_image_filename="${oem}.raw"
+    local output_raw_image="${sysext_work_dir}/${sysext_raw_image_filename}"
+    _prepend_action cleanup_actions rm -f "${output_raw_image}"
+    mksquashfs "${sysext_rootfs}" "${output_raw_image}" -all-root
+
+    info "Generating image reports"
+    local sysext_mounted="${sysext_work_dir}/squashfs_mounted"
+    _prepend_action cleanup_actions rmdir "${sysext_mounted}"
+    mkdir "${sysext_mounted}"
+    _prepend_action cleanup_actions sudo umount "${sysext_mounted}"
+    sudo mount -t squashfs -o loop "${output_raw_image}" "${sysext_mounted}"
+    local contents="${sysext_raw_image_filename%.raw}_contents.txt"
+    local contents_wtd="${sysext_raw_image_filename%.raw}_contents_wtd.txt"
+    local disk_usage="${sysext_raw_image_filename%.raw}_disk_usage.txt"
+    _prepend_action cleanup_actions rm -f "${sysext_work_dir}/${contents}"
+    write_contents "${sysext_mounted}" "${sysext_work_dir}/${contents}"
+    _prepend_action cleanup_actions rm -f "${sysext_work_dir}/${contents_wtd}"
+    write_contents_with_technical_details "${sysext_mounted}" "${sysext_work_dir}/${contents_wtd}"
+    _prepend_action cleanup_actions rm -f "${sysext_work_dir}/${disk_usage}"
+    write_disk_space_usage_in_paths "${sysext_mounted}" "${sysext_work_dir}/${disk_usage}"
+
+    local to_move
+    for to_move in "${sysext_raw_image_filename}" "${contents}" "${contents_wtd}" "${disk_usage}"; do
+        mv "${sysext_work_dir}/${to_move}" "${work_dir}/${to_move}"
+    done
+
+    info "Alles jut, cleaning up"
+    trap - EXIT
+    _invoke_actions "${cleanup_actions[@]}"
+}

--- a/build_library/prod_image_util.sh
+++ b/build_library/prod_image_util.sh
@@ -77,6 +77,7 @@ create_prod_image() {
   local image_initrd_contents="${image_name%.bin}_initrd_contents.txt"
   local image_initrd_contents_wtd="${image_name%.bin}_initrd_contents_wtd.txt"
   local image_disk_usage="${image_name%.bin}_disk_usage.txt"
+  local image_pkgdb="${image_name%.bin}_pkgdb.tar.xz"
 
   start_image "${image_name}" "${disk_layout}" "${root_fs_dir}" "${update_group}"
 
@@ -99,6 +100,8 @@ create_prod_image() {
           "${root_fs_dir}"/var/db/pkg/coreos-base/coreos-au-key-*/USE \
           || die_notrace "coreos-au-key is missing the 'official' use flag"
   fi
+
+  tar -cf "${BUILD_DIR}/${image_pkgdb}" -C "${root_fs_dir}" var/cache/edb var/db/pkg
 
   # clean-ups of things we do not need
   sudo rm ${root_fs_dir}/etc/csh.env

--- a/build_library/reports_util.sh
+++ b/build_library/reports_util.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+#
+# Copyright (c) 2023 The Flatcar Maintainers.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+if [[ -n "${FLATCAR_REPORTS_UTIL_SH_INCLUDED:-}" ]]; then
+    return 0
+fi
+
+FLATCAR_REPORTS_UTIL_SH_INCLUDED=1
+
+# Generate a ls-like listing of a directory tree.
+# The ugly printf is used to predictable time format and size in bytes.
+#
+# Usage:
+#  write_contents "${rootfs}" ${contents_file}"
+write_contents() {
+    local rootfs="${1}"; shift
+    local output="${1}"; shift
+    info "Writing ${output##*/}"
+    # Ensure output is an absolute path before we change the working
+    # directory.
+    output=$(realpath "${output}")
+    pushd "${rootfs}" >/dev/null
+    # %M - file permissions
+    # %n - number of hard links to file
+    # %u - file's user name
+    # %g - file's group name
+    # %s - size in bytes
+    # %Tx - modification time (Y - year, m - month, d - day, H - hours, M - minutes)
+    # %P - file's path
+    # %l - symlink target (empty if not a symlink)
+    sudo TZ=UTC find -printf \
+        '%M %2n %-7u %-7g %7s %TY-%Tm-%Td %TH:%TM ./%P -> %l\n' \
+        | sed -e 's/ -> $//' >"${output}"
+    popd >/dev/null
+}
+
+# Generate a listing that can be used by other tools to analyze
+# image/file size changes.
+#
+# Usage:
+#  write_contents_with_technical_details "${rootfs}" ${output_file}"
+write_contents_with_technical_details() {
+    local rootfs="${1}"; shift
+    local output="${1}"; shift
+    info "Writing ${output##*/}"
+    # Ensure output is an absolute path before we change the working
+    # directory.
+    output=$(realpath "${output}")
+    pushd "${rootfs}" >/dev/null
+    # %M - file permissions
+    # %D - ID of a device where file resides
+    # %i - inode number
+    # %n - number of hard links to file
+    # %s - size in bytes
+    # %P - file's path
+    sudo find -printf \
+        '%M %D %i %n %s ./%P\n' >"${output}"
+    popd >/dev/null
+}
+
+# Generate a report like the following if more than one relative path
+# in rootfs was passed:
+#
+# File    Size  Used Avail Use% Type
+# /boot   127M   62M   65M  50% vfat
+# /usr    983M  721M  212M  78% ext2
+# /       6,0G   13M  5,6G   1% ext4
+# SUM     7,0G  796M  5,9G  12% -
+#
+# or, in case of 0 or 1 relative path:
+#
+# File  Size  Used Avail Use% Type
+# /      27M   27M     0 100% squashfs
+#
+# Usage:
+#  write_disk_space_usage_in_paths "${rootfs}" "${output_file}" ./boot ./usr ./
+write_disk_space_usage_in_paths() {
+    local rootfs="${1}"; shift
+    local output="${1}"; shift
+    info "Writing ${output##*/}"
+    # Ensure output is an absolute path before we change the working
+    # directory.
+    output=$(realpath "${output}")
+    pushd "${rootfs}" >/dev/null
+    local extra_flags
+    extra_flags=()
+    if [[ ${#} -eq 0 ]]; then
+        set -- ./
+    fi
+    if [[ ${#} -gt 1 ]]; then
+        extra_flags+=('--total')
+    fi
+    # The sed's first command turns './<path>' into '/<path> ', second
+    # command replaces '- ' with 'SUM' for the total row. All this to
+    # keep the numbers neatly aligned in columns.
+    sudo df \
+         --human-readable \
+         "${extra_flags[@]}" \
+         --output='file,size,used,avail,pcent,fstype' \
+         "${@}" | \
+        sed \
+            -e 's#^\.\(/[^ ]*\)#\1 #' \
+            -e 's/^-  /SUM/' >"${output}"
+    popd >/dev/null
+}
+
+# Generate a report like the following:
+#
+# File    Size  Used Avail Use% Type
+# /boot   127M   62M   65M  50% vfat
+# /usr    983M  721M  212M  78% ext2
+# /       6,0G   13M  5,6G   1% ext4
+# SUM     7,0G  796M  5,9G  12% -
+write_disk_space_usage() {
+    write_disk_space_usage_in_paths "${1}" "${2}" ./boot ./usr ./
+}

--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -71,6 +71,7 @@ VM_IMG_TYPE=DEFAULT
 
 # Set at runtime to the source and destination image paths
 VM_SRC_IMG=
+VM_SRC_PKGDB=
 VM_TMP_IMG=
 VM_TMP_DIR=
 VM_TMP_ROOT=
@@ -97,6 +98,12 @@ IMG_DEFAULT_OEM_USE=
 
 # Forced USE flags for the OEM package
 IMG_FORCE_OEM_USE=
+
+# If set install the given package name to the OEM sysext image
+IMG_DEFAULT_OEM_SYSEXT=
+
+# Forced OEM package name overriding what may be in the format
+IMG_FORCE_OEM_SYSEXT=
 
 # Hook to do any final tweaks or grab data while fs is mounted.
 IMG_DEFAULT_FS_HOOK=
@@ -345,13 +352,18 @@ set_vm_oem_pkg() {
 
 # Validate and set source vm image path
 set_vm_paths() {
-    local src_dir="$1"
-    local dst_dir="$2"
-    local src_name="$3"
+    local src_dir="${1}"; shift
+    local dst_dir="${1}"; shift
+    local src_name="${1}"; shift
+    local pkgdb_name="${1}"; shift
 
     VM_SRC_IMG="${src_dir}/${src_name}"
     if [[ ! -f "${VM_SRC_IMG}" ]]; then
-        die "Source image does not exist: $VM_SRC_IMG"
+        die "Source image does not exist: ${VM_SRC_IMG}"
+    fi
+    VM_SRC_PKGDB="${src_dir}/${pkgdb_name}"
+    if [[ ! -f "${VM_SRC_PKGDB}" ]]; then
+        die "Source package database does not exist: ${VM_SRC_PKGDB}"
     fi
 
     local dst_name="$(_src_to_dst_name "${src_name}" "_image.$(_disk_ext)")"
@@ -515,6 +527,50 @@ install_oem_aci() {
     die "Could not install ${oem_aci} OEM ACI"
     # Remove aci_dir if building ACI and installing it succeeded
     rm -rf "${aci_dir}"
+}
+
+# Write the OEM sysext file into the OEM partition.
+install_oem_sysext() {
+    local oem_sysext=$(_get_vm_opt OEM_SYSEXT)
+
+    if [[ -z "${oem_sysext}" ]]; then
+        return 0
+    fi
+
+    local built_sysext_dir="${FLAGS_to}/${oem_sysext}-sysext"
+    local built_sysext_filename="${oem_sysext}.raw"
+    local built_sysext_path="${built_sysext_dir}/${built_sysext_filename}"
+
+    "${SCRIPT_ROOT}/build_oem_sysext" \
+        --board="${BOARD}" \
+        --build_dir="${built_sysext_dir}" \
+        --prod_image_path="${VM_SRC_IMG}" \
+        --prod_pkgdb_path="${VM_SRC_PKGDB}" \
+        "${oem_sysext}"
+
+    local installed_sysext_oem_dir='/usr/share/oem/sysext'
+    local installed_sysext_file_prefix="${oem_sysext}-${FLATCAR_VERSION}"
+    local installed_sysext_filename="${installed_sysext_file_prefix}.raw"
+    local installed_sysext_abspath="${installed_sysext_oem_dir}/${installed_sysext_filename}"
+    info "Installing ${oem_sysext} sysext"
+    sudo install -Dpm 0644 \
+         "${built_sysext_path}" \
+         "${VM_TMP_ROOT}${installed_sysext_abspath}" ||
+        die "Could not install ${oem_sysext} sysext"
+    # Move sysext image and reports to a destination directory to
+    # upload them, thus making them available as separate artifacts to
+    # download.
+    local upload_dir to_move
+    upload_dir="$(_dst_dir)"
+    for to_move in "${built_sysext_dir}/${oem_sysext}"*; do
+        mv "${to_move}" "${upload_dir}/${to_move##*/}"
+    done
+    # Remove sysext_dir if building sysext and installing it
+    # succeeded.
+    rm -rf "${built_sysext_dir}"
+
+    # Mark the installed sysext as active.
+    sudo touch "${VM_TMP_ROOT}${installed_sysext_oem_dir}/active-${oem_sysext}"
 }
 
 # Any other tweaks required?

--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -279,7 +279,9 @@ IMG_exoscale_OEM_PACKAGE=oem-exoscale
 ## azure
 IMG_azure_DISK_FORMAT=vhd_fixed
 IMG_azure_DISK_LAYOUT=azure
-IMG_azure_OEM_PACKAGE=oem-azure
+IMG_azure_OEM_USE=azure
+IMG_azure_OEM_PACKAGE=common-oem-files
+IMG_azure_OEM_SYSEXT=oem-azure
 
 ## hyper-v
 IMG_hyperv_DISK_FORMAT=vhd

--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -131,17 +131,23 @@ IMG_DEFAULT_CPUS=2
 IMG_qemu_DISK_FORMAT=qcow2
 IMG_qemu_DISK_LAYOUT=vm
 IMG_qemu_CONF_FORMAT=qemu
-IMG_qemu_OEM_PACKAGE=oem-qemu
+IMG_qemu_OEM_USE=qemu
+IMG_qemu_OEM_PACKAGE=common-oem-files
+IMG_qemu_OEM_SYSEXT=oem-qemu
 
 IMG_qemu_uefi_DISK_FORMAT=qcow2
 IMG_qemu_uefi_DISK_LAYOUT=vm
 IMG_qemu_uefi_CONF_FORMAT=qemu_uefi
-IMG_qemu_uefi_OEM_PACKAGE=oem-qemu
+IMG_qemu_uefi_USE=qemu
+IMG_qemu_uefi_OEM_PACKAGE=common-oem-files
+IMG_qemu_uefi_OEM_SYSEXT=oem-qemu
 
 IMG_qemu_uefi_secure_DISK_FORMAT=qcow2
 IMG_qemu_uefi_secure_DISK_LAYOUT=vm
 IMG_qemu_uefi_secure_CONF_FORMAT=qemu_uefi_secure
-IMG_qemu_uefi_secure_OEM_PACKAGE=oem-qemu
+IMG_qemu_uefi_secure_USE=qemu
+IMG_qemu_uefi_secure_OEM_PACKAGE=common-oem-files
+IMG_qemu_uefi_secure_OEM_SYSEXT=oem-qemu
 
 ## xen
 IMG_xen_CONF_FORMAT=xl

--- a/build_oem_sysext
+++ b/build_oem_sysext
@@ -1,0 +1,77 @@
+#!/bin/bash
+#
+# Copyright (c) 2023 The Flatcar Maintainers.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+SCRIPT_ROOT=$(dirname $(readlink -f "$0"))
+. "${SCRIPT_ROOT}/common.sh" || exit 1
+
+# Script must run inside the chroot
+assert_inside_chroot
+
+assert_not_root_user
+
+# Developer-visible flags.
+DEFINE_string board "${DEFAULT_BOARD}" \
+  "The board to build an image for."
+DEFINE_string build_dir "" \
+  "Directory in which to place image result directories (named by version)"
+DEFINE_string prod_image_path "" \
+  "Path to the generic production image"
+DEFINE_string prod_pkgdb_path "" \
+  "Path to the tarball with portage package database from generic image production image"
+DEFINE_string version_id "${FLATCAR_VERSION_ID}" \
+  "Version ID stored inside the sysext extension"
+
+FLAGS_HELP="USAGE: build_oem_sysext [flags] [oem name].
+This script is used to build a Flatcar OEM sysext images.
+The built image is in <build_dir>/flatcar-oem-<oem>.raw.
+
+Examples:
+
+build_oem_sysext \
+    --board=amd64-usr \
+    --build_dir=<build_dir> \
+    --prod_image_path=<path_to_bin_file> \
+    --prod_pkgdb_path=<path_to_pkgdb_tarbal> \
+    --version_id=\"\${FLATCAR_VERSION_ID}\" \
+    oem-azure
+...
+"
+show_help_if_requested "$@"
+
+# Parse command line.
+FLAGS "$@" || exit 1
+if [[ -z "${FLAGS_ARGV}" ]]; then
+    echo 'No OEM given'
+    exit 0
+fi
+
+eval set -- "${FLAGS_ARGV}"
+
+# Only now can we die on error.  shflags functions leak non-zero error codes,
+# so will die prematurely if 'switch_to_strict_mode' is specified before now.
+switch_to_strict_mode
+
+# N.B.  Ordering matters for some of the libraries below, because
+# some of the files contain initialization used by later files.
+. "${BUILD_LIBRARY_DIR}/toolchain_util.sh" || exit 1
+. "${BUILD_LIBRARY_DIR}/board_options.sh" || exit 1
+. "${BUILD_LIBRARY_DIR}/oem_sysext_util.sh" || exit 1
+
+BUILD_DIR=${FLAGS_build_dir:-"${BUILD_DIR}"}
+
+if [[ -z "${FLAGS_prod_image_path}" ]]; then
+    error "--prod_image_path is required."
+    exit 1
+fi
+
+if [[ -z "${FLAGS_prod_pkgdb_path}" ]]; then
+    error "--prod_pkgdb_path is required."
+    exit 1
+fi
+
+for oem; do
+    oem_sysext_create "${oem}" "${BOARD}" "${FLAGS_version_id}" "${FLAGS_prod_image_path}" "${FLAGS_prod_pkgdb_path}" "${BUILD_DIR}"
+done

--- a/build_oem_sysext
+++ b/build_oem_sysext
@@ -26,7 +26,7 @@ DEFINE_string version_id "${FLATCAR_VERSION_ID}" \
 
 FLAGS_HELP="USAGE: build_oem_sysext [flags] [oem name].
 This script is used to build a Flatcar OEM sysext images.
-The built image is in <build_dir>/flatcar-oem-<oem>.raw.
+The built image is in <build_dir>/oem-<oem>.raw.
 
 Examples:
 

--- a/ci-automation/vms.sh
+++ b/ci-automation/vms.sh
@@ -108,9 +108,11 @@ function _vm_build_impl() {
     formats=$(echo "$formats" | tr ' ' '\n' | sed 's/equinix_metal/packet/g')
 
     local images_in="images-in/"
+    local file
     rm -rf "${images_in}"
-    copy_from_buildcache "images/${arch}/${vernum}/flatcar_production_image.bin.bz2" "${images_in}"
-    copy_from_buildcache "images/${arch}/${vernum}/version.txt" "${images_in}"
+    for file in flatcar_production_image.bin.bz2 flatcar_production_image_pkgdb.tar.xz version.txt; do
+        copy_from_buildcache "images/${arch}/${vernum}/${file}" "${images_in}"
+    done
     lbunzip2 "${images_in}/flatcar_production_image.bin.bz2"
     ./run_sdk_container -x ./ci-cleanup.sh -n "${vms_container}" -C "${packages_image}" \
             -v "${vernum}" \

--- a/common.sh
+++ b/common.sh
@@ -425,6 +425,7 @@ BUILD_DIR=
 # Standard filenames
 FLATCAR_DEVELOPER_CONTAINER_NAME="flatcar_developer_container.bin"
 FLATCAR_PRODUCTION_IMAGE_NAME="flatcar_production_image.bin"
+FLATCAR_PRODUCTION_IMAGE_PKGDB_NAME="flatcar_production_image_pkgdb.tar.xz"
 
 # -----------------------------------------------------------------------------
 # Functions

--- a/image_to_vm.sh
+++ b/image_to_vm.sh
@@ -105,7 +105,7 @@ if [ -f "${FLAGS_from}/version.txt" ]; then
     FLATCAR_VERSION_STRING="${FLATCAR_VERSION}"
 fi
 
-set_vm_paths "${FLAGS_from}" "${FLAGS_to}" "${FLATCAR_PRODUCTION_IMAGE_NAME}"
+set_vm_paths "${FLAGS_from}" "${FLAGS_to}" "${FLATCAR_PRODUCTION_IMAGE_NAME}" "${FLATCAR_PRODUCTION_IMAGE_PKGDB_NAME}"
 
 # Make sure things are cleaned up on failure
 trap vm_cleanup EXIT
@@ -118,6 +118,7 @@ setup_disk_image "${FLAGS_disk_layout}"
 # Optionally install any OEM packages
 install_oem_package
 install_oem_aci
+install_oem_sysext
 run_fs_hook
 
 # Changes done, glue it together


### PR DESCRIPTION
Portage database is put into the tarball and uploaded to bincache before it's dropped from the generic image. This is done in order to reinject it into the mounted generic image when building sysext images, so we have retained all the portage information and we don't need to strip RDEPENDS from the oem packages. That way they can become bog-standard ebuilds.

Adds some scripts for building oem sysexts and then ports azure to use them.

CI: http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/1472/cldsv

Related coreos overlay PR: https://github.com/flatcar/coreos-overlay/pull/2506

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
