### PR TITLE
Changes to nvidia.service to allow ordering on the subsequent services

### DIFF
--- a/changelog/changes/2023-08-08-change-nvidia-oneshot.md
+++ b/changelog/changes/2023-08-08-change-nvidia-oneshot.md
@@ -1,0 +1,1 @@
+- Change nvidia.service to type oneshot (from the default "simple") so the subsequent services (configured with "Requires/After") are executed after the driver installation is successfully finished (flatcar/Flatcar#1136)

--- a/sdk_container/src/third_party/coreos-overlay/x11-drivers/nvidia-drivers/files/units/nvidia.service
+++ b/sdk_container/src/third_party/coreos-overlay/x11-drivers/nvidia-drivers/files/units/nvidia.service
@@ -2,9 +2,11 @@
 Description=NVIDIA Configure Service
 Wants=network-online.target
 After=network-online.target
+Before=containerd.target
 
 [Service]
-Type=simple
+Type=oneshot
+RemainsAfterExit=true
 Restart=no
 Environment=PATH=/opt/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
 ExecStart=/usr/lib/nvidia/bin/setup-nvidia


### PR DESCRIPTION
# Changes to nvidia.service to allow ordering on the subsequent services

When changed to oneshot, the subsequent services wiill actually wait for the nvidia.service to finish, i.e. wait for drivers to be installed. The subsequent services can be configured to wait for nvidia.service. This needs to be coupled with 
RemainAfterExit=yes to ensure it doesn't get kicked-off automatically again.
Solves : https://github.com/flatcar/Flatcar/issues/1136

## How to use


## Testing done
- [x] Setup a new service that is `After` and `Wants` `containerd.target` - Make sure it stays `disabled` until `containerd.target` & `nvidia.service` are completed successfully -  tested with a drop-in unit