### PR TITLE
prefix: remove gcc-13 mask as the SDK now uses gcc-13

### DIFF
--- a/sdk_container/src/third_party/prefix-overlay/skel/etc/portage/package.mask/cross
+++ b/sdk_container/src/third_party/prefix-overlay/skel/etc/portage/package.mask/cross
@@ -1,1 +1,0 @@
->=sys-devel/gcc-13 # FIXME: Cannot cross-compile gcc 13+ using older version


### PR DESCRIPTION
Back when SDK prefix builds were introduced, the SDK shipped with gcc-12. As prefix uses experimental packages during bootstrapping of the staging area, this lead to (the SDK's) gcc-12 being used to build an experimental (prefix staging area)  gcc-13 - which led to build breakage. Therefore, gcc-13 was explicitly masked in the prefix overlay.

Now that the SDK ships gcc-13 this mask can be removed. More specifically it _must_ be removed in order for prefix bootstrapping to work, because trying to build gcc-12 with gcc-13 breaks the bootstrap build.

Relevant discussion in the original prefix PR: https://github.com/flatcar/scripts/pull/1158#discussion_r1341097924

This is a minimal, non-intrusive change that only affects the prefix overlay. Neither SDK nor OS image are affected.