### PR TITLE
sys-apps/systemd: add systemd patch from v252.12

### DIFF
--- a/changelog/bugfixes/2023-08-10-systemd-restart-service.md
+++ b/changelog/bugfixes/2023-08-10-systemd-restart-service.md
@@ -1,0 +1,1 @@
+- Fixed the restart of Systemd services when the main process is being killed by a SIGHUP signal ([flatcar#1157](https://github.com/flatcar/Flatcar/issues/1157))

--- a/sdk_container/src/third_party/coreos-overlay/sys-apps/systemd/files/0008-Revert-core-service-when-resetting-PID-also-reset-known.patch
+++ b/sdk_container/src/third_party/coreos-overlay/sys-apps/systemd/files/0008-Revert-core-service-when-resetting-PID-also-reset-known.patch
@@ -1,0 +1,40 @@
+From 34e834f496338fdc2a8a8cc771cba4082079cf9a Mon Sep 17 00:00:00 2001
+From: msizanoen <msizanoen@qtmlabs.xyz>
+Date: Mon, 12 Jun 2023 10:30:12 +0700
+Subject: [PATCH] Revert "core/service: when resetting PID also reset known
+ flag"
+
+This reverts commit ff32060f2ed37b68dc26256b05e2e69013b0ecfe.
+
+This change is incorrect as we don't want to mark the PID as invalid but
+only mark it as dead.
+
+The change in question also breaks user level socket activation for
+`podman.service` as the termination of the main `podman system service`
+process is not properly handled, causing any application accessing the
+socket to hang.
+
+This is because the user-level `podman.service` unit also hosts two
+non-main processes: `rootlessport` and `rootlessport-child` which causes
+the `cgroup_good` check to still succeed.
+
+The original submitter of this commit is recommended to find another
+more correct way to fix the cgroupsv1 issue on CentOS 8.
+
+(cherry picked from commit f29f0877c5abfd03060838d1812ea6fdff3b0b37)
+---
+ src/core/service.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/src/core/service.c b/src/core/service.c
+index c05f13c765..211f72900e 100644
+--- a/src/core/service.c
++++ b/src/core/service.c
+@@ -3529,7 +3529,6 @@ static void service_sigchld_event(Unit *u, pid_t pid, int code, int status) {
+                         return;
+ 
+                 s->main_pid = 0;
+-                s->main_pid_known = false;
+                 exec_status_exit(&s->main_exec_status, &s->exec_context, pid, code, status);
+ 
+                 if (s->main_command) {

--- a/sdk_container/src/third_party/coreos-overlay/sys-apps/systemd/systemd-252.11-r1.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/sys-apps/systemd/systemd-252.11-r1.ebuild
@@ -248,6 +248,7 @@ src_prepare() {
 		"${FILESDIR}/0005-systemd-Disable-SELinux-permissions-checks.patch"
 		"${FILESDIR}/0006-Revert-getty-Pass-tty-to-use-by-agetty-via-stdin.patch"
 		"${FILESDIR}/0007-units-Keep-using-old-journal-file-format.patch"
+		"${FILESDIR}/0008-Revert-core-service-when-resetting-PID-also-reset-known.patch"
 	)
 
 	if ! use vanilla; then


### PR DESCRIPTION
It fixes an issue with Systemd service restart when the main process is being killed by a SIGHUP signal.

Closes: https://github.com/flatcar/Flatcar/issues/1157
Commit-Ref: https://github.com/systemd/systemd-stable/commit/34e834f496338fdc2a8a8cc771cba4082079cf9a

## Testing done

- [x] locally tested that the patch applies `sudo ebuild systemd-252.11-r1.ebuild prepare`
- [x] https://github.com/flatcar/mantle/pull/447
- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

```
$ sudo ./bin/kola run --qemu-image /home/mathieu/flatcar/stable/flatcar_production_qemu_image.img docker.containerd-restart
=== RUN   docker.containerd-restart
--- FAIL: docker.containerd-restart (70.78s)
        cluster.go:117: Unable to find image 'ghcr.io/flatcar/busybox:latest' locally
        cluster.go:117: latest: Pulling from flatcar/busybox
        cluster.go:117: 3f4d90098f5b: Pulling fs layer
        cluster.go:117: 3f4d90098f5b: Verifying Checksum
        cluster.go:117: 3f4d90098f5b: Download complete
        cluster.go:117: 3f4d90098f5b: Pull complete
        cluster.go:117: Digest: sha256:a20bc8249a9e522a11102c61230350537cfa0bc1fef41d382eb660a3bc0b853a
        cluster.go:117: Status: Downloaded newer image for ghcr.io/flatcar/busybox:latest
        docker.go:545: Containerd is not running (could not find pid) after signal: SIGHUP
FAIL, output in _kola_temp/qemu-2023-08-10-1932-113273
harness: test suite failed
$ sudo ./bin/kola run --qemu-image ./flatcar/pr1058/flatcar_production_qemu_uefi_image.img docker.containerd-restart
=== RUN   docker.containerd-restart
--- PASS: docker.containerd-restart (98.99s)
        cluster.go:117: Unable to find image 'ghcr.io/flatcar/busybox:latest' locally
        cluster.go:117: latest: Pulling from flatcar/busybox
        cluster.go:117: 3f4d90098f5b: Pulling fs layer
        cluster.go:117: 3f4d90098f5b: Verifying Checksum
        cluster.go:117: 3f4d90098f5b: Download complete
        cluster.go:117: 3f4d90098f5b: Pull complete
        cluster.go:117: Digest: sha256:a20bc8249a9e522a11102c61230350537cfa0bc1fef41d382eb660a3bc0b853a
        cluster.go:117: Status: Downloaded newer image for ghcr.io/flatcar/busybox:latest
PASS, output in _kola_temp/qemu-2023-08-10-1933-113682
```