### PR TITLE
ci-automation: Update the SDK container extension in check

### DIFF
--- a/ci-automation/sdk_bootstrap.sh
+++ b/ci-automation/sdk_bootstrap.sh
@@ -115,7 +115,7 @@ function _sdk_bootstrap_impl() {
             local flatcar_version="${versions[1]}"
             local sdk_docker_vernum=""
             sdk_docker_vernum=$(vernum_to_docker_image_version "${flatcar_sdk_version}")
-            if curl --head --fail --silent --show-error --location "https://${BUILDCACHE_SERVER}/containers/${sdk_docker_vernum}/flatcar-sdk-all-${sdk_docker_vernum}.tar.gz" \
+            if curl --head --fail --silent --show-error --location "https://${BUILDCACHE_SERVER}/containers/${sdk_docker_vernum}/flatcar-sdk-all-${sdk_docker_vernum}.tar.zst" \
               && curl --head --fail --silent --show-error --location "https://${BUILDCACHE_SERVER}/images/amd64/${flatcar_version}/flatcar_production_image.bin.bz2" \
               && curl --head --fail --silent --show-error --location "https://${BUILDCACHE_SERVER}/images/arm64/${flatcar_version}/flatcar_production_image.bin.bz2"; then
                 echo "Stopping build because there are no changes since tag ${existing_tag}, the SDK container tar ball and the Flatcar images exist" >&2


### PR DESCRIPTION
We have switched to zst for SDK container tarballs.
