### PR TITLE
coreos-base/misc-files: Make Kubernetes work by default through symlink

### DIFF
--- a/changelog/changes/2023-10-09-kubernetes-usr-libexec.md
+++ b/changelog/changes/2023-10-09-kubernetes-usr-libexec.md
@@ -1,0 +1,1 @@
+- To make Kubernetes work by default, `/usr/libexec/kubernetes/kubelet-plugins/volume/exec` is now a symlink to the writable folder `/var/kubernetes/kubelet-plugins/volume/exec` ([Flatcar#1193](https://github.com/flatcar/Flatcar/issues/1193))

--- a/sdk_container/src/third_party/coreos-overlay/coreos-base/misc-files/misc-files-0-r2.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/coreos-base/misc-files/misc-files-0-r2.ebuild
@@ -142,4 +142,9 @@ src_install() {
         # Enable some sockets that aren't enabled by their own ebuilds.
         systemd_enable_service sockets.target sshd.socket
     fi
+
+    # Create a symlink for Kubernetes to redirect writes from /usr/libexec/... to /var/kubernetes/...
+    # (The below keepdir will result in a tmpfiles entry in base_image_var.conf)
+    keepdir /var/kubernetes/kubelet-plugins/volume/exec
+    dosym /var/kubernetes/kubelet-plugins/volume/exec /usr/libexec/kubernetes/kubelet-plugins/volume/exec
 }


### PR DESCRIPTION
In the past user had to customize Kubernetes or use a bind mount to make writing the default /usr/libexec/kubernetes/ path work. With systemd-sysext on by default the bind mount doesn't work anymore because it can get lost. A newer workaround is to use a systemd-sysext image that creates a symlink in /usr/libexec/... to redirect to somewhere under /var/.
Instead of relying on workarounds, make Kubernetes work by default on Flatcar by having the symlink be part of the generic image. The target folder will be created through a tmpfiles rule.

(The same paths are used as in https://github.com/flatcar/sysext-bakery/pull/28)
## How to use

Backport to Stable and maybe even LTS?

## Testing done

[Done](http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/2690/cldsv/):
Checked that the symlink exists under `/usr` and that the target dir is created by a tmpfile rule in `base_image_var.conf` (`base_image_var.conf:d /var/kubernetes/kubelet-plugins/volume/exec 0755 root       root       - -`)

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [x] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
