### PR TITLE
coreos-base/coreos-cloudinit: Don't use configdrive on DigitalOcean

### DIFF
--- a/sdk_container/src/third_party/coreos-overlay/coreos-base/coreos-cloudinit/coreos-cloudinit-9999.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/coreos-base/coreos-cloudinit/coreos-cloudinit-9999.ebuild
@@ -12,7 +12,7 @@ inherit cros-workon systemd toolchain-funcs udev coreos-go
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm64"
 else
-	CROS_WORKON_COMMIT="eb49a8f36aa0ac6e0f372ca6404c4f5b926955ca" # flatcar-master
+	CROS_WORKON_COMMIT="a5d40f3d2178fed068228a66e40c2db24b2d14a9" # flatcar-master
 	KEYWORDS="amd64 arm64"
 fi
 


### PR DESCRIPTION
This pulls in
https://github.com/flatcar/coreos-cloudinit/pull/22 to prevent using the configdrive on DigitalOcean.


## How to use
Backport to `flatcar-3637`

## Testing done

Tested on [Jenkins](http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/2021/cldsv/)

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
