### PR TITLE
[sys-auth/polkit] Harden systemd service configuration

### DIFF
--- a/sdk_container/src/third_party/coreos-overlay/sys-auth/polkit/files/override.conf
+++ b/sdk_container/src/third_party/coreos-overlay/sys-auth/polkit/files/override.conf
@@ -1,11 +1,4 @@
-[Unit]
-Description=Authorization Manager
-Documentation=man:polkit(8)
-
 [Service]
-Type=dbus
-BusName=org.freedesktop.PolicyKit1
-ExecStart=/usr/lib/polkit-1/polkitd --no-debug
 
 # Network Sandboxing
  
@@ -83,4 +76,3 @@ SystemCallFilter=~@debug @mount @cpu-emulation @obsolete @clock @swap @reboot @m
 SystemCallFilter=@system-service @resources @privileged
 SystemCallFilter=~@debug @mount @cpu-emulation @obsolete @clock @swap @reboot @module
 SystemCallArchitectures=native
-

--- a/sdk_container/src/third_party/coreos-overlay/sys-auth/polkit/files/override.conf
+++ b/sdk_container/src/third_party/coreos-overlay/sys-auth/polkit/files/override.conf
@@ -1,0 +1,86 @@
+[Unit]
+Description=Authorization Manager
+Documentation=man:polkit(8)
+
+[Service]
+Type=dbus
+BusName=org.freedesktop.PolicyKit1
+ExecStart=/usr/lib/polkit-1/polkitd --no-debug
+
+# Network Sandboxing
+ 
+PrivateNetwork=yes
+RestrictAddressFamilies=AF_UNIX
+RestrictAddressFamilies=~AF_INET AF_INET6 AF_NETLINK AF_PACKET
+IPAccounting=yes
+# IPAddressAllow=any
+# IPAddressDeny= service needs access to all IPs
+
+# File System Sandboxing
+
+ProtectHome=yes
+ProtectSystem=strict
+ProtectProc=ptraceable
+# ReadWritePaths=
+PrivateTmp=yes
+
+# User seperation
+
+# PrivateUsers= service runs as root
+# DynamicUser= service runs as root
+
+# Device sandboxing
+
+PrivateDevices=yes
+# DeviceAllow=/dev/exampledevice
+
+# Kernel 
+
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+ProtectHostname=yes
+ProtectClock=yes
+
+
+# Other hardening
+
+UMask=077
+AmbientCapabilities=CAP_BPF CAP_PERFMON
+CapabilityBoundingSet=~CAP_AUDIT_CONTROL CAP_AUDIT_READ CAP_DAC_READ_SEARCH
+CapabilityBoundingSet=~CAP_SYS_RAWIO
+CapabilityBoundingSet=~CAP_SYS_PTRACE
+CapabilityBoundingSet=~CAP_DAC_* CAP_FOWNER CAP_IPC_OWNER
+CapabilityBoundingSet=~CAP_NET_ADMIN
+CapabilityBoundingSet=~CAP_KILL
+CapabilityBoundingSet=~CAP_NET_BIND_SERVICE CAP_NET_BROADCAST
+CapabilityBoundingSet=~CAP_SYS_NICE CAP_SYS_RESOURCE
+CapabilityBoundingSet=~CAP_SYS_BOOT
+CapabilityBoundingSet=~CAP_LINUX_IMMUTABLE
+CapabilityBoundingSet=~CAP_SYS_CHROOT
+CapabilityBoundingSet=~CAP_BLOCK_SUSPEND
+CapabilityBoundingSet=~CAP_LEASE
+CapabilityBoundingSet=~CAP_SYS_PACCT
+CapabilityBoundingSet=~CAP_SYS_TTY_CONFIG
+CapabilityBoundingSet=~CAP_SYS_ADMIN
+# CapabilityBoundingSet=~CAP_SETUID CAP_SETGID CAP_SETPCAP
+CapabilityBoundingSet=~CAP_CHOWN CAP_FSETID CAP_SETFCAP
+CapabilityBoundingSet=~CAP_NET_RAW
+CapabilityBoundingSet=~CAP_IPC_LOCK
+NoNewPrivileges=yes
+ProtectControlGroups=yes
+RestrictNamespaces=yes
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+# RemoveIPC= service runs as root
+
+# System calls 
+
+SystemCallFilter=@system-service @resources
+SystemCallFilter=~@debug @mount @cpu-emulation @obsolete @clock @swap @reboot @module @privileged
+SystemCallFilter=@system-service @resources @privileged
+SystemCallFilter=~@debug @mount @cpu-emulation @obsolete @clock @swap @reboot @module
+SystemCallArchitectures=native
+

--- a/sdk_container/src/third_party/coreos-overlay/sys-auth/polkit/polkit-121.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/sys-auth/polkit/polkit-121.ebuild
@@ -145,7 +145,7 @@ src_install() {
 	mv "${D}"/{etc,usr/lib}/pam.d/polkit-1 || die
 	rmdir "${D}"/etc/polkit-1/rules.d "${D}"/etc/polkit-1 || die
 	rmdir "${D}"/etc/pam.d || die
-
+        install -D -m 0644 ${FILESDIR}/override.conf /etc/systemd/system/polkit.service.d/override.conf
 	dotmpfiles "${FILESDIR}/polkit.conf"
 
 	if use examples ; then


### PR DESCRIPTION
# [sys-auth/polkit] Harden systemd service configuration

This pull request introduces hardened systemd service configuration for the polkit service, resulting in a significant reduction in the exposure level from 9.6 to 1.9, as determined by the [``systemd-analyze security``](https://www.freedesktop.org/software/systemd/man/systemd-analyze.html#systemd-analyze%20security%20%5BUNIT...%5D) command.

## Changes Made

- Added hardening measures utilizing systemd features to enhance the security of the polkit service.

## How to Use

I have already modified the ebuild to include the necessary changes for installing the additional hardening measures. Simply follow the regular installation process to benefit from the enhanced security.

## Testing Done

- Analyzed the polkit service using systemd-analyze to ensure the effectiveness of the hardening measures.
- Conducted testing to verify that the polkit service functions as expected after implementing the changes.
- Examined logs

## Checklist

- [ ] Added appropriate changelog entries in the respective `changelog/` directory to reflect the changes made (user-facing change, bug fix, security fix, update).

Please review the changes and provide any feedback or suggestions for improvement.