### PR TITLE
ci-automation: Follow-up fix for 2-phase nightly SDK build tags

### DIFF
--- a/ci-automation/ci_automation_common.sh
+++ b/ci-automation/ci_automation_common.sh
@@ -23,7 +23,7 @@ function check_version_string() {
 
 function update_and_push_version() {
     local version="$1"
-    local push_to_branch="${2:-false}"
+    local target_branch="${2:-}"
 
     # set up author and email so git does not complain when tagging
     if ! git config --get user.name >/dev/null 2>&1 ; then
@@ -64,9 +64,8 @@ function update_and_push_version() {
 
     git tag -f "${TAG_ARGS[@]}" "${version}"
 
-    if [ "${push_to_branch}" = "true" ]; then
-      local branch="$(git rev-parse --abbrev-ref HEAD)"
-      git push origin "${branch}"
+    if [[ -n "${target_branch}" ]]; then
+      git push origin "HEAD:${target_branch}"
     fi
 
     git push origin "${version}"

--- a/ci-automation/packages-tag.sh
+++ b/ci-automation/packages-tag.sh
@@ -70,8 +70,16 @@ function _packages_tag_impl() {
     # Also push the changes to the branch ONLY IF we're doing a nightly
     #   build of the 'flatcar-MAJOR' branch AND we're definitely ON the respective branch
     local target_branch=''
-    if    [[ "${version}" =~ ^(stable|alpha|beta|lts)-[0-9.]+-nightly-[-0-9]+$ ]] \
-       && [[ "$(git rev-parse --abbrev-ref HEAD)" =~ ^flatcar-[0-9]+$ ]] ; then
+    # These variables are here to make it easier to test nightly
+    # builds without messing with actual release branches.
+    local flatcar_branch_prefix='flatcar'
+    local nightly='nightly'
+    # Patterns used below.
+    local nightly_pattern_1='^(stable|alpha|beta|lts)-[0-9.]+-'"${nightly}"'-[-0-9]+$'
+    local nightly_pattern_2='^(stable|alpha|beta|lts)-[0-9.]+(|-'"${nightly}"'-[-0-9]+)$'
+    local flatcar_pattern='^'"${flatcar_branch_prefix}"'-[0-9]+$'
+    if    [[ "${version}" =~ ${nightly_pattern_1} ]] \
+       && [[ "$(git rev-parse --abbrev-ref HEAD)" =~ ${flatcar_pattern} ]] ; then
         target_branch="$(git rev-parse --abbrev-ref HEAD)"
         local existing_tag=""
         # Check for the existing tag only when we allow shortcutting
@@ -83,7 +91,7 @@ function _packages_tag_impl() {
             existing_tag=$(git tag --points-at HEAD) # exit code is always 0, output may be empty
         fi
         # If the found tag is a release or nightly tag, we stop this build if there are no changes
-        if [[ "${existing_tag}" =~ ^(stable|alpha|beta|lts)-[0-9.]+(|-nightly-[-0-9]+)$ ]]; then
+        if [[ "${existing_tag}" =~ ${nightly_pattern_2} ]]; then
           local ret=0
           git diff --exit-code "${existing_tag}" || ret=$?
           if [[ ret -eq 0 ]]; then

--- a/ci-automation/packages-tag.sh
+++ b/ci-automation/packages-tag.sh
@@ -68,11 +68,11 @@ function _packages_tag_impl() {
 
     # Create new tag in scripts repo w/ updated versionfile
     # Also push the changes to the branch ONLY IF we're doing a nightly
-    #   build of the 'main'/'flatcar-MAJOR' branch AND we're definitely ON the respective branch
-    local push_branch="false"
+    #   build of the 'flatcar-MAJOR' branch AND we're definitely ON the respective branch
+    local target_branch=''
     if    [[ "${version}" =~ ^(stable|alpha|beta|lts)-[0-9.]+-nightly-[-0-9]+$ ]] \
        && [[ "$(git rev-parse --abbrev-ref HEAD)" =~ ^flatcar-[0-9]+$ ]] ; then
-        push_branch="true"
+        target_branch="$(git rev-parse --abbrev-ref HEAD)"
         local existing_tag=""
         # Check for the existing tag only when we allow shortcutting
         # the builds. That way we can skip the checks for build
@@ -108,7 +108,7 @@ function _packages_tag_impl() {
       source sdk_lib/sdk_container_common.sh
       create_versionfile "$sdk_version" "$version"
     )
-    update_and_push_version "${version}" "${push_branch}"
+    update_and_push_version "${version}" "${target_branch}"
     apply_local_patches
 }
 # --

--- a/ci-automation/sdk_bootstrap.sh
+++ b/ci-automation/sdk_bootstrap.sh
@@ -78,10 +78,10 @@ function _sdk_bootstrap_impl() {
     # Also push the changes to the branch ONLY IF we're doing a nightly
     #   build of the 'main' branch AND we're definitely ON the main branch.
     #   This includes intermediate SDKs when doing 2-phase nightly builds.
-    local push_branch="false"
+    local target_branch=''
     if   [[ "${version}" =~ ^main-[0-9.]+-nightly-[-0-9]+(-INTERMEDIATE)?$ ]] \
-       && [ "$(git rev-parse --abbrev-ref HEAD)" = "main"  ] ; then
-        push_branch="true"
+       && [ "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)"  ] ; then
+        target_branch='main'
         local existing_tag=""
         # Check for the existing tag only when we allow shortcutting
         # the builds. That way we can skip the checks for build
@@ -132,7 +132,7 @@ function _sdk_bootstrap_impl() {
       source sdk_lib/sdk_container_common.sh
       create_versionfile "${vernum}"
     )
-    update_and_push_version "${version}" "${push_branch}"
+    update_and_push_version "${version}" "${target_branch}"
     apply_local_patches
 
     ./bootstrap_sdk_container -x ./ci-cleanup.sh "${seed_version}" "${vernum}"

--- a/ci-automation/sdk_bootstrap.sh
+++ b/ci-automation/sdk_bootstrap.sh
@@ -79,9 +79,16 @@ function _sdk_bootstrap_impl() {
     #   build of the 'main' branch AND we're definitely ON the main branch.
     #   This includes intermediate SDKs when doing 2-phase nightly builds.
     local target_branch=''
-    if   [[ "${version}" =~ ^main-[0-9.]+-nightly-[-0-9]+(-INTERMEDIATE)?$ ]] \
-       && [ "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)"  ] ; then
-        target_branch='main'
+    # These variables are here to make it easier to test nightly
+    # builds without messing with actual release branches.
+    local main_branch='main'
+    local nightly='nightly'
+    # Patterns used below.
+    local nightly_pattern_1='^main-[0-9.]+-'"${nightly}"'-[-0-9]+(-INTERMEDIATE)?$'
+    local nightly_pattern_2='^main-[0-9.]+-'"${nightly}"'-[-0-9]+$'
+    if   [[ "${version}" =~ ${nightly_pattern_1} ]] \
+       && [ "$(git rev-parse HEAD)" = "$(git rev-parse "origin/${main_branch}")"  ] ; then
+        target_branch=${main_branch}
         local existing_tag=""
         # Check for the existing tag only when we allow shortcutting
         # the builds. That way we can skip the checks for build
@@ -92,7 +99,7 @@ function _sdk_bootstrap_impl() {
             existing_tag=$(git tag --points-at HEAD) # exit code is always 0, output may be empty
         fi
         # If the found tag is a nightly tag, we stop this build if there are no changes
-        if [[ "${existing_tag}" =~ ^main-[0-9.]+-nightly-[-0-9]+$ ]]; then
+        if [[ "${existing_tag}" =~ ${nightly_pattern_2} ]]; then
           local ret=0
           git diff --exit-code "${existing_tag}" || ret=$?
           if [ "$ret" = "0" ]; then


### PR DESCRIPTION
We push a commit with the nightly SDK tag to the main branch if the SDK was built from the main branch. Which is what happens when we build the nightly intermediate SDK. The final nightly SDK is not built from the main branch, but rather from the nightly intermediate SDK tag. Both of them point to the exactly same commit, but the difference is in what `git rev-parse --abbrev-ref HEAD` returns for each of those. When the main branch is checked out, the command will return "main". When the nightly intermediate SDK tag is checked out, the command will return "HEAD". So when nightly final SDK is being built, the command returns a string different than "main" and thus decides not to push the commit with the final nightly SDK tag to the main branch. Rework it to assume that if `git rev-parse HEAD` and `git rev-parse main` return the same commit hash (and it's the nightly build and all that) then the commit should be pushed.
