### PR TITLE
ci-automation/vms: Export official release variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 # SDK container env passing helpers
 sdk_container/.env
 sdk_container/.sdkenv
+ci-cleanup.sh
 
 # build cache / artefacts directories
 __build__/

--- a/ci-automation/vms.sh
+++ b/ci-automation/vms.sh
@@ -102,6 +102,14 @@ function _vm_build_impl() {
     # Keep compatibility with SDK scripts where "equinix_metal" remains unknown.
     formats=$(echo "$formats" | tr ' ' '\n' | sed 's/equinix_metal/packet/g')
 
+    source sdk_lib/sdk_container_common.sh
+
+    if is_official "${vernum}"; then
+        export COREOS_OFFICIAL=1
+    else
+        export COREOS_OFFICIAL=0
+    fi
+
     local images_in="images-in/"
     local file
     rm -rf "${images_in}"


### PR DESCRIPTION
The official release variable is used to decide whether a build ID gets
    appended to the FLATCAR_VERSION (or VERSION in os-release) or not. It
    was set for the image job but not for the vms job, causing the
    build_sysext script to get the build ID appended to the FLATCAR_VERSION
    which causes a mismatch with the one from the image job.
    Set the official release variable in the vms job as well.

## How to use

Needed for the branched Alpha

## Testing done

In the workspace of the vms job I ran this:
```
sdk@flatcar-sdk-all-3665_0_0_os-alpha-3665_0_0 ~/trunk/src/scripts $ COREOS_OFFICIAL=1 sh -c 'source ./common.sh ; echo "$FLATCAR_VERSION"'
3665.0.0
sdk@flatcar-sdk-all-3665_0_0_os-alpha-3665_0_0 ~/trunk/src/scripts $ COREOS_OFFICIAL=0 sh -c 'source ./common.sh ; echo "$FLATCAR_VERSION"'
3665.0.0+2023-07-17-1517
```
