### PR TITLE
sys-auth/sssd: Add missing /var/log/sssd tmpfiles entry

### DIFF
--- a/changelog/bugfixes/2023-06-28-sssd-var-log.md
+++ b/changelog/bugfixes/2023-06-28-sssd-var-log.md
@@ -1,0 +1,1 @@
+- Ensured that the folder `/var/log/sssd` is created if it doesn't exist, required for `sssd.service` ([Flatcar#1096](https://github.com/flatcar/Flatcar/issues/1096))

--- a/sdk_container/src/third_party/coreos-overlay/sys-auth/sssd/files/tmpfiles.d/sssd.conf
+++ b/sdk_container/src/third_party/coreos-overlay/sys-auth/sssd/files/tmpfiles.d/sssd.conf
@@ -11,3 +11,4 @@ d /var/lib/sss/pipes/private	0700	root	root	-	-
 d /var/lib/sss/pubconf		0700	root	root	-	-
 d /var/lib/sss/pubconf/krb5.include.d	0700	root	root	-	-
 d /var/lib/sss/secrets		0755	root	root	-	-
+d /var/log/sssd			0700	root	root	-	-


### PR DESCRIPTION
The folders are not created through "keepdir" which results in tmpfiles rules but an explict tmpfiles file. This is error prone and we should try to move to "keepdir" instead but for the backport, just add the missing line.

## How to use

Backport to Beta

## Testing done

Checked that the folder is there. With the default config, `sssd.service` can't start but the error message is different.

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
