### PR TITLE
Check the url in get_sdk_binhost before echoing

### DIFF
--- a/build_library/toolchain_util.sh
+++ b/build_library/toolchain_util.sh
@@ -201,8 +201,10 @@ get_sdk_binhost() {
         # but normally it is not needed because everything is already part of the tarball.
         # To install the crossdev Rust package, /toolchain-arm64/ is derived from /toolchain/
         # when necessary in install_cross_toolchain().
-        echo "${FLATCAR_DEV_BUILDS_SDK}/${arch}/${ver}/toolchain/"
-        echo "${FLATCAR_DEV_BUILDS_SDK}/${arch}/${ver}/pkgs/"
+        if curl -Ifs -o /dev/null "${FLATCAR_DEV_BUILDS_SDK}/${arch}/${ver}/pkgs/"; then
+            echo "${FLATCAR_DEV_BUILDS_SDK}/${arch}/${ver}/toolchain/"
+            echo "${FLATCAR_DEV_BUILDS_SDK}/${arch}/${ver}/pkgs/"
+        fi
     done
 }
 

--- a/update_chroot
+++ b/update_chroot
@@ -188,7 +188,7 @@ if [ "${FLAGS_usepkg}" -eq "${FLAGS_TRUE}" ]; then
   if [[ "${FLAGS_usepkgonly}" -eq "${FLAGS_TRUE}" ]]; then
     EMERGE_FLAGS+=( --usepkgonly --rebuilt-binaries n )
   fi
-  if [ "${FLAGS_getbinpkg}" -eq "${FLAGS_TRUE}" ]; then
+  if [ "${FLAGS_getbinpkg}" -eq "${FLAGS_TRUE}" ] && [ -n "${PORTAGE_BINHOST// }" ]; then
     EMERGE_FLAGS+=( --getbinpkg )
   fi
 


### PR DESCRIPTION
# Check the url in get_sdk_binhost before echoing

Hi. When running the build_packages script, one can encounter an error such as 'Error fetching binhost package info from.' This pertains to SDK packages (not board packages). Since we have transitioned to the SDK container, the SDK packages are no longer published independently from the container image.

@jepio encouraged me to submit a pull request (PR) for the same

