### PR TITLE
.github: check for remote branches with git ls-remote

### DIFF
--- a/.github/workflows/common.sh
+++ b/.github/workflows/common.sh
@@ -66,8 +66,7 @@ function prepare_git_repo() {
 
 function check_remote_branch() {
   local target_branch="${1}"
-
-  if git -C "${SDK_OUTER_TOPDIR}" show-ref "remotes/origin/${target_branch}"; then
+  if git -C "${SDK_OUTER_TOPDIR}" ls-remote --refs --heads --exit-code origin "${target_branch}" >/dev/null; then
     return 1
   fi
   return 0


### PR DESCRIPTION
`git show-ref` in `check_remote_branch` is not working at all, because the GitHub Actions checkout fetches a git repo with only depth 1 by default. That means only main branch is available, not any other remote branches. As a result, `git show-ref` always fails.

Fix that by checking for remote branches by `git ls-remote`.

Fixes bugs resulted from https://github.com/flatcar/scripts/pull/784.

## Testing done

tested via my fork