### PR TITLE
Fix garbled output in image changes reports

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -225,6 +225,9 @@ jobs:
           )
           show_changes_env=(
               # Nothing to add.
+              "SCRIPTS_REPO=scripts"
+              "COREOS_OVERLAY_REPO=coreos-overlay"
+              "PORTAGE_STABLE_REPO=portage-stable"
           )
           show_changes_params_overrides=(
               # We may not have a tag handy, so we tell show-changes

--- a/ci-automation/image_changes.sh
+++ b/ci-automation/image_changes.sh
@@ -63,6 +63,9 @@ function image_changes() (
     show_changes_env=(
         # Provide a python3 command for the CVE DB parsing
         "PATH=${PATH}:${PWD}/ci-automation/python-bin"
+        "SCRIPTS_REPO=scripts"
+        "COREOS_OVERLAY_REPO=coreos-overlay"
+        "PORTAGE_STABLE_REPO=portage-stable"
     )
     show_changes_params_overrides=(
         # Nothing to override.


### PR DESCRIPTION
2 issues needed fixing:

- truncated leading output stemming from redirecting standard output to /dev/stdout, which is no-worky on Jenkins, apparently.
- a bug in show-changes resulting in no changelog differences being printed

Fix tested in http://jenkins.infra.kinvolk.io:8080/job/container/job/image_changes/2999/console