### PR TITLE
vm_image_util: Fix variable quoting to create correct OEM sysext file

### DIFF
--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -531,7 +531,7 @@ install_oem_sysext() {
     local built_sysext_dir="${FLAGS_to}/${oem_sysext}-sysext"
     local built_sysext_filename="${oem_sysext}.raw"
     local built_sysext_path="${built_sysext_dir}/${built_sysext_filename}"
-    local version='${FLATCAR_VERSION}'
+    local version="${FLATCAR_VERSION}"
     local metapkg="coreos-base/${oem_sysext}"
     local build_sysext_flags=(
         --board="${BOARD}"


### PR DESCRIPTION
The OEM sysext image file in the OEM partition had the version variable name being part of the filename instead of the substituted version value because of wrong quoting when the fixed string got replaced by ${…}.

## How to use


## Testing done

None but after building you can download the qemu .img file and mount it to check.