### PR TITLE
Update from "flatcar_production_packet.ipxe" to "flatcar_production_equinix_metal.ipxe"

### DIFF
--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -780,7 +780,7 @@ You can pass extra kernel parameters with -append, for example:
 When using -nographic or -serial you must also enable the serial console:
   ./$(basename "${script}") -nographic -append 'console=ttyS0,115200n8'
 EOF
-    local packetipxe="$(_dst_dir)/flatcar_production_packet.ipxe"
+    local packetipxe="$(_dst_dir)/flatcar_production_equinix_metal.ipxe"
     cat > "$packetipxe" <<EOF
 #!ipxe
 

--- a/ci-automation/ci-config.env
+++ b/ci-automation/ci-config.env
@@ -85,7 +85,7 @@ EQUINIXMETAL_PARALLEL="${PARALLEL_TESTS:-4}"
 EQUINIXMETAL_amd64_METRO="${EQUINIXMETAL_amd64_METRO:-SV}"
 EQUINIXMETAL_arm64_METRO="${EQUINIXMETAL_arm64_METRO:-DC}"
 # Name of the Equinix Metal image
-EQUINIXMETAL_IMAGE_NAME="flatcar_production_packet_image.bin.bz2"
+EQUINIXMETAL_IMAGE_NAME="flatcar_production_equinix_metal_image.bin.bz2"
 # Storage URL required to store user-data
 EQUINIXMETAL_STORAGE_URL="${EQUINIXMETAL_STORAGE_URL:-gs://flatcar-jenkins/mantle/packet}"
 # Equinix Metal default AMD64 instance type

--- a/jenkins/kola/packet.sh
+++ b/jenkins/kola/packet.sh
@@ -14,12 +14,12 @@ if [[ "${DOWNLOAD_ROOT}" == gs://flatcar-jenkins-private/* ]]; then
   echo "Fetching google/cloud-sdk"
   docker pull google/cloud-sdk > /dev/null
   BUCKET_PATH="${DOWNLOAD_ROOT}/boards/${BOARD}/${FLATCAR_VERSION}"
-  IMAGE_URL="$(docker run --rm --net=host -v "${GOOGLE_APPLICATION_CREDENTIALS}:${GOOGLE_APPLICATION_CREDENTIALS}" google/cloud-sdk sh -c "python3 -m pip install pyopenssl > /dev/null; gsutil signurl -d 7d -r us ${GOOGLE_APPLICATION_CREDENTIALS} ${BUCKET_PATH}/flatcar_production_packet_image.bin.bz2 | grep -o 'https.*'")"
+  IMAGE_URL="$(docker run --rm --net=host -v "${GOOGLE_APPLICATION_CREDENTIALS}:${GOOGLE_APPLICATION_CREDENTIALS}" google/cloud-sdk sh -c "python3 -m pip install pyopenssl > /dev/null; gsutil signurl -d 7d -r us ${GOOGLE_APPLICATION_CREDENTIALS} ${BUCKET_PATH}/flatcar_production_equinix_metal_image.bin.bz2 | grep -o 'https.*'")"
   KERNEL_URL="$(docker run --rm --net=host -v "${GOOGLE_APPLICATION_CREDENTIALS}:${GOOGLE_APPLICATION_CREDENTIALS}" google/cloud-sdk sh -c "python3 -m pip install pyopenssl > /dev/null; gsutil signurl -d 7d -r us ${GOOGLE_APPLICATION_CREDENTIALS} ${BUCKET_PATH}/flatcar_production_pxe.vmlinuz | grep -o 'https.*'")"
   CPIO_URL="$(docker run --rm --net=host -v "${GOOGLE_APPLICATION_CREDENTIALS}:${GOOGLE_APPLICATION_CREDENTIALS}" google/cloud-sdk sh -c "python3 -m pip install pyopenssl > /dev/null; gsutil signurl -d 7d -r us ${GOOGLE_APPLICATION_CREDENTIALS} ${BUCKET_PATH}/flatcar_production_pxe_image.cpio.gz | grep -o 'https.*'")"
 else
   BASE_PATH="bucket.release.flatcar-linux.net/$(echo $DOWNLOAD_ROOT | sed 's|gs://||g')/boards/${BOARD}/${FLATCAR_VERSION}"
-  IMAGE_URL="https://${BASE_PATH}/flatcar_production_packet_image.bin.bz2"
+  IMAGE_URL="https://${BASE_PATH}/flatcar_production_equinix_metal_image.bin.bz2"
   KERNEL_URL="https://${BASE_PATH}/flatcar_production_pxe.vmlinuz"
   CPIO_URL="https://${BASE_PATH}/flatcar_production_pxe_image.cpio.gz"
 fi


### PR DESCRIPTION
# Update from "flatcar_production_packet.ipxe" to "flatcar_production_equinix_metal.ipxe"

In the current release, the "flatcar_production_packet.ipxe" file still mentions "Packet" instead of "Equinix Metal". To address this, let's rename the file from "flatcar_production_packet.ipxe" to "flatcar_production_equinix_metal.ipxe" for accurate representation.

Reference: https://github.com/flatcar/Flatcar/issues/483