### PR TITLE
.github: check remote branch, add correct changelog

### DIFF
--- a/.github/workflows/cacerts-apply-patch.sh
+++ b/.github/workflows/cacerts-apply-patch.sh
@@ -6,13 +6,18 @@ source "${GHA_SCRIPTS_DIR}/.github/workflows/common.sh"
 
 prepare_git_repo
 
+if ! check_remote_branch "cacerts-${VERSION_NEW}-${TARGET_BRANCH}"; then
+    echo "remote branch already exists, nothing to do"
+    exit 0
+fi
+
 pushd "${SDK_OUTER_OVERLAY}"
 
 # Parse the Manifest file for already present source files and keep the latest version in the current series
 VERSION_OLD=$(sed -n "s/^DIST nss-\([0-9]*\.[0-9]*\).*$/\1/p" app-misc/ca-certificates/Manifest | sort -ruV | head -n1)
 if [[ "${VERSION_NEW}" = "${VERSION_OLD}" ]]; then
-  echo "already the latest ca-certificates, nothing to do"
-  exit 0
+    echo "already the latest ca-certificates, nothing to do"
+    exit 0
 fi
 
 EBUILD_FILENAME=$(get_ebuild_filename app-misc/ca-certificates "${VERSION_OLD}")

--- a/.github/workflows/cacerts-release.yaml
+++ b/.github/workflows/cacerts-release.yaml
@@ -53,6 +53,7 @@ jobs:
           VERSION_NEW: ${{ steps.nss-latest-release.outputs.NSS_VERSION }}
           PACKAGES_CONTAINER: ${{ steps.setup-flatcar-sdk.outputs.PACKAGES_CONTAINER }}
           SDK_NAME: ${{ steps.setup-flatcar-sdk.outputs.SDK_NAME }}
+          TARGET_BRANCH: ${{ steps.figure-out-branch.outputs.BRANCH }}
         run: gha/.github/workflows/cacerts-apply-patch.sh
       - name: Create pull request
         if: (steps.figure-out-branch.outputs.SKIP == 0) && (steps.apply-patch.outputs.UPDATE_NEEDED == 1)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: "Run build"
 on:
   pull_request:
     # Run when the PR is opened, reopened, or updated (synchronize)
-    types: [opened, reopened, synchronize]
+    types: [opened, ready_for_review, reopened, synchronize]
   workflow_dispatch:
     inputs:
       image_formats:

--- a/.github/workflows/common.sh
+++ b/.github/workflows/common.sh
@@ -173,12 +173,17 @@ function commit_changes() {
 
   regenerate_manifest "${pkg}" "${new_version}"
 
-  pushd "${SDK_OUTER_OVERLAY}"
+  pushd "${SDK_OUTER_TOPDIR}"
 
-  git add "${pkg}"
   if [[ -d changelog ]]; then
     git add changelog
   fi
+
+  popd
+
+  pushd "${SDK_OUTER_OVERLAY}"
+
+  git add "${pkg}"
   for dir; do
     git add "${dir}"
   done
@@ -193,7 +198,7 @@ function commit_changes() {
 # avoid unwanted changes to be a part of a PR created by the
 # peter-evans/create-pull-request action that follows up.
 function cleanup_repo() {
-    git -C "${SDK_OUTER_OVERLAY}" status
-    git -C "${SDK_OUTER_OVERLAY}" reset --hard HEAD
-    git -C "${SDK_OUTER_OVERLAY}" clean -ffdx
+    git -C "${SDK_OUTER_TOPDIR}" status
+    git -C "${SDK_OUTER_TOPDIR}" reset --hard HEAD
+    git -C "${SDK_OUTER_TOPDIR}" clean -ffdx
 }

--- a/.github/workflows/common.sh
+++ b/.github/workflows/common.sh
@@ -64,6 +64,15 @@ function prepare_git_repo() {
   git -C "${SDK_OUTER_TOPDIR}" config user.email "${BUILDBOT_USEREMAIL}"
 }
 
+function check_remote_branch() {
+  local target_branch="${1}"
+
+  if git -C "${SDK_OUTER_TOPDIR}" show-ref "remotes/origin/${target_branch}"; then
+    return 1
+  fi
+  return 0
+}
+
 # Regenerates a manifest file using an ebuild of a given package with
 # a given version.
 #

--- a/.github/workflows/containerd-apply-patch.sh
+++ b/.github/workflows/containerd-apply-patch.sh
@@ -6,12 +6,17 @@ source "${GHA_SCRIPTS_DIR}/.github/workflows/common.sh"
 
 prepare_git_repo
 
+if ! check_remote_branch "containerd-${VERSION_NEW}-${TARGET_BRANCH}"; then
+    echo "remote branch already exists, nothing to do"
+    exit 0
+fi
+
 pushd "${SDK_OUTER_OVERLAY}"
 
 VERSION_OLD=$(sed -n "s/^DIST containerd-\([0-9]*\.[0-9]*\.[0-9]*\).*/\1/p" app-emulation/containerd/Manifest | sort -ruV | head -n1)
 if [[ "${VERSION_NEW}" = "${VERSION_OLD}" ]]; then
-  echo "already the latest Containerd, nothing to do"
-  exit 0
+    echo "already the latest Containerd, nothing to do"
+    exit 0
 fi
 
 # we need to update not only the main ebuild file, but also its CONTAINERD_COMMIT,

--- a/.github/workflows/containerd-release-main.yaml
+++ b/.github/workflows/containerd-release-main.yaml
@@ -35,6 +35,7 @@ jobs:
           COMMIT_HASH: ${{ steps.containerd-latest-release.outputs.COMMIT_HASH }}
           PACKAGES_CONTAINER: ${{ steps.setup-flatcar-sdk.outputs.PACKAGES_CONTAINER }}
           SDK_NAME: ${{ steps.setup-flatcar-sdk.outputs.SDK_NAME }}
+          TARGET_BRANCH: main
         run: scripts/.github/workflows/containerd-apply-patch.sh
       - name: Create pull request for main
         uses: peter-evans/create-pull-request@v5

--- a/.github/workflows/docker-apply-patch.sh
+++ b/.github/workflows/docker-apply-patch.sh
@@ -6,12 +6,17 @@ source "${GHA_SCRIPTS_DIR}/.github/workflows/common.sh"
 
 prepare_git_repo
 
+if ! check_remote_branch "docker-${VERSION_NEW}-${TARGET_BRANCH}"; then
+    echo "remote branch already exists, nothing to do"
+    exit 0
+fi
+
 pushd "${SDK_OUTER_OVERLAY}"
 
 VERSION_OLD=$(sed -n "s/^DIST docker-\([0-9]*.[0-9]*.[0-9]*\).*/\1/p" app-emulation/docker/Manifest | sort -ruV | head -n1)
 if [[ "${VERSION_NEW}" = "${VERSION_OLD}" ]]; then
-  echo "already the latest Docker, nothing to do"
-  exit 0
+    echo "already the latest Docker, nothing to do"
+    exit 0
 fi
 
 # we need to update not only the main ebuild file, but also its DOCKER_GITCOMMIT,

--- a/.github/workflows/docker-release-main.yaml
+++ b/.github/workflows/docker-release-main.yaml
@@ -38,6 +38,7 @@ jobs:
           COMMIT_HASH_CLI: ${{ steps.docker-latest-release.outputs.COMMIT_HASH_CLI }}
           PACKAGES_CONTAINER: ${{ steps.setup-flatcar-sdk.outputs.PACKAGES_CONTAINER }}
           SDK_NAME: ${{ steps.setup-flatcar-sdk.outputs.SDK_NAME }}
+          TARGET_BRANCH: main
         run: scripts/.github/workflows/docker-apply-patch.sh
       - name: Create pull request for main
         uses: peter-evans/create-pull-request@v5

--- a/.github/workflows/firmware-apply-patch.sh
+++ b/.github/workflows/firmware-apply-patch.sh
@@ -6,13 +6,18 @@ source "${GHA_SCRIPTS_DIR}/.github/workflows/common.sh"
 
 prepare_git_repo
 
+if ! check_remote_branch "firmware-${VERSION_NEW}-${TARGET_BRANCH}"; then
+    echo "remote branch already exists, nothing to do"
+    exit 0
+fi
+
 pushd "${SDK_OUTER_OVERLAY}"
 
 # Parse the Manifest file for already present source files and keep the latest version in the current series
 VERSION_OLD=$(sed -n "s/^DIST linux-firmware-\([0-9]*\).*$/\1/p" sys-kernel/coreos-firmware/Manifest | sort -ruV | head -n1)
 if [[ "${VERSION_NEW}" = "${VERSION_OLD}" ]]; then
-  echo "already the latest Linux Firmware, nothing to do"
-  exit 0
+    echo "already the latest Linux Firmware, nothing to do"
+    exit 0
 fi
 
 EBUILD_FILENAME=$(get_ebuild_filename sys-kernel/coreos-firmware "${VERSION_OLD}")

--- a/.github/workflows/firmware-release-main.yaml
+++ b/.github/workflows/firmware-release-main.yaml
@@ -32,6 +32,7 @@ jobs:
           VERSION_NEW: ${{ steps.firmware-latest-release.outputs.VERSION_NEW }}
           PACKAGES_CONTAINER: ${{ steps.setup-flatcar-sdk.outputs.PACKAGES_CONTAINER }}
           SDK_NAME: ${{ steps.setup-flatcar-sdk.outputs.SDK_NAME }}
+          TARGET_BRANCH: main
         run: scripts/.github/workflows/firmware-apply-patch.sh
       - name: Create pull request for main
         uses: peter-evans/create-pull-request@v5

--- a/.github/workflows/go-apply-patch.sh
+++ b/.github/workflows/go-apply-patch.sh
@@ -18,6 +18,11 @@ done
 
 branch_name="go-$(join_by '-and-' ${VERSIONS_NEW})-main"
 
+if ! check_remote_branch "${branch_name}"; then
+  echo "remote branch already exists, nothing to do"
+  exit 0
+fi
+
 # Parse the Manifest file for already present source files and keep the latest version in the current series
 # DIST go1.17.src.tar.gz ... => 1.17
 # DIST go1.17.1.src.tar.gz ... => 1.17.1
@@ -56,8 +61,8 @@ done
 cleanup_repo
 
 if [[ $any_different -eq 0 ]]; then
-  echo "go packages were already at the latest versions, nothing to do"
-  exit 0
+    echo "go packages were already at the latest versions, nothing to do"
+    exit 0
 fi
 
 vo_gh="$(join_by ' and ' "${UPDATED_VERSIONS_OLD[@]}")"

--- a/.github/workflows/go-release-main.yaml
+++ b/.github/workflows/go-release-main.yaml
@@ -33,6 +33,7 @@ jobs:
           VERSIONS_NEW: ${{ steps.go-latest-release.outputs.VERSIONS_NEW }}
           PACKAGES_CONTAINER: ${{ steps.setup-flatcar-sdk.outputs.PACKAGES_CONTAINER }}
           SDK_NAME: ${{ steps.setup-flatcar-sdk.outputs.SDK_NAME }}
+          TARGET_BRANCH: main
         run: scripts/.github/workflows/go-apply-patch.sh
       - name: Create pull request for main
         uses: peter-evans/create-pull-request@v5

--- a/.github/workflows/kernel-apply-patch.sh
+++ b/.github/workflows/kernel-apply-patch.sh
@@ -6,6 +6,11 @@ source "${GHA_SCRIPTS_DIR}/.github/workflows/common.sh"
 
 prepare_git_repo
 
+if ! check_remote_branch "linux-${VERSION_NEW}-${TARGET_BRANCH}"; then
+    echo "remote branch already exists, nothing to do"
+    exit 0
+fi
+
 pushd "${SDK_OUTER_OVERLAY}"
 
 # trim the 3rd part in the input semver, e.g. from 5.4.1 to 5.4

--- a/.github/workflows/kernel-release.yaml
+++ b/.github/workflows/kernel-release.yaml
@@ -54,6 +54,7 @@ jobs:
           VERSION_NEW: ${{ steps.kernel-latest-release.outputs.KERNEL_VERSION }}
           PACKAGES_CONTAINER: ${{ steps.setup-flatcar-sdk.outputs.PACKAGES_CONTAINER }}
           SDK_NAME: ${{ steps.setup-flatcar-sdk.outputs.SDK_NAME }}
+          TARGET_BRANCH: ${{ steps.figure-out-branch.outputs.BRANCH }}
         run: gha/.github/workflows/kernel-apply-patch.sh
       - name: Create pull request
         if: (steps.figure-out-branch.outputs.SKIP == 0) && (steps.apply-patch.outputs.UPDATE_NEEDED == 1)

--- a/.github/workflows/runc-apply-patch.sh
+++ b/.github/workflows/runc-apply-patch.sh
@@ -6,6 +6,11 @@ source "${GHA_SCRIPTS_DIR}/.github/workflows/common.sh"
 
 prepare_git_repo
 
+if ! check_remote_branch "runc-${VERSION_NEW}-${TARGET_BRANCH}"; then
+    echo "remote branch already exists, nothing to do"
+    exit 0
+fi
+
 pushd "${SDK_OUTER_OVERLAY}"
 
 # Get the newest runc version, including official releases and rc
@@ -16,8 +21,8 @@ pushd "${SDK_OUTER_OVERLAY}"
 # "0.0.2.1" as newer than "0.0.2".
 VERSION_OLD=$(sed -n "s/^DIST docker-runc-\([0-9]*\.[0-9]*.*\)\.tar.*/\1_/p" app-emulation/docker-runc/Manifest | tr '.' '_' | sort -ruV | sed -e 's/_$//' | tr '_' '.' | head -n1)
 if [[ "${VERSION_NEW}" = "${VERSION_OLD}" ]]; then
-  echo "already the latest Runc, nothing to do"
-  exit 0
+    echo "already the latest Runc, nothing to do"
+    exit 0
 fi
 
 runcEbuildOld=$(get_ebuild_filename app-emulation/docker-runc "${VERSION_OLD}")

--- a/.github/workflows/runc-release-main.yaml
+++ b/.github/workflows/runc-release-main.yaml
@@ -50,6 +50,7 @@ jobs:
           COMMIT_HASH: ${{ steps.runc-latest-release.outputs.COMMIT_HASH }}
           PACKAGES_CONTAINER: ${{ steps.setup-flatcar-sdk.outputs.PACKAGES_CONTAINER }}
           SDK_NAME: ${{ steps.setup-flatcar-sdk.outputs.SDK_NAME }}
+          TARGET_BRANCH: main
         run: scripts/.github/workflows/runc-apply-patch.sh
       - name: Create pull request for main
         uses: peter-evans/create-pull-request@v5

--- a/.github/workflows/rust-apply-patch.sh
+++ b/.github/workflows/rust-apply-patch.sh
@@ -6,12 +6,17 @@ source "${GHA_SCRIPTS_DIR}/.github/workflows/common.sh"
 
 prepare_git_repo
 
+if ! check_remote_branch "rust-${VERSION_NEW}-${TARGET_BRANCH}"; then
+    echo "remote branch already exists, nothing to do"
+    exit 0
+fi
+
 pushd "${SDK_OUTER_OVERLAY}"
 
 VERSION_OLD=$(sed -n "s/^DIST rustc-\(1\.[0-9]*\.[0-9]*\).*/\1/p" dev-lang/rust/Manifest | sort -ruV | head -n1)
 if [[ "${VERSION_NEW}" = "${VERSION_OLD}" ]]; then
-  echo "already the latest Rust, nothing to do"
-  exit 0
+    echo "already the latest Rust, nothing to do"
+    exit 0
 fi
 
 # Replace (dev-lang/virtual)/rust versions in profiles/, e.g. package.accept_keywords.

--- a/.github/workflows/rust-release-main.yaml
+++ b/.github/workflows/rust-release-main.yaml
@@ -32,6 +32,7 @@ jobs:
           VERSION_NEW: ${{ steps.rust-latest-release.outputs.VERSION_NEW }}
           PACKAGES_CONTAINER: ${{ steps.setup-flatcar-sdk.outputs.PACKAGES_CONTAINER }}
           SDK_NAME: ${{ steps.setup-flatcar-sdk.outputs.SDK_NAME }}
+          TARGET_BRANCH: main
         run: scripts/.github/workflows/rust-apply-patch.sh
       - name: Create pull request for main
         id: create-pull-request

--- a/.github/workflows/vmware-apply-patch.sh
+++ b/.github/workflows/vmware-apply-patch.sh
@@ -6,6 +6,11 @@ source "${GHA_SCRIPTS_DIR}/.github/workflows/common.sh"
 
 prepare_git_repo
 
+if ! check_remote_branch "open-vm-tools-${VERSION_NEW}-${TARGET_BRANCH}"; then
+    echo "remote branch already exists, nothing to do"
+    exit 0
+fi
+
 # Update app-emulation/open-vm-tools
 
 pushd "${SDK_OUTER_OVERLAY}"
@@ -13,8 +18,8 @@ pushd "${SDK_OUTER_OVERLAY}"
 # Parse the Manifest file for already present source files and keep the latest version in the current series
 VERSION_OLD=$(sed -n "s/^DIST open-vm-tools-\([0-9]*\.[0-9]*\.[0-9]*\).*$/\1/p" app-emulation/open-vm-tools/Manifest | sort -ruV | head -n1)
 if [[ "${VERSION_NEW}" = "${VERSION_OLD}" ]]; then
-  echo "already the latest open-vm-tools, nothing to do"
-  exit 0
+    echo "already the latest open-vm-tools, nothing to do"
+    exit 0
 fi
 
 EBUILD_FILENAME_OVT=$(get_ebuild_filename app-emulation/open-vm-tools "${VERSION_OLD}")

--- a/.github/workflows/vmware-release-main.yaml
+++ b/.github/workflows/vmware-release-main.yaml
@@ -35,6 +35,7 @@ jobs:
           VERSION_NEW: ${{ steps.openvmtools-latest-release.outputs.VERSION_NEW }}
           PACKAGES_CONTAINER: ${{ steps.setup-flatcar-sdk.outputs.PACKAGES_CONTAINER }}
           SDK_NAME: ${{ steps.setup-flatcar-sdk.outputs.SDK_NAME }}
+          TARGET_BRANCH: main
         run: scripts/.github/workflows/vmware-apply-patch.sh
       - name: Create pull request for main
         uses: peter-evans/create-pull-request@v5


### PR DESCRIPTION
To avoid noise of touching existing PRs, check first if the remote branch already exists. If that exists, skip creating or updating the PR.

In case of a draft PR created first, no CI gets triggered at the time. So we should trigger CI afterwards when it is being set to a ready_for_review state.

Changelog directory is now located under flatcar scripts, not under coreos-overlay. Fix the location to add correct changelog to the git commit.

## Testing done

Tested via my fork repo