### PR TITLE
coreos-base/coreos-cloudinit: Update to latest commit

### DIFF
--- a/changelog/changes/2023-05-12-coreos-cloudinit.md
+++ b/changelog/changes/2023-05-12-coreos-cloudinit.md
@@ -1,0 +1,1 @@
+- Update coreos-cloudinit to the [latest commit](https://github.com/flatcar/coreos-cloudinit/commit/89319292b9bca85a7a1f5f8a47c459dd45a8cc7a). This commit changes how coreos-cloudinit sets the hostname fetched from the metadata service. The short form hostname is now set as opposed to the FQDN.

--- a/changelog/changes/2023-05-12-coreos-cloudinit.md
+++ b/changelog/changes/2023-05-12-coreos-cloudinit.md
@@ -1,1 +1,1 @@
-- Update coreos-cloudinit to the [latest commit](https://github.com/flatcar/coreos-cloudinit/commit/89319292b9bca85a7a1f5f8a47c459dd45a8cc7a). This commit changes how coreos-cloudinit sets the hostname fetched from the metadata service. The short form hostname is now set as opposed to the FQDN.
+- Changed coreos-cloudinit to now set the short hostname instead of the FQDN when fetched from the metadata service ([coreos-cloudinit#19](https://github.com/flatcar/coreos-cloudinit/pull/19))

--- a/sdk_container/src/third_party/coreos-overlay/coreos-base/coreos-cloudinit/coreos-cloudinit-9999.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/coreos-base/coreos-cloudinit/coreos-cloudinit-9999.ebuild
@@ -12,7 +12,7 @@ inherit cros-workon systemd toolchain-funcs udev coreos-go
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm64"
 else
-	CROS_WORKON_COMMIT="2c383a41a1718f66be2add7f58a885df5b89d86f" # flatcar-master
+	CROS_WORKON_COMMIT="89319292b9bca85a7a1f5f8a47c459dd45a8cc7a" # flatcar-master
 	KEYWORDS="amd64 arm64"
 fi
 


### PR DESCRIPTION
Upgrade ```coreos-cloudinit``` to [89319292b9bca85a7a1f5f8a47c459dd45a8cc7a](https://github.com/flatcar/coreos-cloudinit/commit/89319292b9bca85a7a1f5f8a47c459dd45a8cc7a)

This change adds the short form of the hostname retrieved from metadata.

## Testing done

Deployed a VM on OpenStack and inspected ```/etc/hostname```. The hostname was set to the short form instead of the FQDN.