### PR TITLE
net-nds/openldap: update to 2.6.3

### DIFF
--- a/changelog/updates/2023-08-11-openldap-2.6.3.md
+++ b/changelog/updates/2023-08-11-openldap-2.6.3.md
@@ -1,0 +1,1 @@
+- openldap ([2.6.3](https://lists.openldap.org/hyperkitty/list/openldap-announce@openldap.org/thread/FQJM2JSSSOMLQH7XC7Q5IZJYOGCTV2LK/) (includes [2.6](https://lists.openldap.org/hyperkitty/list/openldap-announce@openldap.org/thread/IHS5V46H6NFNFUERMC6AWMPHTWRVNLFA/)))

--- a/sdk_container/src/third_party/coreos-overlay/profiles/coreos/base/package.mask
+++ b/sdk_container/src/third_party/coreos-overlay/profiles/coreos/base/package.mask
@@ -20,8 +20,3 @@
 # Python 3.12 is in portage-stable (currently testing), so avoid picking it
 # up. Update this to mask later versions when we switch to 3.11.
 >=dev-lang/python-3.12
-
-# Do not update to openldap 2.6.3+, to take 2 different steps of updating
-# openldap, 1) from 2.4 to 2.5, 2) do an Alpha release around 2023-08, and
-# 3) finally update from 2.5 to 2.6.
->=net-nds/openldap-2.6


### PR DESCRIPTION
Now that Alpha 3689.0.0 was released with openldap 2.5.14, we do not need to mask openldap >= 2.6.
Drop the mask, to update openldap to 2.6.3-r7.

/update-sdk

## Testing done

CI: http://jenkins.infra.kinvolk.io:8080/job/container/job/sdk/994/cldsv/

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [x] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
