### PR TITLE
ci-automation: Switch to managed identity on azure

### DIFF
--- a/ci-automation/garbage_collect_cloud.sh
+++ b/ci-automation/garbage_collect_cloud.sh
@@ -3,18 +3,7 @@ set -euo pipefail
 timeout --signal=SIGQUIT 60m ore aws gc --access-id "${AWS_ACCESS_KEY_ID}" --secret-key "${AWS_SECRET_ACCESS_KEY}"
 timeout --signal=SIGQUIT 60m ore do gc --config-file=<(echo "${DIGITALOCEAN_TOKEN_JSON}" | base64 --decode)
 timeout --signal=SIGQUIT 60m ore gcloud gc --json-key <(echo "${GCP_JSON_KEY}" | base64 --decode)
-# Because the Azure file gets read multiple times it can't be passed like <(cmd) because bash backs this FD
-# by a pipe meaning the data is gone after reading. We can create an FD (the FD number is assigned to
-# variable through exec {NAME}) manually and use a file under /tmp to back it instead, allowing multiple
-# reads.
-echo "${AZURE_PROFILE}" | base64 --decode > /tmp/azure_profile
-exec {azure_profile}</tmp/azure_profile
-rm /tmp/azure_profile
-echo "${AZURE_AUTH_CREDENTIALS}" | base64 --decode > /tmp/azure_auth
-exec {azure_auth}</tmp/azure_auth
-rm /tmp/azure_auth
-timeout --signal=SIGQUIT 60m ore azure gc --duration 6h \
-  --azure-profile="/proc/$$/fd/${azure_profile}" --azure-auth="/proc/$$/fd/${azure_auth}"
+timeout --signal=SIGQUIT 60m ore azure gc --duration 6h --azure-identity
 timeout --signal=SIGQUIT 60m ore equinixmetal gc --duration 6h \
   --project="${EQUINIXMETAL_PROJECT}" --gs-json-key=<(echo "${GCP_JSON_KEY}" | base64 --decode) --api-key="${EQUINIXMETAL_KEY}"
 timeout --signal=SIGQUIT 60m ore openstack gc --duration 6h \

--- a/ci-automation/vendor-testing/azure.sh
+++ b/ci-automation/vendor-testing/azure.sh
@@ -18,11 +18,6 @@ azure_instance_type_var="AZURE_${CIA_ARCH}_MACHINE_SIZE"
 azure_instance_type="${!azure_instance_type_var}"
 azure_vnet_subnet_name="jenkins-vnet-${AZURE_LOCATION}"
 
-azure_profile_config_file=''
-secret_to_file azure_profile_config_file "${AZURE_PROFILE}"
-azure_auth_config_file=''
-secret_to_file azure_auth_config_file "${AZURE_AUTH_CREDENTIALS}"
-
 # Fetch the Azure image if not present
 if [ -f "${AZURE_IMAGE_NAME}" ] ; then
     echo "++++ ${CIA_TESTSCRIPT}: Using existing ${AZURE_IMAGE_NAME} for testing ${CIA_VERNUM} (${CIA_ARCH}) ++++"
@@ -57,8 +52,7 @@ run_kola_tests() {
       --platform=azure \
       --azure-image-file="${AZURE_IMAGE_NAME}" \
       --azure-location="${AZURE_LOCATION}" \
-      --azure-profile="${azure_profile_config_file}" \
-      --azure-auth="${azure_auth_config_file}" \
+      --azure-identity \
       --torcx-manifest="${CIA_TORCX_MANIFEST}" \
       --tapfile="${instance_tapfile}" \
       --azure-size="${instance_type}" \


### PR DESCRIPTION
Switch to using a managed identity instead of file based credentials for running kola/ore (not plume). This covers our test subscription, but not our publishing subscription.

(removed the issue template because this is only a change to ci)

Depends on this PR being merged first (and the reference in this repo being updated):
- https://github.com/flatcar/mantle/pull/456