### PR TITLE
Enable elfutils flag for systemd to get coredump stacktraces in journal

### DIFF
--- a/sdk_container/src/third_party/coreos-overlay/changelog/changes/2023-05-09-systemd-journal-stacktrace.md
+++ b/sdk_container/src/third_party/coreos-overlay/changelog/changes/2023-05-09-systemd-journal-stacktrace.md
@@ -1,0 +1,1 @@
+- Enabled support for coredump stacktraces in the system journal ([]())

--- a/sdk_container/src/third_party/coreos-overlay/profiles/coreos/base/package.use
+++ b/sdk_container/src/third_party/coreos-overlay/profiles/coreos/base/package.use
@@ -31,7 +31,7 @@ app-admin/sudo -sendmail
 
 # disable hybrid cgroup as we use the unified mode now
 # use lzma which is the default on non-gentoo systems, enable selinux,
-sys-apps/systemd -cgroup-hybrid curl idn lzma selinux
+sys-apps/systemd -cgroup-hybrid curl elfutils idn lzma selinux
 net-libs/libmicrohttpd -ssl
 
 # disable kernel config detection and module building


### PR DESCRIPTION
When encountering https://github.com/systemd/systemd/issues/27491 no debug info is available when the coredump file is not found (e.g., because it's cleaned up). Normally a stracktrace is included in the journal but the ebuild feature is disabled.
Enable the elfutils ebuild feature for systemd to get coredump stacktraces in the system journal.

## How to use

todo: insert link in changelog

## Testing done

todo: check that the feature gets enabled
[build running](http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/1786/cldsv/)

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
