### PR TITLE
Build docker with go 1.19

### DIFF
--- a/changelog/bugfixes/2023-10-09-docker-go-1.19.md
+++ b/changelog/bugfixes/2023-10-09-docker-go-1.19.md
@@ -1,0 +1,1 @@
+- Fixed a regression in Docker resulting in file permissions being dropped from exported container images. ([scripts#1231](https://github.com/flatcar/scripts/pull/1231))

--- a/sdk_container/src/third_party/coreos-overlay/app-emulation/docker-cli/docker-cli-20.10.24.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/app-emulation/docker-cli/docker-cli-20.10.24.ebuild
@@ -6,7 +6,7 @@ GIT_COMMIT=e78084afe5
 EGO_PN="github.com/docker/cli"
 
 COREOS_GO_PACKAGE="${EGO_PN}"
-COREOS_GO_VERSION="go1.18"
+COREOS_GO_VERSION="go1.19"
 
 inherit bash-completion-r1  golang-vcs-snapshot coreos-go-depend
 

--- a/sdk_container/src/third_party/coreos-overlay/app-emulation/docker-proxy/docker-proxy-9999.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/app-emulation/docker-proxy/docker-proxy-9999.ebuild
@@ -5,7 +5,7 @@ EAPI=6
 EGO_PN="github.com/docker/libnetwork"
 
 COREOS_GO_PACKAGE="${EGO_PN}"
-COREOS_GO_VERSION="go1.18"
+COREOS_GO_VERSION="go1.19"
 COREOS_GO_GO111MODULE="off"
 
 if [[ ${PV} == *9999 ]]; then

--- a/sdk_container/src/third_party/coreos-overlay/app-emulation/docker-runc/docker-runc-1.1.7.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/app-emulation/docker-runc/docker-runc-1.1.7.ebuild
@@ -5,7 +5,7 @@ EAPI=6
 
 GITHUB_URI="github.com/opencontainers/runc"
 COREOS_GO_PACKAGE="${GITHUB_URI}"
-COREOS_GO_VERSION="go1.18"
+COREOS_GO_VERSION="go1.19"
 # the commit of runc that docker uses.
 # see https://github.com/docker/docker-ce/blob/v19.03.15/components/engine/hack/dockerfile/install/runc.installer#L4
 COMMIT_ID="532d81d385677036958916d9aed5dd3431c5edb5"

--- a/sdk_container/src/third_party/coreos-overlay/app-emulation/docker/docker-20.10.24.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/app-emulation/docker/docker-20.10.24.ebuild
@@ -4,7 +4,7 @@
 EAPI=7
 EGO_PN=github.com/docker/docker
 GIT_COMMIT=d6cbf44b8c
-COREOS_GO_VERSION="go1.18"
+COREOS_GO_VERSION="go1.19"
 COREOS_GO_GO111MODULE="off"
 
 inherit bash-completion-r1 linux-info systemd udev golang-vcs-snapshot


### PR DESCRIPTION
# Build docker with go 1.19

Docker 20.10.24 expects to be built with go 1.19 and if it isn't certain unix level functionality is broken. We already bumped to building with go 1.19 for alpha-3619.0.0, so this change it present in beta/alpha/main.

Fixes a regression in stable https://github.com/flatcar/Flatcar/issues/1203.

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
