### PR TITLE
profiles/coreos: Account for python versions with minor > 10

### DIFF
--- a/sdk_container/src/third_party/coreos-overlay/profiles/coreos/base/profile.bashrc
+++ b/sdk_container/src/third_party/coreos-overlay/profiles/coreos/base/profile.bashrc
@@ -81,7 +81,7 @@ cros_pre_src_unpack_python_multilib_setup() {
 	[[ ${am_cv_python_version:+set} == "set" ]] && return
 
 	local py=${PYTHON:-python}
-	local py_ver=$(${py} -c 'import sys;sys.stdout.write(sys.version[:3])')
+	local py_ver=$(${py} -c 'import sys;sys.stdout.write(sys.version[:4])')
 
 	export am_cv_python_version=${py_ver}
 	export am_cv_python_pythondir="\${libdir}/python${py_ver}/site-packages"


### PR DESCRIPTION


# don't truncate python minor in profile

`sys.version` returns `3.10.12 (main, Jul  6 2023, 22:54:08) [GCC 12.2.1 20230428]`.
The previous expression (sys.version[:3])) truncates 3.10 to 3.1 leading to build failures in some ebuilds that depend on python (like zfs).

## How to use

Don't know which ebuilds (other than sys-fs/zfs) use this but the problem is obvious.

## Testing done

Built zfs sysext.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
