### PR TITLE
sdk_lib: Workaround docker issue with missing ownership preservation

### DIFF
--- a/sdk_lib/Dockerfile.sdk-import
+++ b/sdk_lib/Dockerfile.sdk-import
@@ -34,7 +34,6 @@ RUN chown sdk:sdk /mnt/host/source
 COPY sdk_lib/90_env_keep /etc/sudoers.d/90_env_keep
 RUN chmod 0440 /etc/sudoers.d/90_env_keep
 
-USER sdk:sdk
 RUN mkdir -p /mnt/host/source/src/scripts /mnt/host/source/src/build
 RUN ln -s /mnt/host/source /home/sdk/trunk
 
@@ -47,12 +46,13 @@ RUN echo 'export PATH="$PATH:/usr/local/bin:/usr/local/sbin"' >> /home/sdk/.bash
 RUN echo "if [ -f /mnt/host/source/.env ]; then source /mnt/host/source/.env; fi" >> /home/sdk/.bashrc
 RUN echo "if [ -f /mnt/host/source/.sdkenv ]; then source /mnt/host/source/.sdkenv; fi" >> /home/sdk/.bashrc
 
+RUN chown -h sdk:sdk /mnt/host/source/src/scripts /mnt/host/source/src/build /home/sdk/trunk /home/sdk/.bashrc
+
 COPY --chown=sdk:sdk sdk_lib/sdk_entry.sh /home/sdk
 RUN chmod 755 /home/sdk/sdk_entry.sh
 
-USER root:root
 # This should be a NOP; if you see packages being rebuilt
-#  it's likely that submodules and SDK tarball are out of sync
+#  it's likely that scripts and SDK tarball are out of sync
 RUN /home/sdk/sdk_entry.sh ./update_chroot --toolchain_boards="amd64-usr arm64-usr"
 
 ENTRYPOINT /home/sdk/sdk_entry.sh


### PR DESCRIPTION
Just do stuff as root for now.

The workaround can be removed when our builders pick up a stable release with a fix.

CI: (weekly package updates using this commit): http://jenkins.infra.kinvolk.io:8080/job/container/job/sdk/1103/cldsv/
