### PR TITLE
Fix workflow typo

### DIFF
--- a/.github/workflows/pr-comment-build-dispatcher.yaml
+++ b/.github/workflows/pr-comment-build-dispatcher.yaml
@@ -15,8 +15,7 @@ jobs:
     # Only run if this is a PR comment that contains a valid command
     if: |
       ${{ github.event.issue.pull_request }} &&
-        (    contains(github.event.comment.body, '/update-sdk')
-          || contains(github.event.comment.body, '/build-image') )
+        (    contains(github.event.comment.body, '/update-sdk') || contains(github.event.comment.body, '/build-image') )
     name: Check if commenter is in the Flatcar maintainers team
     outputs:
       maintainers: steps.step1.output.maintainers
@@ -60,10 +59,9 @@ jobs:
     uses: ./.github/workflows/update-sdk.yaml
 
   build_image:
-    needs: [ check_maintainer_membership, build_sdk ]
+    needs: [ check_maintainer_membership, update_sdk ]
     if: ( always() && needs.check_maintainer_membership.result == 'success'
-                   && (    contains(github.event.comment.body, '/build-image')
-                        || needs.build_sdk.result == 'success' ) )
+                   && (    contains(github.event.comment.body, '/build-image') || needs.update_sdk.result == 'success' ) )
     name: "Build the OS image"
     uses: ./.github/workflows/ci.yaml
     with:

--- a/.github/workflows/update-sdk.yaml
+++ b/.github/workflows/update-sdk.yaml
@@ -48,6 +48,7 @@ jobs:
 
     steps:
       - name: Prepare machine
+        id: step1
         shell: bash
         working-directory: ${{ github.workspace }}
         run: |
@@ -63,11 +64,13 @@ jobs:
           sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
 
       - uses: actions/checkout@v3
+        id: step2
         with:
           path: scripts
           fetch-depth: 0
 
       - name: Set environment
+        id: step3
         shell: bash
         run: |
           if [ -n "${{ github.event.inputs.source_sdk_version }}" ] ; then
@@ -78,6 +81,7 @@ jobs:
           fi
 
       - name: Build an updated SDK container
+        id: step4
         shell: bash
         run: |
           exec 2>&1
@@ -119,6 +123,7 @@ jobs:
           ./update_sdk_container_image "${target_version}"
 
       - name: Upload the SDK container and binary packages to bincache
+        id: step5
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
# Fix typo in workflow

There is a typo in ```pr-comment-build-dispatcher.yaml``` that prevents it from running. Example:

https://github.com/flatcar/scripts/actions/runs/5055309046

