### PR TITLE
Drop more tmpfiles rules that cause /etc upcopies

### DIFF
--- a/build_library/build_image_util.sh
+++ b/build_library/build_image_util.sh
@@ -801,8 +801,9 @@ EOF
   done
   sudo "${root_fs_dir}"/usr/sbin/flatcar-tmpfiles "${root_fs_dir}"
   # Now that we used the tmpfiles for creating /etc we delete them because
-  # the L, d, and C entries cause upcopies
-  sudo sed -i '/^[CLd] *\/etc\//d' "${root_fs_dir}"/usr/lib/tmpfiles.d/*
+  # the L, d, and C entries cause upcopies. Also filter out rules with ! or - but no other modifiers
+  # like + or = which explicitly recreate files.
+  sudo sed -i '/^[CLd]-*!*-*[ \t]*\/etc\//d' "${root_fs_dir}"/usr/lib/tmpfiles.d/*
 
   # SELinux: Label the root filesystem for using 'file_contexts'.
   # The labeling has to be done before moving /etc to /usr/share/flatcar/etc to prevent wrong labels for these files and as


### PR DESCRIPTION
We already drop tmpfile rules that we don't need because we ship the files through our /etc overlay. However, some rules weren't dropped because they used tabs and not spaces (/etc/selinux/, /etc/iscsi and /etc/ssl/*).
Also drop rule lines for /etc that use tabs.


## How to use
Backport to Alpha

## Testing done
[CI](http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/1588/cldsv/) passed
Ran `grep -R -P '[CLd][ \t]*/etc/'  /usr/lib/tmpfiles.d/` and saw that it is empty.
`/etc` contents are now reduced to
```
-rw-------.  1 root root  144 Mar 30 13:57 .ignition-result.json
-rw-------.  1 root root    0 Mar 30 12:37 .pwd.lock
-rw-r--r--.  1 root root  208 Mar 30 12:33 .updated
drwxr-x---.  2 root root 4.0K Mar 30 13:57 audit
drwxr-xr-x.  3 root root 4.0K Mar 30 13:57 cni
-rwxr-xr-x.  1 root root    0 Mar 30 12:37 environment
drwxr-xr-x.  2 root root 4.0K Mar 30 12:37 flatcar
-rw-r--r--.  1 root root   77 Mar 30 12:37 group
-rw-r-----.  1 root root   65 Mar 30 12:37 gshadow
-rw-r--r--.  1 root root  25K Mar 30 13:57 ld.so.cache
lrwxrwxrwx.  1 root root   21 Mar 30 12:37 ld.so.conf -> ../usr/lib/ld.so.conf
-r--r--r--.  1 root root   33 Mar 30 13:57 machine-id
lrwxrwxrwx.  1 root root   19 Mar 30 12:37 mtab -> ../proc/self/mounts
-rw-r--r--.  1 root root   82 Mar 30 12:37 passwd
-rw-r-----.  1 root root   40 Mar 30 12:37 shadow
drwxr-xr-x.  2 root root 4.0K Mar 30 13:57 ssh
drwxr-xr-x.  3 root root 4.0K Mar 30 12:32 systemd
drwxr-xr-x.  3 root root 4.0K Mar 30 13:57 torcx
drwxr-xr-x.  2 root root 4.0K Mar 30 13:57 udev
```
(`/etc/ssl`, `/etc/selinux`, and `/etc/iscsi` are gone)

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
