### PR TITLE
Run kola without --qemu-skip-mangle on Jenkins

### DIFF
--- a/.github/workflows/run-kola-tests.yaml
+++ b/.github/workflows/run-kola-tests.yaml
@@ -100,6 +100,9 @@ jobs:
           export QEMU_IMAGE_NAME="/work/flatcar_production_image.bin"
           export QEMU_UEFI_BIOS="/work/flatcar_production_qemu_uefi_efi_code.fd"
           export PARALLEL_TESTS=${PARALLEL_ARCH}
+          # The runner uses lxc containers for kola, and can't use loopback devices to
+          # prepare the serial console setting - this means that kola may miss some errors
+          export QEMU_KOLA_SKIP_MANGLE=true
           EOF
 
           export MAX_RETRIES=5

--- a/ci-automation/ci-config.env
+++ b/ci-automation/ci-config.env
@@ -52,6 +52,9 @@ CONTAINER_IMAGE_ROOT="/home/sdk/build/images"
 QEMU_IMAGE_NAME=${QEMU_IMAGE_NAME:-flatcar_production_image.bin}
 QEMU_PARALLEL="${PARALLEL_TESTS:-20}"
 
+# Whether kola can use loop devices to capture serial console output and check for error patterns
+QEMU_KOLA_SKIP_MANGLE="${QEMU_KOLA_SKIP_MANGLE:-}"
+
 # BIOS path within the SDK
 QEMU_BIOS="/usr/share/qemu/bios-256k.bin"
 

--- a/ci-automation/vendor-testing/qemu.sh
+++ b/ci-automation/vendor-testing/qemu.sh
@@ -52,7 +52,7 @@ kola run \
     --qemu-image="${QEMU_IMAGE_NAME}" \
     --tapfile="${CIA_TAPFILE}" \
     --torcx-manifest="${CIA_TORCX_MANIFEST}" \
-    --qemu-skip-mangle \
+    ${QEMU_KOLA_SKIP_MANGLE:+--qemu-skip-mangle} \
     "${@}"
 
 set +x

--- a/ci-automation/vendor-testing/qemu_update.sh
+++ b/ci-automation/vendor-testing/qemu_update.sh
@@ -106,7 +106,7 @@ run_kola_tests() {
       --tapfile="${instance_tapfile}" \
       --torcx-manifest="${CIA_TORCX_MANIFEST}" \
       --update-payload=tmp/flatcar_test_update.gz \
-      --qemu-skip-mangle \
+      ${QEMU_KOLA_SKIP_MANGLE:+--qemu-skip-mangle} \
       cl.update.payload
 }
 


### PR DESCRIPTION
For the GitHub CI we have to use --qemu-skip-mangle because the LXC
    containers don't have access to loop devices. Running with
    --qemu-skip-mangle means that the serial console does not get captured
    completely because systemd and dracut messages are missing, and thus we
    don't catch these errors in kola.
    Make the skipping conditional and use it in Jenkins at least for the
    nightlies and releases.


## How to use/Testing done
Fixes https://github.com/flatcar/Flatcar/issues/980

Checked that the PR CI uses skip-mangle and Jenkins doesn't.
Test for PR CI here: https://github.com/flatcar/scripts/actions/runs/4511305236/jobs/7943425165
and for Jenkins here: http://jenkins.infra.kinvolk.io:8080/job/container/job/test/8842/console
http://jenkins.infra.kinvolk.io:8080/job/container/job/test/8844/console