### PR TITLE
run-kola-tests.yaml: fix path of PR comment file

### DIFF
--- a/.github/workflows/run-kola-tests.yaml
+++ b/.github/workflows/run-kola-tests.yaml
@@ -356,4 +356,4 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         uses: mshick/add-pr-comment@v2
         with:
-          message-path: "test-results.md"
+          message-path: "scripts/test-results.md"


### PR DESCRIPTION
This is a one-line fix for the "post test results to PR as a comment" CI feature.
The path of the markdown file to be posted to the PR was wrong.

Should be cherry-picked to to flatcar-3033, flatcar-3549, flatcar-3510, flatcar-3374.