### PR TITLE
Allow use qcow2 inline compression

### DIFF
--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -619,7 +619,7 @@ _write_raw_disk() {
 }
 
 _write_qcow2_disk() {
-    qemu-img convert -f raw "$1" -O qcow2 -o compat=0.10 "$2"
+    qemu-img convert -f raw "$1" -O qcow2 -c -o compat=0.10 "$2"
     assert_image_size "$2" qcow2
 }
 

--- a/ci-automation/vms.sh
+++ b/ci-automation/vms.sh
@@ -129,6 +129,8 @@ function _vm_build_impl() {
         COMPRESSION_FORMAT="bz2"
         if [[ "${format}" =~ ^(openstack|openstack_mini|digitalocean)$ ]];then
             COMPRESSION_FORMAT="gz,bz2"
+        elif [[ "${format}" =~ ^(qemu|qemu_uefi)$ ]];then
+            COMPRESSION_FORMAT="bz2,none"
         fi
         ./run_sdk_container -n "${vms_container}" -C "${packages_image}" \
             -v "${vernum}" \


### PR DESCRIPTION
#  Provide the .img qcow2 without wrapped compression by enabling the inline compression

[#1135](https://github.com/flatcar/Flatcar/issues/1135) by @tuxtof

Spoke with @pothos 
