### PR TITLE
coreos-base/oem-ec2-compat: fix JSON formatting

### DIFF
--- a/sdk_container/src/third_party/coreos-overlay/coreos-base/oem-ec2-compat/files/base/base-ec2.ign
+++ b/sdk_container/src/third_party/coreos-overlay/coreos-base/oem-ec2-compat/files/base/base-ec2.ign
@@ -12,7 +12,7 @@
         "name": "amazon-ssm-agent.service",
         "enabled": true,
         "contents": "[Unit]\nDescription=amazon-ssm-agent\nAfter=network-online.target\n\n[Service]\nType=simple\nWorkingDirectory=/oem\nExecStart=/oem/bin/amazon-ssm-agent\nKillMode=process\nRestart=on-failure\nRestartForceExitStatus=SIGPIPE\nRestartSec=15min\n\n[Install]\nWantedBy=multi-user.target\n"
-      },
+      }
     ]
   },
   "storage": {
@@ -40,7 +40,7 @@
           "source": "oem:///eks/bootstrap.sh"
         },
         "mode": 493
-      },
+      }
     ]
   }
 }


### PR DESCRIPTION
It was causing an issue on AWS for both arch:
```
$ aws ec2 get-console-output
[    8.130342] ignition[1051]: Ignition 2.15.0
[    8.131688] ignition[1051]: Stage: fetch-offline
[    8.134886] ignition[1051]: reading system config file "/usr/lib/ignition/base.d/base.ign"
[    8.137355] ignition[1051]: error at line 16 col 6: invalid character ']' looking for beginning of value
[    8.139947] ignition[1051]: failed to acquire system base config: config is not valid
[    8.142090] ignition[1051]: Ignition failed: config is not valid
[    8.145266] systemd[1]: ignition-fetch-offline.service: Main process exited, code=exited, status=1/FAILURE
[    8.147987] systemd[1]: ignition-fetch-offline.service: Failed with result 'exit-code'.
[    8.150262] systemd[1]: Failed to start ignition-fetch-offline.service - Ignition (fetch-offline).
$ ./ign-converter < base.ign
error at line 16, column 6
   15:       },
   16:     ]
           ^
invalid character ']' looking for beginning of valueError parsing spec v2 config: config is not valid
error at line 16, column 6
   15:       },
   16:     ]
           ^
invalid character ']' looking for beginning of value
$ jq < base.ign
jq: parse error: Expected another array element at line 16, column 5
```

<hr>

Tested with `jq` only.
