### PR TITLE
Upload dev-key-signed OEM sysext update payload

### DIFF
--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -579,6 +579,11 @@ install_oem_sysext() {
     for to_move in "${built_sysext_dir}/${oem_sysext}"*; do
         mv "${to_move}" "${upload_dir}/${to_move##*/}"
     done
+    # Generate dev-key-signed update payload for testing
+    delta_generator \
+      -private_key "/usr/share/update_engine/update-payload-key.key.pem" \
+      -new_image "${upload_dir}/${built_sysext_filename}" \
+      -out_file "${upload_dir}/flatcar_test_update-${oem_sysext}.gz"
     # Remove sysext_dir if building sysext and installing it
     # succeeded.
     rm -rf "${built_sysext_dir}"


### PR DESCRIPTION
For release tests and updating a machine to a dev build we already have the dev-key-signed generic update payload but not yet the OEM sysext update payload.
Generate the dev-key-signed OEM sysext update payload during build and upload it.

## How to use

From ue-rs (or with `protoc` when starting from the right offset)

## Testing done

TODO: check if it gets uploaded to bincache with a Jenkins build
