### PR TITLE
overlay sys-libs/libsemanage: set compression on

### DIFF
--- a/sdk_container/src/third_party/coreos-overlay/sys-libs/libsemanage/libsemanage-3.5.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/sys-libs/libsemanage/libsemanage-3.5.ebuild
@@ -59,7 +59,7 @@ src_prepare() {
 	echo "# 1-9 when compressing.  The higher the number," >> "${S}/src/semanage.conf"
 	echo "# the more memory is traded off for disk space." >> "${S}/src/semanage.conf"
 	echo "# Set to 0 to disable bzip2 compression." >> "${S}/src/semanage.conf"
-	echo "bzip-blocksize=0" >> "${S}/src/semanage.conf"
+	echo "bzip-blocksize=1" >> "${S}/src/semanage.conf"
 	echo >> "${S}/src/semanage.conf"
 	echo "# Reduce memory usage for bzip2 compression and" >> "${S}/src/semanage.conf"
 	echo "# decompression of modules in the module store." >> "${S}/src/semanage.conf"


### PR DESCRIPTION
otherwise it blows from 3MB to 33MB on `/usr/lib/selinux/policy/mcs/` for example.

---

Locally tested, 33MB to 3MB for `/usr/lib/selinux/policy/mcs/`

- [x] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
- [x] CI: http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/2560/cldsv/ (except cgroupv1)

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
