### PR TITLE
workflows/pr-comment,run-kola: fix concurrency + results comment

### DIFF
--- a/.github/workflows/pr-comment-build-dispatcher.yaml
+++ b/.github/workflows/pr-comment-build-dispatcher.yaml
@@ -7,7 +7,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{ github.workflow }}-pr-command-${{ github.head_ref || github.ref_name }}
+  group: ${{ github.workflow }}-pr-command-${{ github.event.issue.pull_request.number }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pr-comment-build-dispatcher.yaml
+++ b/.github/workflows/pr-comment-build-dispatcher.yaml
@@ -57,8 +57,8 @@ jobs:
 
   update_sdk:
     needs: check_maintainer_membership
-    if: ( always() && needs.check_maintainer_membership.result == 'success'
-                   && contains(github.event.comment.body, '/update-sdk') )
+    if: ( needs.check_maintainer_membership.result == 'success'
+           && contains(github.event.comment.body, '/update-sdk') )
     name: "Build an updated SDK container"
     # SDK build needs access to bincache ssh secret
     secrets: inherit
@@ -66,8 +66,8 @@ jobs:
 
   build_image:
     needs: [ check_maintainer_membership, update_sdk ]
-    if: ( always() && needs.check_maintainer_membership.result == 'success'
-                   && (    contains(github.event.comment.body, '/build-image') || needs.update_sdk.result == 'success' ) )
+    if: ( needs.check_maintainer_membership.result == 'success'
+          && (    contains(github.event.comment.body, '/build-image') || needs.update_sdk.result == 'success' ) )
     name: "Build the OS image"
     uses: ./.github/workflows/ci.yaml
     with:

--- a/.github/workflows/pr-comment-build-dispatcher.yaml
+++ b/.github/workflows/pr-comment-build-dispatcher.yaml
@@ -49,6 +49,12 @@ jobs:
 
           $res
 
+      - name: Post a link to the workflow run to the PR
+        uses: mshick/add-pr-comment@v2
+        with:
+          issue: ${{ github.event.issue.pull_request.number }}
+          message: "Build action triggered: [${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+
   update_sdk:
     needs: check_maintainer_membership
     if: ( always() && needs.check_maintainer_membership.result == 'success'

--- a/.github/workflows/run-kola-tests.yaml
+++ b/.github/workflows/run-kola-tests.yaml
@@ -351,8 +351,9 @@ jobs:
 
           cat test-results.md >> "$GITHUB_STEP_SUMMARY"
 
-      - name: If started from a PR, post test summary to PR
-        if: ${{ github.event_name == 'pull_request' }}
+      - name: If started from a PR event or a PR comment command, post test summary to PR
+        if: ${{ github.event_name == 'pull_request' || github.event.issue.pull_request }}
         uses: mshick/add-pr-comment@v2
         with:
+          issue: ${{ github.event.pull_request.number || github.event.issue.pull_request.number }}
           message-path: "scripts/test-results.md"


### PR DESCRIPTION
This change includes 2 unrelated small fixes to the "PR comment command" build+test feature:

1. The concurrency group now contains the PR number, ensuring that builds for multiple PRs can run in parallel. This addresses an issue in which starting a build on a PR would cancel a running build of another PR.
2. Post test results to the PR where the build command was issued on. The add-pr-comment step's condition was not updated when switching to PR comment commands for starting builds, so the step would only run if the action was triggered by a PR change event. Since we now trigger on issue_comment, the step never ran.

Additionally, the PR from which a run was triggered will now receive a comment with a link to the workflow run.

Fixes [#1046](https://github.com/flatcar/Flatcar/issues/1046).