### PR TITLE
disk_layout: use btrfs for the /usr partition

### DIFF
--- a/build_library/disk_layout.json
+++ b/build_library/disk_layout.json
@@ -29,7 +29,8 @@
         "type":"flatcar-rootfs",
         "blocks":"2097152",
         "fs_blocks":"260094",
-        "fs_type":"ext2",
+        "fs_type":"btrfs",
+        "fs_compression":"zstd",
         "mount":"/usr",
         "features": ["prioritize", "verity"]
       },


### PR DESCRIPTION
The compression feature of btrfs allows us to store more in the size-limited /usr and OEM partitions. The size should of course still be monitored to not bloat the image but more headroom helps to try things out quickly without hitting the hard limit which fails the build.
Use btrfs with zstd compression for the /usr partition. While for ext2 a hack exists to force read-only mounts by manipulating some bytes of the filesystem, on btrfs we can use the subvolume read-only flag instead which also works for the default top level subvolume. However, it also makes also sense to mount the filesystem with the "norecovery" mount option to prevent any write attempts even when the "ro" option is set (not needed when using dm-verity in read-only mode but when directly mounting without dm-verity). A new subvolumes is not created because subvolumes don't offer anything special as long as we use the A/B partition update mechanism (but they could be an alternative for that). Note that switching to the btrfs on the /usr partition is only possible when the Flatcar Stable release has all patches in update-engine and seismograph's rootdev.

(Taken from the comment in https://github.com/flatcar/scripts/pull/131)

## How to use

We need to document the minimal required Flatcar version to update. Ideally Nebraska would help with that: https://github.com/flatcar/Flatcar/issues/1185
Minimal Stable version is https://www.flatcar.org/releases#release-2983.2.0
This means that the current 3033 LTS is good but our very first 2605 LTS is not supported for updating.

New filesystem usage on `/usr`:
```
  File    Size  Used Avail Use% Type
 -/usr    952M  787M  114M  88% ext2
 +/usr   1016M  399M  331M  55% btrfs
```

## Testing done

[Here](http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/2561/cldsv/), required a fix in kola: https://github.com/flatcar/mantle/pull/453

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
