### PR TITLE
Switch default ext4 inode size to 256 bytes

### DIFF
--- a/build_library/disk_util
+++ b/build_library/disk_util
@@ -403,7 +403,7 @@ def FormatExt(part, device):
                   '-t', part['fs_type'],
                   '-b', part['fs_block_size'],
                   '-i', part.get('fs_bytes_per_inode', part['fs_block_size']),
-                  '-I', part.get('fs_inode_size', 128),
+                  '-I', part.get('fs_inode_size', 256),
                   device,
                   part['fs_blocks']])
 

--- a/changelog/changes/2023-06-22-ext4-inode-size.md
+++ b/changelog/changes/2023-06-22-ext4-inode-size.md
@@ -1,0 +1,1 @@
+- Changed ext4 inode size of root partition to 256 bytes. This improves compatibility with applications and is necessary for 2038 readiness ([Flatcar#1082](https://github.com/flatcar/Flatcar/issues/1082))


### PR DESCRIPTION

# Switch default ext4 inode size to 256 bytes

Inode sizes smaller than 256:
- don't support extended metadata (nanosecond timestamp resolution)
- cannot handle dates beyond 2038
- are deprecated

Change the default from 128 to 256. There is no way to apply this change on a mounted filesystem so this change will only apply to new deployments.

Fixes: flatcar/flatcar#1082

## How to use

```
./build_image
<run flatcar>
tune2fs -l /dev/vda9
```

## Testing done

No testing done.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
