### PR TITLE
.github: get build and CI triggered by opened, synchronize

### DIFF
--- a/.github/workflows/cacerts-release.yaml
+++ b/.github/workflows/cacerts-release.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Check out main scripts branch for GitHub workflow scripts only
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BOT_PR_TOKEN }}
           path: gha
           ref: main
       - name: Figure out branch
@@ -25,7 +25,7 @@ jobs:
         if: steps.figure-out-branch.outputs.SKIP == 0
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BOT_PR_TOKEN }}
           path: work
           ref: ${{ steps.figure-out-branch.outputs.BRANCH }}
       - name: Figure out latest ca-certificates release version
@@ -58,7 +58,7 @@ jobs:
         if: (steps.figure-out-branch.outputs.SKIP == 0) && (steps.apply-patch.outputs.UPDATE_NEEDED == 1)
         uses: peter-evans/create-pull-request@v5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BOT_PR_TOKEN }}
           path: work
           branch: "cacerts-${{ steps.nss-latest-release.outputs.NSS_VERSION }}-${{ steps.figure-out-branch.outputs.BRANCH }}"
           base: ${{ steps.figure-out-branch.outputs.BRANCH }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,9 +1,8 @@
 name: "Run build"
 on:
   pull_request:
-    # Run when the PR is ready and each time a review is re-requested
-    #  (i.e. after feedback has been addressed).
-    types: [review_requested, ready_for_review]
+    # Run when the PR is opened, reopened, or updated (synchronize)
+    types: [opened, reopened, synchronize]
   workflow_dispatch:
     inputs:
       image_formats:

--- a/.github/workflows/containerd-release-main.yaml
+++ b/.github/workflows/containerd-release-main.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Check out scripts
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BOT_PR_TOKEN }}
           path: scripts
       - name: Figure out latest Containerd release version
         id: containerd-latest-release
@@ -40,7 +40,7 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         if: steps.apply-patch-main.outputs.UPDATE_NEEDED == 1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BOT_PR_TOKEN }}
           path: scripts
           branch: "containerd-${{ steps.containerd-latest-release.outputs.VERSION_NEW }}-main"
           base: main

--- a/.github/workflows/docker-release-main.yaml
+++ b/.github/workflows/docker-release-main.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Check out scripts
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BOT_PR_TOKEN }}
           path: scripts
       - name: Figure out latest Docker release version
         id: docker-latest-release
@@ -43,7 +43,7 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         if: steps.apply-patch-main.outputs.UPDATE_NEEDED == 1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BOT_PR_TOKEN }}
           path: scripts
           branch: docker-${{ steps.docker-latest-release.outputs.VERSION_NEW }}-main
           base: main

--- a/.github/workflows/firmware-release-main.yaml
+++ b/.github/workflows/firmware-release-main.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Check out scripts
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BOT_PR_TOKEN }}
           path: scripts
       - name: Figure out latest Linux Firmware release version
         id: firmware-latest-release
@@ -37,7 +37,7 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         if: steps.apply-patch-main.outputs.UPDATE_NEEDED == 1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BOT_PR_TOKEN }}
           path: scripts
           branch: firmware-${{ steps.firmware-latest-release.outputs.VERSION_NEW }}-main
           base: main

--- a/.github/workflows/go-release-main.yaml
+++ b/.github/workflows/go-release-main.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Check out scripts
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BOT_PR_TOKEN }}
           path: scripts
       - name: Figure out latest Go release versions
         id: go-latest-release
@@ -38,7 +38,7 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         if: steps.apply-patch-main.outputs.UPDATE_NEEDED == 1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BOT_PR_TOKEN }}
           path: scripts
           branch: ${{ steps.apply-patch-main.outputs.BRANCH_NAME }}
           base: main

--- a/.github/workflows/kernel-release.yaml
+++ b/.github/workflows/kernel-release.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Check out main scripts branch for GitHub workflow scripts only
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BOT_PR_TOKEN }}
           path: gha
           ref: main
       - name: Figure out branch
@@ -25,7 +25,7 @@ jobs:
         if: steps.figure-out-branch.outputs.SKIP == 0
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BOT_PR_TOKEN }}
           path: work
           ref: ${{ steps.figure-out-branch.outputs.BRANCH }}
       - name: Figure out latest Linux release version
@@ -59,7 +59,7 @@ jobs:
         if: (steps.figure-out-branch.outputs.SKIP == 0) && (steps.apply-patch.outputs.UPDATE_NEEDED == 1)
         uses: peter-evans/create-pull-request@v5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BOT_PR_TOKEN }}
           path: work
           branch: "linux-${{ steps.kernel-latest-release.outputs.KERNEL_VERSION }}-${{ steps.figure-out-branch.outputs.BRANCH }}"
           base: ${{ steps.figure-out-branch.outputs.BRANCH }}

--- a/.github/workflows/mantle-releases-main.yml
+++ b/.github/workflows/mantle-releases-main.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v3
         if: ${{ steps.figure-out-branch.outputs.SKIP == 0 }}
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BOT_PR_TOKEN }}
           ref: ${{ steps.figure-out-branch.outputs.BRANCH }}
       - name: Fetch latest mantle hash
         if: ${{ steps.figure-out-branch.outputs.SKIP == 0 }}
@@ -71,7 +71,7 @@ jobs:
         if: ${{ steps.figure-out-branch.outputs.SKIP == 0 }}
         uses: peter-evans/create-pull-request@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BOT_PR_TOKEN }}
           base: ${{ steps.figure-out-branch.outputs.BRANCH }}
           branch: mantle-update-${{ steps.figure-out-branch.outputs.BRANCH }}
           author: Flatcar Buildbot <buildbot@flatcar-linux.org>

--- a/.github/workflows/runc-release-main.yaml
+++ b/.github/workflows/runc-release-main.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Check out scripts
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BOT_PR_TOKEN }}
           path: scripts
       - name: Figure out latest Runc release version
         id: runc-latest-release
@@ -55,7 +55,7 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         if: steps.apply-patch-main.outputs.UPDATE_NEEDED == 1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BOT_PR_TOKEN }}
           path: scripts
           branch: runc-${{ steps.runc-latest-release.outputs.VERSION_NEW }}-main
           base: main

--- a/.github/workflows/rust-release-main.yaml
+++ b/.github/workflows/rust-release-main.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Check out scripts
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BOT_PR_TOKEN }}
           path: scripts
       - name: Figure out latest Rust release version
         id: rust-latest-release
@@ -38,7 +38,7 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         if: steps.apply-patch-main.outputs.UPDATE_NEEDED == 1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BOT_PR_TOKEN }}
           path: scripts
           branch: rust-${{ steps.rust-latest-release.outputs.VERSION_NEW }}-main
           base: main

--- a/.github/workflows/update-metadata-glsa.yaml
+++ b/.github/workflows/update-metadata-glsa.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Check out scripts
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BOT_PR_TOKEN }}
       - name: Update GLSA metadata
         id: update-glsa-metadata
         run: |
@@ -24,7 +24,7 @@ jobs:
       - name: Create pull request for main branch
         uses: peter-evans/create-pull-request@v5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BOT_PR_TOKEN }}
           branch: buildbot/monthly-glsa-metadata-updates-${{steps.update-glsa-metadata.outputs.TODAYDATE }}
           delete-branch: true
           base: main

--- a/.github/workflows/vmware-release-main.yaml
+++ b/.github/workflows/vmware-release-main.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Check out scripts
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BOT_PR_TOKEN }}
           path: scripts
       - name: Figure out latest open-vm-tools release version
         id: openvmtools-latest-release
@@ -40,7 +40,7 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         if: steps.apply-patch-main.outputs.UPDATE_NEEDED == 1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BOT_PR_TOKEN }}
           path: scripts
           branch: vmware-${{ steps.openvmtools-latest-release.outputs.VERSION_NEW }}-main
           base: main


### PR DESCRIPTION
Build and CI tests should run automatically whenever a pull request is opened, reopened or updated.
On the other hand, it is not necessary to run build and CI tests on the events `ready_for_review` and `review_requested`.

That could already work out of the box for `reopened` and `synchronized` events.

To do that especially for the `opened` event, however, it is necessary to use a dedicated personal access token `BOT_PR_TOKEN` for bot PRs instead of the default `GITHUB_TOKEN`. It is needed for triggering another workflow from pull requests created by Github Actions. The default `GITHUB_TOKEN` is by design not able to trigger another workflow.

See also https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow.

## Testing done

tested via my fork repo