### PR TITLE
sdk_lib: Use curl for downloading SDK tarballs

### DIFF
--- a/sdk_lib/sdk_util.sh
+++ b/sdk_lib/sdk_util.sh
@@ -30,9 +30,9 @@ sdk_download_tarball() {
         info "URL: ${url}"
         for suffix in "${suffixes[@]}"; do
             # If all downloads fail, we will detect it later.
-            if ! wget --tries=3 --timeout=30 --continue \
-                 -O "${FLATCAR_SDK_TARBALL_PATH}${suffix}" \
-                 "${url}${suffix}"; then
+            if ! curl --fail --silent --show-error --location --retry-delay 1 --retry 60 \
+                 --retry-connrefused --retry-max-time 60 --connect-timeout 20 \
+                 --output "${FLATCAR_SDK_TARBALL_PATH}${suffix}" "${url}${suffix}"; then
                 break
             fi
         done


### PR DESCRIPTION
This seems to be the only place where we are using wget for downloading anything - all other places use curl. Thus switch to curl here too. This also makes the job output much shorter as previously it was spammed with progress reporting.

CI: http://jenkins.infra.kinvolk.io:8080/job/container/job/sdk/714/ (I short-circuited it to stop after the successful download)
