### PR TITLE
dev-libs/openssl: update to 3.0.8-r4

### DIFF
--- a/changelog/security/2023-05-04-openssl-3.0.8-r4.md
+++ b/changelog/security/2023-05-04-openssl-3.0.8-r4.md
@@ -1,0 +1,1 @@
+- OpenSSL ([CVE-2023-0464](https://nvd.nist.gov/vuln/detail/CVE-2023-0464), [CVE-2023-0465](https://nvd.nist.gov/vuln/detail/CVE-2023-0465), [CVE-2023-0466](https://nvd.nist.gov/vuln/detail/CVE-2023-0466), [CVE-2023-1255](https://nvd.nist.gov/vuln/detail/CVE-2023-1255))

--- a/sdk_container/src/third_party/coreos-overlay/dev-libs/openssl/files/openssl-3.0.8-CVE-2023-0464.patch
+++ b/sdk_container/src/third_party/coreos-overlay/dev-libs/openssl/files/openssl-3.0.8-CVE-2023-0464.patch
@@ -1,0 +1,214 @@
+commit 959c59c7a0164117e7f8366466a32bb1f8d77ff1
+Author: Pauli <pauli@openssl.org>
+Date:   Wed Mar 8 15:28:20 2023 +1100
+
+    x509: excessive resource use verifying policy constraints
+    
+    A security vulnerability has been identified in all supported versions
+    of OpenSSL related to the verification of X.509 certificate chains
+    that include policy constraints.  Attackers may be able to exploit this
+    vulnerability by creating a malicious certificate chain that triggers
+    exponential use of computational resources, leading to a denial-of-service
+    (DoS) attack on affected systems.
+    
+    Fixes CVE-2023-0464
+    
+    Reviewed-by: Tomas Mraz <tomas@openssl.org>
+    Reviewed-by: Shane Lontis <shane.lontis@oracle.com>
+    (Merged from https://github.com/openssl/openssl/pull/20568)
+
+diff --git a/crypto/x509/pcy_local.h b/crypto/x509/pcy_local.h
+index 18b53cc09e..cba107ca03 100644
+--- a/crypto/x509/pcy_local.h
++++ b/crypto/x509/pcy_local.h
+@@ -111,6 +111,11 @@ struct X509_POLICY_LEVEL_st {
+ };
+ 
+ struct X509_POLICY_TREE_st {
++    /* The number of nodes in the tree */
++    size_t node_count;
++    /* The maximum number of nodes in the tree */
++    size_t node_maximum;
++
+     /* This is the tree 'level' data */
+     X509_POLICY_LEVEL *levels;
+     int nlevel;
+@@ -157,7 +162,8 @@ X509_POLICY_NODE *ossl_policy_tree_find_sk(STACK_OF(X509_POLICY_NODE) *sk,
+ X509_POLICY_NODE *ossl_policy_level_add_node(X509_POLICY_LEVEL *level,
+                                              X509_POLICY_DATA *data,
+                                              X509_POLICY_NODE *parent,
+-                                             X509_POLICY_TREE *tree);
++                                             X509_POLICY_TREE *tree,
++                                             int extra_data);
+ void ossl_policy_node_free(X509_POLICY_NODE *node);
+ int ossl_policy_node_match(const X509_POLICY_LEVEL *lvl,
+                            const X509_POLICY_NODE *node, const ASN1_OBJECT *oid);
+diff --git a/crypto/x509/pcy_node.c b/crypto/x509/pcy_node.c
+index 9d9a7ea179..450f95a655 100644
+--- a/crypto/x509/pcy_node.c
++++ b/crypto/x509/pcy_node.c
+@@ -59,10 +59,15 @@ X509_POLICY_NODE *ossl_policy_level_find_node(const X509_POLICY_LEVEL *level,
+ X509_POLICY_NODE *ossl_policy_level_add_node(X509_POLICY_LEVEL *level,
+                                              X509_POLICY_DATA *data,
+                                              X509_POLICY_NODE *parent,
+-                                             X509_POLICY_TREE *tree)
++                                             X509_POLICY_TREE *tree,
++                                             int extra_data)
+ {
+     X509_POLICY_NODE *node;
+ 
++    /* Verify that the tree isn't too large.  This mitigates CVE-2023-0464 */
++    if (tree->node_maximum > 0 && tree->node_count >= tree->node_maximum)
++        return NULL;
++
+     node = OPENSSL_zalloc(sizeof(*node));
+     if (node == NULL) {
+         ERR_raise(ERR_LIB_X509V3, ERR_R_MALLOC_FAILURE);
+@@ -70,7 +75,7 @@ X509_POLICY_NODE *ossl_policy_level_add_node(X509_POLICY_LEVEL *level,
+     }
+     node->data = data;
+     node->parent = parent;
+-    if (level) {
++    if (level != NULL) {
+         if (OBJ_obj2nid(data->valid_policy) == NID_any_policy) {
+             if (level->anyPolicy)
+                 goto node_error;
+@@ -90,7 +95,7 @@ X509_POLICY_NODE *ossl_policy_level_add_node(X509_POLICY_LEVEL *level,
+         }
+     }
+ 
+-    if (tree) {
++    if (extra_data) {
+         if (tree->extra_data == NULL)
+             tree->extra_data = sk_X509_POLICY_DATA_new_null();
+         if (tree->extra_data == NULL){
+@@ -103,6 +108,7 @@ X509_POLICY_NODE *ossl_policy_level_add_node(X509_POLICY_LEVEL *level,
+         }
+     }
+ 
++    tree->node_count++;
+     if (parent)
+         parent->nchild++;
+ 
+diff --git a/crypto/x509/pcy_tree.c b/crypto/x509/pcy_tree.c
+index fa45da5117..f953a05a41 100644
+--- a/crypto/x509/pcy_tree.c
++++ b/crypto/x509/pcy_tree.c
+@@ -14,6 +14,17 @@
+ 
+ #include "pcy_local.h"
+ 
++/*
++ * If the maximum number of nodes in the policy tree isn't defined, set it to
++ * a generous default of 1000 nodes.
++ *
++ * Defining this to be zero means unlimited policy tree growth which opens the
++ * door on CVE-2023-0464.
++ */
++#ifndef OPENSSL_POLICY_TREE_NODES_MAX
++# define OPENSSL_POLICY_TREE_NODES_MAX 1000
++#endif
++
+ static void expected_print(BIO *channel,
+                            X509_POLICY_LEVEL *lev, X509_POLICY_NODE *node,
+                            int indent)
+@@ -163,6 +174,9 @@ static int tree_init(X509_POLICY_TREE **ptree, STACK_OF(X509) *certs,
+         return X509_PCY_TREE_INTERNAL;
+     }
+ 
++    /* Limit the growth of the tree to mitigate CVE-2023-0464 */
++    tree->node_maximum = OPENSSL_POLICY_TREE_NODES_MAX;
++
+     /*
+      * http://tools.ietf.org/html/rfc5280#section-6.1.2, figure 3.
+      *
+@@ -180,7 +194,7 @@ static int tree_init(X509_POLICY_TREE **ptree, STACK_OF(X509) *certs,
+     if ((data = ossl_policy_data_new(NULL,
+                                      OBJ_nid2obj(NID_any_policy), 0)) == NULL)
+         goto bad_tree;
+-    if (ossl_policy_level_add_node(level, data, NULL, tree) == NULL) {
++    if (ossl_policy_level_add_node(level, data, NULL, tree, 1) == NULL) {
+         ossl_policy_data_free(data);
+         goto bad_tree;
+     }
+@@ -239,7 +253,8 @@ static int tree_init(X509_POLICY_TREE **ptree, STACK_OF(X509) *certs,
+  * Return value: 1 on success, 0 otherwise
+  */
+ static int tree_link_matching_nodes(X509_POLICY_LEVEL *curr,
+-                                    X509_POLICY_DATA *data)
++                                    X509_POLICY_DATA *data,
++                                    X509_POLICY_TREE *tree)
+ {
+     X509_POLICY_LEVEL *last = curr - 1;
+     int i, matched = 0;
+@@ -249,13 +264,13 @@ static int tree_link_matching_nodes(X509_POLICY_LEVEL *curr,
+         X509_POLICY_NODE *node = sk_X509_POLICY_NODE_value(last->nodes, i);
+ 
+         if (ossl_policy_node_match(last, node, data->valid_policy)) {
+-            if (ossl_policy_level_add_node(curr, data, node, NULL) == NULL)
++            if (ossl_policy_level_add_node(curr, data, node, tree, 0) == NULL)
+                 return 0;
+             matched = 1;
+         }
+     }
+     if (!matched && last->anyPolicy) {
+-        if (ossl_policy_level_add_node(curr, data, last->anyPolicy, NULL) == NULL)
++        if (ossl_policy_level_add_node(curr, data, last->anyPolicy, tree, 0) == NULL)
+             return 0;
+     }
+     return 1;
+@@ -268,7 +283,8 @@ static int tree_link_matching_nodes(X509_POLICY_LEVEL *curr,
+  * Return value: 1 on success, 0 otherwise.
+  */
+ static int tree_link_nodes(X509_POLICY_LEVEL *curr,
+-                           const X509_POLICY_CACHE *cache)
++                           const X509_POLICY_CACHE *cache,
++                           X509_POLICY_TREE *tree)
+ {
+     int i;
+ 
+@@ -276,7 +292,7 @@ static int tree_link_nodes(X509_POLICY_LEVEL *curr,
+         X509_POLICY_DATA *data = sk_X509_POLICY_DATA_value(cache->data, i);
+ 
+         /* Look for matching nodes in previous level */
+-        if (!tree_link_matching_nodes(curr, data))
++        if (!tree_link_matching_nodes(curr, data, tree))
+             return 0;
+     }
+     return 1;
+@@ -307,7 +323,7 @@ static int tree_add_unmatched(X509_POLICY_LEVEL *curr,
+     /* Curr may not have anyPolicy */
+     data->qualifier_set = cache->anyPolicy->qualifier_set;
+     data->flags |= POLICY_DATA_FLAG_SHARED_QUALIFIERS;
+-    if (ossl_policy_level_add_node(curr, data, node, tree) == NULL) {
++    if (ossl_policy_level_add_node(curr, data, node, tree, 1) == NULL) {
+         ossl_policy_data_free(data);
+         return 0;
+     }
+@@ -370,7 +386,7 @@ static int tree_link_any(X509_POLICY_LEVEL *curr,
+     /* Finally add link to anyPolicy */
+     if (last->anyPolicy &&
+             ossl_policy_level_add_node(curr, cache->anyPolicy,
+-                                       last->anyPolicy, NULL) == NULL)
++                                       last->anyPolicy, tree, 0) == NULL)
+         return 0;
+     return 1;
+ }
+@@ -553,7 +569,7 @@ static int tree_calculate_user_set(X509_POLICY_TREE *tree,
+             extra->flags = POLICY_DATA_FLAG_SHARED_QUALIFIERS
+                 | POLICY_DATA_FLAG_EXTRA_NODE;
+             node = ossl_policy_level_add_node(NULL, extra, anyPolicy->parent,
+-                                              tree);
++                                              tree, 1);
+         }
+         if (!tree->user_policies) {
+             tree->user_policies = sk_X509_POLICY_NODE_new_null();
+@@ -580,7 +596,7 @@ static int tree_evaluate(X509_POLICY_TREE *tree)
+ 
+     for (i = 1; i < tree->nlevel; i++, curr++) {
+         cache = ossl_policy_cache_set(curr->cert);
+-        if (!tree_link_nodes(curr, cache))
++        if (!tree_link_nodes(curr, cache, tree))
+             return X509_PCY_TREE_INTERNAL;
+ 
+         if (!(curr->flags & X509_V_FLAG_INHIBIT_ANY)

--- a/sdk_container/src/third_party/coreos-overlay/dev-libs/openssl/files/openssl-3.0.8-CVE-2023-0465.patch
+++ b/sdk_container/src/third_party/coreos-overlay/dev-libs/openssl/files/openssl-3.0.8-CVE-2023-0465.patch
@@ -1,0 +1,46 @@
+commit 1dd43e0709fece299b15208f36cc7c76209ba0bb
+Author: Matt Caswell <matt@openssl.org>
+Date:   Tue Mar 7 16:52:55 2023 +0000
+
+    Ensure that EXFLAG_INVALID_POLICY is checked even in leaf certs
+    
+    Even though we check the leaf cert to confirm it is valid, we
+    later ignored the invalid flag and did not notice that the leaf
+    cert was bad.
+    
+    Fixes: CVE-2023-0465
+    
+    Reviewed-by: Hugo Landau <hlandau@openssl.org>
+    Reviewed-by: Tomas Mraz <tomas@openssl.org>
+    (Merged from https://github.com/openssl/openssl/pull/20587)
+
+diff --git a/crypto/x509/x509_vfy.c b/crypto/x509/x509_vfy.c
+index 9384f1da9b..a0282c3ef1 100644
+--- a/crypto/x509/x509_vfy.c
++++ b/crypto/x509/x509_vfy.c
+@@ -1654,15 +1654,23 @@ static int check_policy(X509_STORE_CTX *ctx)
+         goto memerr;
+     /* Invalid or inconsistent extensions */
+     if (ret == X509_PCY_TREE_INVALID) {
+-        int i;
++        int i, cbcalled = 0;
+ 
+         /* Locate certificates with bad extensions and notify callback. */
+-        for (i = 1; i < sk_X509_num(ctx->chain); i++) {
++        for (i = 0; i < sk_X509_num(ctx->chain); i++) {
+             X509 *x = sk_X509_value(ctx->chain, i);
+ 
++            if ((x->ex_flags & EXFLAG_INVALID_POLICY) != 0)
++                cbcalled = 1;
+             CB_FAIL_IF((x->ex_flags & EXFLAG_INVALID_POLICY) != 0,
+                        ctx, x, i, X509_V_ERR_INVALID_POLICY_EXTENSION);
+         }
++        if (!cbcalled) {
++            /* Should not be able to get here */
++            ERR_raise(ERR_LIB_X509, ERR_R_INTERNAL_ERROR);
++            return 0;
++        }
++        /* The callback ignored the error so we return success */
+         return 1;
+     }
+     if (ret == X509_PCY_TREE_FAILURE) {

--- a/sdk_container/src/third_party/coreos-overlay/dev-libs/openssl/files/openssl-3.0.8-CVE-2023-0466.patch
+++ b/sdk_container/src/third_party/coreos-overlay/dev-libs/openssl/files/openssl-3.0.8-CVE-2023-0466.patch
@@ -1,0 +1,41 @@
+commit 51e8a84ce742db0f6c70510d0159dad8f7825908
+Author: Tomas Mraz <tomas@openssl.org>
+Date:   Tue Mar 21 16:15:47 2023 +0100
+
+    Fix documentation of X509_VERIFY_PARAM_add0_policy()
+    
+    The function was incorrectly documented as enabling policy checking.
+    
+    Fixes: CVE-2023-0466
+    
+    Reviewed-by: Matt Caswell <matt@openssl.org>
+    Reviewed-by: Paul Dale <pauli@openssl.org>
+    (Merged from https://github.com/openssl/openssl/pull/20563)
+
+diff --git a/doc/man3/X509_VERIFY_PARAM_set_flags.pod b/doc/man3/X509_VERIFY_PARAM_set_flags.pod
+index 75a1677022..43c1900bca 100644
+--- a/doc/man3/X509_VERIFY_PARAM_set_flags.pod
++++ b/doc/man3/X509_VERIFY_PARAM_set_flags.pod
+@@ -98,8 +98,9 @@ B<trust>.
+ X509_VERIFY_PARAM_set_time() sets the verification time in B<param> to
+ B<t>. Normally the current time is used.
+ 
+-X509_VERIFY_PARAM_add0_policy() enables policy checking (it is disabled
+-by default) and adds B<policy> to the acceptable policy set.
++X509_VERIFY_PARAM_add0_policy() adds B<policy> to the acceptable policy set.
++Contrary to preexisting documentation of this function it does not enable
++policy checking.
+ 
+ X509_VERIFY_PARAM_set1_policies() enables policy checking (it is disabled
+ by default) and sets the acceptable policy set to B<policies>. Any existing
+@@ -400,6 +401,10 @@ The X509_VERIFY_PARAM_get_hostflags() function was added in OpenSSL 1.1.0i.
+ The X509_VERIFY_PARAM_get0_host(), X509_VERIFY_PARAM_get0_email(),
+ and X509_VERIFY_PARAM_get1_ip_asc() functions were added in OpenSSL 3.0.
+ 
++The function X509_VERIFY_PARAM_add0_policy() was historically documented as
++enabling policy checking however the implementation has never done this.
++The documentation was changed to align with the implementation.
++
+ =head1 COPYRIGHT
+ 
+ Copyright 2009-2023 The OpenSSL Project Authors. All Rights Reserved.

--- a/sdk_container/src/third_party/coreos-overlay/dev-libs/openssl/files/openssl-3.0.8-CVE-2023-1255.patch
+++ b/sdk_container/src/third_party/coreos-overlay/dev-libs/openssl/files/openssl-3.0.8-CVE-2023-1255.patch
@@ -1,0 +1,40 @@
+commit 02ac9c9420275868472f33b01def01218742b8bb
+Author: Tomas Mraz <tomas@openssl.org>
+Date:   Mon Apr 17 16:51:20 2023 +0200
+
+    aesv8-armx.pl: Avoid buffer overrread in AES-XTS decryption
+    
+    Original author: Nevine Ebeid (Amazon)
+    Fixes: CVE-2023-1255
+    
+    The buffer overread happens on decrypts of 4 mod 5 sizes.
+    Unless the memory just after the buffer is unmapped this is harmless.
+    
+    Reviewed-by: Paul Dale <pauli@openssl.org>
+    Reviewed-by: Tom Cosgrove <tom.cosgrove@arm.com>
+    (Merged from https://github.com/openssl/openssl/pull/20759)
+    
+    (cherry picked from commit 72dfe46550ee1f1bbfacd49f071419365bc23304)
+
+diff --git a/crypto/aes/asm/aesv8-armx.pl b/crypto/aes/asm/aesv8-armx.pl
+index 6a7bf05d1b..bd583e2c89 100755
+--- a/crypto/aes/asm/aesv8-armx.pl
++++ b/crypto/aes/asm/aesv8-armx.pl
+@@ -3353,7 +3353,7 @@ $code.=<<___	if ($flavour =~ /64/);
+ .align	4
+ .Lxts_dec_tail4x:
+ 	add	$inp,$inp,#16
+-	vld1.32	{$dat0},[$inp],#16
++	tst	$tailcnt,#0xf
+ 	veor	$tmp1,$dat1,$tmp0
+ 	vst1.8	{$tmp1},[$out],#16
+ 	veor	$tmp2,$dat2,$tmp2
+@@ -3362,6 +3362,8 @@ $code.=<<___	if ($flavour =~ /64/);
+ 	veor	$tmp4,$dat4,$tmp4
+ 	vst1.8	{$tmp3-$tmp4},[$out],#32
+ 
++	b.eq	.Lxts_dec_abort
++	vld1.32	{$dat0},[$inp],#16
+ 	b	.Lxts_done
+ .align	4
+ .Lxts_outer_dec_tail:

--- a/sdk_container/src/third_party/coreos-overlay/dev-libs/openssl/files/openssl-3.0.8-mips-cflags.patch
+++ b/sdk_container/src/third_party/coreos-overlay/dev-libs/openssl/files/openssl-3.0.8-mips-cflags.patch
@@ -1,0 +1,30 @@
+https://bugs.gentoo.org/894140
+https://github.com/openssl/openssl/issues/20214
+
+From d500b51791cd56e73065e3a7f4487fc33f31c91c Mon Sep 17 00:00:00 2001
+From: Mike Gilbert <floppym@gentoo.org>
+Date: Sun, 12 Feb 2023 17:56:58 -0500
+Subject: [PATCH] Fix Configure test for -mips in CFLAGS
+
+We want to add -mips2 or -mips3 only if the user hasn't already
+specified a mips version in CFLAGS. The existing test was a
+double-negative.
+
+Fixes: https://github.com/openssl/openssl/issues/20214
+---
+ Configure | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Configure b/Configure
+index b6bbec0a85c4..ec48614d6b99 100755
+--- a/Configure
++++ b/Configure
+@@ -1475,7 +1475,7 @@ if ($target =~ /^mingw/ && `$config{CC} --target-help 2>&1` =~ m/-mno-cygwin/m)
+         }
+ 
+ if ($target =~ /linux.*-mips/ && !$disabled{asm}
+-        && !grep { $_ !~ /-m(ips|arch=)/ } (@{$config{CFLAGS}})) {
++        && !grep { $_ =~ /-m(ips|arch=)/ } (@{$config{CFLAGS}})) {
+         # minimally required architecture flags for assembly modules
+         my $value;
+         $value = '-mips2' if ($target =~ /mips32/);

--- a/sdk_container/src/third_party/coreos-overlay/dev-libs/openssl/files/openssl.conf
+++ b/sdk_container/src/third_party/coreos-overlay/dev-libs/openssl/files/openssl.conf
@@ -1,0 +1,3 @@
+d      /etc/ssl                -       -       -       -       -
+d      /etc/ssl/private        0700    -       -       -       -
+L      /etc/ssl/openssl.cnf    -       -       -       -       ../../usr/share/ssl/openssl.cnf

--- a/sdk_container/src/third_party/coreos-overlay/dev-libs/openssl/files/openssl.conf
+++ b/sdk_container/src/third_party/coreos-overlay/dev-libs/openssl/files/openssl.conf
@@ -1,3 +1,0 @@
-d      /etc/ssl                -       -       -       -       -
-d      /etc/ssl/private        0700    -       -       -       -
-L      /etc/ssl/openssl.cnf    -       -       -       -       ../../usr/share/ssl/openssl.cnf

--- a/sdk_container/src/third_party/coreos-overlay/dev-libs/openssl/openssl-3.0.8-r4.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/dev-libs/openssl/openssl-3.0.8-r4.ebuild
@@ -4,7 +4,8 @@
 EAPI=8
 
 VERIFY_SIG_OPENPGP_KEY_PATH="${BROOT}"/usr/share/openpgp-keys/openssl.org.asc
-inherit edo flag-o-matic linux-info toolchain-funcs multilib-minimal multiprocessing verify-sig
+TMPFILES_OPTIONAL=1
+inherit edo flag-o-matic linux-info toolchain-funcs multilib-minimal multiprocessing verify-sig systemd tmpfiles
 
 DESCRIPTION="Robust, full-featured Open Source Toolkit for the Transport Layer Security (TLS)"
 HOMEPAGE="https://www.openssl.org/"
@@ -18,7 +19,7 @@ if [[ ${PV} == 9999 ]] ; then
 else
 	SRC_URI="mirror://openssl/source/${MY_P}.tar.gz
 		verify-sig? ( mirror://openssl/source/${MY_P}.tar.gz.asc )"
-	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~arm64-macos"
+	KEYWORDS="~alpha amd64 ~arm arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86 ~arm64-macos"
 fi
 
 S="${WORKDIR}"/${MY_P}
@@ -28,7 +29,11 @@ SLOT="0/3" # .so version of libssl/libcrypto
 IUSE="+asm cpu_flags_x86_sse2 fips ktls rfc3779 sctp static-libs test tls-compression vanilla verify-sig weak-ssl-ciphers"
 RESTRICT="!test? ( test )"
 
+# Flatcar: Gentoo dropped dependency on c_rehash, a required tool for
+# generating certs, and does not provide a built-in tool either.
+# Continue shipping it.
 COMMON_DEPEND="
+	>=app-misc/c_rehash-1.7-r1
 	tls-compression? ( >=sys-libs/zlib-1.2.8-r1[static-libs(+)?,${MULTILIB_USEDEP}] )
 "
 BDEPEND="
@@ -252,15 +257,21 @@ multilib_src_install_all() {
 
 	dodoc {AUTHORS,CHANGES,NEWS,README,README-PROVIDERS}.md doc/*.txt doc/${PN}-c-indent.el
 
-	# Create the certs directory
-	keepdir ${SSL_CNF_DIR}/certs
-
 	# bug #254521
 	dodir /etc/sandbox.d
 	echo 'SANDBOX_PREDICT="/dev/crypto"' > "${ED}"/etc/sandbox.d/10openssl
 
-	diropts -m0700
-	keepdir ${SSL_CNF_DIR}/private
+	# flatcar changes: do not keep the sample CA files in `/etc`
+	rm -rf "${ED}"${SSL_CNF_DIR}
+
+	# flatcar changes: save the default `openssl.cnf` in `/usr`
+	dodir /usr/share/ssl
+	insinto /usr/share/ssl
+	doins "${S}"/apps/openssl.cnf
+	dotmpfiles "${FILESDIR}"/openssl.conf
+
+	# flatcar changes: package `tmpfiles.d` setup for SDK bootstrapping.
+	systemd-tmpfiles --create --root="${ED}" "${FILESDIR}"/openssl.conf
 }
 
 pkg_preinst() {
@@ -274,8 +285,3 @@ pkg_preinst() {
 	fi
 }
 
-pkg_postinst() {
-	ebegin "Running 'openssl rehash ${EROOT}${SSL_CNF_DIR}/certs' to rebuild hashes (bug #333069)"
-	openssl rehash "${EROOT}${SSL_CNF_DIR}/certs"
-	eend $?
-}


### PR DESCRIPTION
Update `dev-libs/openssl` to 3.0.8-r4, mainly to address the following security issues:
* [CVE-2023-0464](https://nvd.nist.gov/vuln/detail/CVE-2023-0464)
* [CVE-2023-0465](https://nvd.nist.gov/vuln/detail/CVE-2023-0465)
* [CVE-2023-0466](https://nvd.nist.gov/vuln/detail/CVE-2023-0466)
* [CVE-2023-1255](https://nvd.nist.gov/vuln/detail/CVE-2023-1255)

Based on Gentoo commit [bebe8fa4ec3e](https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=bebe8fa4ec3ef6b87551157f4e13755956936aa3).

Flatcar changes are based on [9cd2474a4950](https://github.com/flatcar/scripts/commit/9cd2474a49507794ef5fdcf053fbe82716bba0f0).

## Testing done

CI: http://jenkins.infra.kinvolk.io:8080/job/container/job/sdk/788/cldsv/

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [x] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
