### PR TITLE
Add fstrim conf

### DIFF
--- a/sdk_container/src/third_party/portage-stable/sys-apps/util-linux/files/fstrim.conf
+++ b/sdk_container/src/third_party/portage-stable/sys-apps/util-linux/files/fstrim.conf
@@ -1,0 +1,5 @@
+[Service]
+# Use `-a` flag - Flatcar does not have /etc/fstab file - so run against all
+# mounted filesystems
+ExecStart=
+ExecStart=/sbin/fstrim -av

--- a/sdk_container/src/third_party/portage-stable/sys-apps/util-linux/util-linux-2.37.4.ebuild
+++ b/sdk_container/src/third_party/portage-stable/sys-apps/util-linux/util-linux-2.37.4.ebuild
@@ -330,4 +330,5 @@ pkg_postinst() {
 		elog "The agetty util now clears the terminal by default. You"
 		elog "might want to add --noclear to your /etc/inittab lines."
 	fi
+	cp "${FILESDIR}/fstrim.conf" /etc/fstrim.conf
 }

--- a/sdk_container/src/third_party/portage-stable/sys-apps/util-linux/util-linux-9999.ebuild
+++ b/sdk_container/src/third_party/portage-stable/sys-apps/util-linux/util-linux-9999.ebuild
@@ -325,4 +325,5 @@ pkg_postinst() {
 		elog "The agetty util now clears the terminal by default. You"
 		elog "might want to add --noclear to your /etc/inittab lines."
 	fi
+	cp "${FILESDIR}/fstrim.conf" /etc/fstrim.conf
 }


### PR DESCRIPTION
# Add fstrim conf

This pull request aims to include an fstrim configuration to util-linux and install it in pkg_postinst. By doing so, the default configuration shipped with upstream will be overwritten. This change is necessary to prevent the failure of fstrim.service on Flatcar Linux due to the absence of /etc/fstab.
