### PR TITLE
sdk_bootstrap: Push a branch also for two-phase SDK nightly builds

### DIFF
--- a/ci-automation/sdk_bootstrap.sh
+++ b/ci-automation/sdk_bootstrap.sh
@@ -76,9 +76,10 @@ function _sdk_bootstrap_impl() {
 
     # Create new tag in scripts repo w/ updated versionfile.
     # Also push the changes to the branch ONLY IF we're doing a nightly
-    #   build of the 'main' branch AND we're definitely ON the main branch
+    #   build of the 'main' branch AND we're definitely ON the main branch.
+    #   This includes intermediate SDKs when doing 2-phase nightly builds.
     local push_branch="false"
-    if   [[ "${version}" =~ ^main-[0-9.]+-nightly-[-0-9]+$ ]] \
+    if   [[ "${version}" =~ ^main-[0-9.]+-nightly-[-0-9]+(-INTERMEDIATE)?$ ]] \
        && [ "$(git rev-parse --abbrev-ref HEAD)" = "main"  ] ; then
         push_branch="true"
         local existing_tag=""


### PR DESCRIPTION
The two-phase nightly builds create an intermediate tag first, which didn't match the main nightly tag regexp before. Because of that, the commit was not pushed to the main branch. The following final SDK build had a version that matched the regexp, but the last commit (with the intermediate tag on it) wasn't in main, and thus was also not pushed.

Tested the regexp change locally:

```
$ version='main-3581.0.0-nightly-20230421-2100-INTERMEDIATE'
$ [[ "${version}" =~ ^main-[0-9.]+-nightly-[-0-9]+(-INTERMEDIATE)?$ ]] && echo true
true
$ version='main-3581.0.0-nightly-20230421-2100'
$ [[ "${version}" =~ ^main-[0-9.]+-nightly-[-0-9]+(-INTERMEDIATE)?$ ]] && echo true
true
```

I can cherry-pick it to other branches, but not sure if there's a point as it only affects the builds from the main branch.