### PR TITLE
[acct-group/docker] Add acct-group/docker to portage-stable

### DIFF
--- a/sdk_container/src/third_party/portage-stable/acct-group/docker/docker-0-r1.ebuild
+++ b/sdk_container/src/third_party/portage-stable/acct-group/docker/docker-0-r1.ebuild
@@ -1,0 +1,8 @@
+# Copyright 2020 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit acct-group
+
+ACCT_GROUP_ID=48

--- a/sdk_container/src/third_party/portage-stable/acct-group/docker/metadata.xml
+++ b/sdk_container/src/third_party/portage-stable/acct-group/docker/metadata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>williamh@gentoo.org</email>
+		<name>William Hubbs</name>
+	</maintainer>
+</pkgmetadata>


### PR DESCRIPTION
# [acct-group/docker] Add acct-group/docker to portage-stable

Add acct-group/docker to portage-stable. Looks like an omission from our side when syncing the docker ebuilds with Gentoo.

## How to use

Dependency to be able to successfully ``emerge app-containers/docker``

## Testing done

With this patch (adding acct-group/docker to portage-stable) I am able to emerge app-containers/docker