### PR TITLE
Add on pr workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,6 @@
 name: "Run build"
 on:
+  pull_request:
   workflow_dispatch:
     inputs:
       image_formats:
@@ -29,7 +30,7 @@ on:
           Custom SDK container version to use for this build.
 
 permissions:
-  pull-requests: write
+  pull-requests: write 
 
 jobs:
   packages:
@@ -39,6 +40,7 @@ jobs:
       - debian
       - build
       - x64
+    environment: main
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,5 @@
 name: "Run build"
 on:
-  pull_request:
   workflow_dispatch:
     inputs:
       image_formats:
@@ -30,7 +29,7 @@ on:
           Custom SDK container version to use for this build.
 
 permissions:
-  pull-requests: write 
+  pull-requests: write
 
 jobs:
   packages:
@@ -40,7 +39,6 @@ jobs:
       - debian
       - build
       - x64
-    environment: main
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pr-comment-build-dispatcher.yaml
+++ b/.github/workflows/pr-comment-build-dispatcher.yaml
@@ -13,11 +13,11 @@ concurrency:
 jobs:
   run_pre_checks:
     # Only run if this is a PR comment that contains a valid command
-    if: ${{ github.event.issue.pull_request }} && contains(github.event.comment.body, '/build-image')
+    if: ${{ github.event.issue.pull_request }} && ( contains(github.event.comment.body, '/build-image') || contains(github.event.comment.body, '/update-sdk'))
     name: Check if commenter is in the Flatcar maintainers team
     outputs:
       maintainers: steps.step1.output.maintainers
-      sdk_changes: steps.step3.outputs.sdk_changes
+      sdk_changes: ${{ steps.step3.outputs.sdk_changes }}
     runs-on:
       - ubuntu-latest
     steps:
@@ -49,29 +49,14 @@ jobs:
 
           $res
 
-      - uses: actions/checkout@v3
-        id: step2
-        with:
-          path: scripts
-          fetch-depth: 0
-  
-      - uses: dorny/paths-filter@v2
-        id: filter
-        with:
-          working-directory: scripts
-          filters: |
-            sdk_changes:
-              - 'sdk_container/**'
-              - 'sdk_libs/**'
-
       - name: Set outputs
-        id: step3
+        id: step2
         shell: bash
         run: |
-          echo "sdk_changes=${{ steps.filter.outputs.sdk_changes }}" >> $GITHUB_OUTPUT
+          echo "sdk_changes=${{ contains(github.event.comment.body, '/update-sdk') }}" >> $GITHUB_OUTPUT
 
       - name: Post a link to the workflow run to the PR
-        id: step4
+        id: step3
         uses: mshick/add-pr-comment@v2
         with:
           issue: ${{ github.event.issue.pull_request.number }}
@@ -87,7 +72,7 @@ jobs:
 
   build_image:
     needs: [ run_pre_checks, update_sdk ]
-    if: (always() && ! cancelled()) && needs.run_pre_checks.result == 'success' && contains(github.event.comment.body, '/build-image')
+    if: (always() && ! cancelled()) && needs.run_pre_checks.result == 'success' && needs.update_sdk.result != 'failure' && contains(github.event.comment.body, '/build-image')
     name: "Build the OS image"
     uses: ./.github/workflows/ci.yaml
     with:

--- a/.github/workflows/pr-comment-build-dispatcher.yaml
+++ b/.github/workflows/pr-comment-build-dispatcher.yaml
@@ -11,18 +11,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check_maintainer_membership:
+  run_pre_checks:
     # Only run if this is a PR comment that contains a valid command
-    if: |
-      ${{ github.event.issue.pull_request }} &&
-        (    contains(github.event.comment.body, '/update-sdk') || contains(github.event.comment.body, '/build-image') )
+    if: ${{ github.event.issue.pull_request }} && contains(github.event.comment.body, '/build-image')
     name: Check if commenter is in the Flatcar maintainers team
     outputs:
       maintainers: steps.step1.output.maintainers
+      sdk_changes: steps.step3.outputs.sdk_changes
     runs-on:
       - ubuntu-latest
     steps:
       - name: Fetch members of the maintainers team
+        id: step1
         env:
           requester: ${{ github.event.comment.user.login }}
         shell: bash
@@ -49,25 +49,45 @@ jobs:
 
           $res
 
+      - uses: actions/checkout@v3
+        id: step2
+        with:
+          path: scripts
+          fetch-depth: 0
+  
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          working-directory: scripts
+          filters: |
+            sdk_changes:
+              - 'sdk_container/**'
+              - 'sdk_libs/**'
+
+      - name: Set outputs
+        id: step3
+        shell: bash
+        run: |
+          echo "sdk_changes=${{ steps.filter.outputs.sdk_changes }}" >> $GITHUB_OUTPUT
+
       - name: Post a link to the workflow run to the PR
+        id: step4
         uses: mshick/add-pr-comment@v2
         with:
           issue: ${{ github.event.issue.pull_request.number }}
           message: "Build action triggered: [${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
 
   update_sdk:
-    needs: check_maintainer_membership
-    if: ( needs.check_maintainer_membership.result == 'success'
-           && contains(github.event.comment.body, '/update-sdk') )
+    needs: run_pre_checks
+    if: needs.run_pre_checks.result == 'success' && needs.run_pre_checks.outputs.sdk_changes == 'true'
     name: "Build an updated SDK container"
     # SDK build needs access to bincache ssh secret
     secrets: inherit
     uses: ./.github/workflows/update-sdk.yaml
 
   build_image:
-    needs: [ check_maintainer_membership, update_sdk ]
-    if: ( needs.check_maintainer_membership.result == 'success'
-          && (    contains(github.event.comment.body, '/build-image') || needs.update_sdk.result == 'success' ) )
+    needs: [ run_pre_checks, update_sdk ]
+    if: (always() && ! cancelled()) && needs.run_pre_checks.result == 'success' && contains(github.event.comment.body, '/build-image')
     name: "Build the OS image"
     uses: ./.github/workflows/ci.yaml
     with:

--- a/.github/workflows/pr-workflows.yaml
+++ b/.github/workflows/pr-workflows.yaml
@@ -1,0 +1,56 @@
+name: "Run PR workflows"
+on:
+  pull_request:
+
+permissions:
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-pr-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  check_for_sdk_changes:
+    name: "Check for SDK changes"
+    runs-on: ubuntu-latest
+    environment: development
+    outputs:
+      sdk_changes: ${{ steps.step2.outputs.sdk_changes }}
+    steps:
+      - uses: actions/checkout@v3
+        id: step1
+        with:
+          path: scripts
+          fetch-depth: 0
+
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          working-directory: scripts
+          filters: |
+            sdk_changes:
+              - 'sdk_container/**'
+              - 'sdk_libs/**'
+
+      - name: Set outputs
+        id: step2
+        shell: bash
+        run: |
+          echo "sdk_changes=${{ steps.filter.outputs.sdk_changes }}" >> $GITHUB_OUTPUT
+
+  update_sdk:
+    name: "Build an updated SDK container"
+    needs: [ check_for_sdk_changes ]
+    if: needs.check_for_sdk_changes.sdk_changes == 'true'
+    # SDK build needs access to bincache ssh secret
+    secrets: inherit
+    uses: ./.github/workflows/update-sdk.yaml
+
+  build_image:
+    needs: [ update_sdk ]
+    if: (always() && ! cancelled()) && needs.update_sdk.result != 'failure'
+    name: "Build the OS image"
+    uses: ./.github/workflows/ci.yaml
+    with:
+      custom_sdk_version: ${{ needs.update_sdk.outputs.sdk_version }}
+      image_formats: qemu_uefi

--- a/.github/workflows/pr-workflows.yaml
+++ b/.github/workflows/pr-workflows.yaml
@@ -10,44 +10,37 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check_for_sdk_changes:
-    name: "Check for SDK changes"
+  pre_check:
+    name: "Check if we need to update the SDK"
     runs-on: ubuntu-latest
+    # Setting the environment is the more important reason we need this job.
+    # We use this job as a gate, so we can approve the PR workflow only once. If
+    # we set this in the update_sdk job and in the build_image job, we would have
+    # to approve the workflow for every job that kicks off. Given that the jobs
+    # are sequenced, this is cumbersome. Use this job as a gate and make the rest
+    # dependent on it.
     environment: development
     outputs:
-      sdk_changes: ${{ steps.step2.outputs.sdk_changes }}
+      sdk_changes: ${{ steps.step1.outputs.sdk_changes }}
     steps:
-      - uses: actions/checkout@v3
-        id: step1
-        with:
-          path: scripts
-          fetch-depth: 0
-
-      - uses: dorny/paths-filter@v2
-        id: filter
-        with:
-          working-directory: scripts
-          filters: |
-            sdk_changes:
-              - 'sdk_container/**'
-              - 'sdk_libs/**'
-
       - name: Set outputs
-        id: step2
+        id: step1
         shell: bash
         run: |
-          echo "sdk_changes=${{ steps.filter.outputs.sdk_changes }}" >> $GITHUB_OUTPUT
+          echo "sdk_changes=${{ contains(github.event.pull_request.body, '/update-sdk') }}" >> $GITHUB_OUTPUT
 
   update_sdk:
     name: "Build an updated SDK container"
-    needs: [ check_for_sdk_changes ]
-    if: needs.check_for_sdk_changes.sdk_changes == 'true'
+    needs: [ pre_check ]
+    if: needs.pre_check.outputs.sdk_changes == 'true'
     # SDK build needs access to bincache ssh secret
     secrets: inherit
     uses: ./.github/workflows/update-sdk.yaml
 
   build_image:
     needs: [ update_sdk ]
+    # The update-sdk job may be skipped, which is fine. We only care if it tried to
+    # run, but failed.
     if: (always() && ! cancelled()) && needs.update_sdk.result != 'failure'
     name: "Build the OS image"
     uses: ./.github/workflows/ci.yaml


### PR DESCRIPTION
# Add a workflow that runs on every PR

This change adds a workflow that is triggered on every PR. This workflow is started in the ```development``` environment and required manual approval from the flatcar-maintainers team before it runs.

Once approved, the workflow runs as usual.

## Triggering an SDK update

When opening a new PR, add the following string anywhere in the **PR summary**:

/update-sdk

This will be parsed by the workflow and signal the ```update_sdk``` job to run. 

Note, the workflows will probably be active for this PR and will try to update the SDK and then build the image. If we don't want to do that, we can simply not approve the run.

The command based PR runs have also been updated and *should* work the same way. If we want to trigger just the image build, it should be enough to specify:

/build-image

anywhere in the comment body. We can optionally use:

/update-sdk
/build-image

to also update the SDK. 