### PR TITLE
oem_sysext_util: Mount overlay on top of /usr before installing sysext

### DIFF
--- a/ci-automation/ci-config.env
+++ b/ci-automation/ci-config.env
@@ -28,8 +28,8 @@ CI_GIT_AUTHOR="flatcar-ci"
 CI_GIT_EMAIL="infra+ci@flatcar-linux.org"
 
 # build artifacts go here (in container)
-CONTAINER_TORCX_ROOT="/home/sdk/build/torcx"
-CONTAINER_IMAGE_ROOT="/home/sdk/build/images"
+CONTAINER_TORCX_ROOT="/home/sdk/trunk/src/build/torcx"
+CONTAINER_IMAGE_ROOT="/home/sdk/trunk/src/build/images"
 
 # Set it to "1" or "true" or "t" or "y" or "yes" to always run a full
 # nightly build. Any other value will allow build shortcuts.

--- a/ci-automation/image.sh
+++ b/ci-automation/image.sh
@@ -84,11 +84,17 @@ function _image_build_impl() {
             official_arg="--noofficial"
     fi
 
+    local torcx_root_tar="torcx_root.tar.zst"
     apply_local_patches
+    copy_from_buildcache "images/${arch}/${vernum}/torcx/${torcx_root_tar}" .
+
     # build image and related artifacts
     ./run_sdk_container -x ./ci-cleanup.sh -n "${image_container}" -C "${packages_image}" \
             -v "${vernum}" \
-            mkdir -p "${CONTAINER_IMAGE_ROOT}"
+            mkdir -p "${CONTAINER_IMAGE_ROOT}" "${CONTAINER_TORCX_ROOT}"
+    ./run_sdk_container -n "${image_container}" -C "${packages_image}" \
+            -v "${vernum}" \
+            tar --zstd -xf "${torcx_root_tar}" -C "${CONTAINER_TORCX_ROOT}"
     ./run_sdk_container -n "${image_container}" -C "${packages_image}" \
             -v "${vernum}" \
             ./set_official --board="${arch}-usr" "${official_arg}"

--- a/ci-automation/packages.sh
+++ b/ci-automation/packages.sh
@@ -123,6 +123,11 @@ function _packages_build_impl() {
     # generate image + push to build cache
     docker_commit_to_buildcache "${packages_container}" "${packages_image}" "${docker_vernum}"
 
+    # publish torcx output root for consumption by build_image
+    local torcx_root_tar="torcx_root.tar.zst"
+    tar --zstd -cpf "${torcx_root_tar}" -C "${torcx_tmp}/torcx" .
+    copy_to_buildcache "images/${arch}/${vernum}/torcx" "${torcx_root_tar}"
+
     # Publish torcx manifest and docker tarball to "images" cache so tests can pull it later.
     create_digests "${SIGNER}" \
         "${torcx_tmp}/torcx/${arch}-usr/latest/torcx_manifest.json" \


### PR DESCRIPTION
# Mount overlay on top of /usr before installing sysext

This fixes the issue of sysext creating running out of disk space after we changed the ext4 inode size to 256 bytes.

## How to use

```
./build_packages
./build_image
./image_to_vm.sh --format=azure
```

## Testing done

Performed the step in `how to use` - successfully.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
