### PR TITLE
overlay coreos/config: Drop python-oem leftovers

### DIFF
--- a/sdk_container/src/third_party/coreos-overlay/coreos/config/env/dev-lang/python-oem
+++ b/sdk_container/src/third_party/coreos-overlay/coreos/config/env/dev-lang/python-oem
@@ -1,9 +1,0 @@
-# Work around configure test that cannot be cross compiled :(
-#
-# When checking if this is still applicable, try grepping the
-# configure script for lines with "$cross_compiling", like
-#
-# grep -B 20 -F 'when cross compiling' configure
-
-export ac_cv_file__dev_ptc=no
-export ac_cv_file__dev_ptmx=yes


### PR DESCRIPTION
The dev-lang/python-oem package is no more, so drop the environment overrides for it.

This should have been dropped in #858, but I missed it.