### PR TITLE
Migrate to Type=notify

### DIFF
--- a/changelog/changes/2023-06-15-containerd-service
+++ b/changelog/changes/2023-06-15-containerd-service
@@ -1,0 +1,1 @@
+- Migrate to Type=notify in containerd.service. Changed the unit to Type=notify, utilizing the existing containerd support for sd_notify call after socket setup.

--- a/sdk_container/src/third_party/coreos-overlay/app-containers/containerd/files/containerd.service
+++ b/sdk_container/src/third_party/coreos-overlay/app-containers/containerd/files/containerd.service
@@ -1,20 +1,24 @@
 [Unit]
-Description=Containerd Container Daemon
-Documentation=http://github.com/docker/containerd
+Description=containerd container runtime
+Documentation=https://containerd.io
+After=network.target local-fs.target
 
 [Service]
-Type=simple
+ExecStartPre=-/sbin/modprobe overlay
 ExecStart=/usr/bin/containerd --listen unix:///var/run/docker/libcontainerd/docker-containerd.sock --shim /usr/bin/containerd-shim --state-dir /var/run/docker/libcontainerd/containerd --start-timeout 2m
-Restart=always
 
-# (lack of) limits from the upstream docker service unit
-LimitNOFILE=1048576
+Type=notify
+Delegate=yes
+KillMode=process
+Restart=always
+RestartSec=5
+# Having non-zero Limit*s causes performance problems due to accounting overhead
+# in the kernel. We recommend using cgroups to do container-local accounting.
 LimitNPROC=infinity
 LimitCORE=infinity
+LimitNOFILE=infinity
 TasksMax=infinity
-
-# set delegate yes so that systemd does not reset the cgroups of containers
-Delegate=yes
+OOMScoreAdjust=-999
 
 [Install]
 WantedBy=multi-user.target early-docker.target


### PR DESCRIPTION
#  [containerd] Migrate to Type=notify in containerd.service
    
Race condition arises when the containerd service unit assumes services are ready as soon as they start running, rather than when they can actually accept socket requests. To rectify this, changing the unit to Type=notify is required, utilizing the existing containerd support for sd_notify call after socket setup.
    
 References:
- https://www.freedesktop.org/software/systemd/man/systemd.service.html#Type=
- https://github.com/flatcar/Flatcar/issues/203

CI: http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/1993/cldsv/