### PR TITLE
build_packages: fix systemd cyclic deps resolver

### DIFF
--- a/build_packages
+++ b/build_packages
@@ -276,7 +276,7 @@ if [[ "${FLAGS_usepkgonly}" -eq "${FLAGS_FALSE}" ]]; then
   break_dep_loop sys-apps/util-linux udev,systemd,cryptsetup \
                  sys-fs/cryptsetup udev \
                  sys-fs/lvm2 udev,systemd \
-                 sys-apps/systemd cryptsetup,curl \
+                 sys-apps/systemd cryptsetup \
                  net-misc/curl http2 \
                  net-libs/nghttp2 systemd
 fi


### PR DESCRIPTION
This change removes "curl" from the USE flags to be removed to build systemd in the cyclic deps resolver step of build_packages. Excluding curl from systemd's USE flags leads to build breakage:

```
09:06:25  !!! The ebuild selected to satisfy "sys-apps/systemd" for /build/amd64-usr/ has unmet requirements. 09:06:25  - sys-apps/systemd-252.11-r1::coreos USE="audit dns-over-tls elfutils gcrypt gnuefi http idn importd iptables kmod lz4 lzma openssl pam pcre policykit resolvconf seccomp selinux (sysv-utils) (vanilla) zstd -acl -apparmor -cgroup-hybrid -cryptsetup -curl -fido2 -gnutls -homed -pkcs11 -pwquality -qrcode (-split-usr) -test -tpm -xkb" 09:06:25
09:06:25    The following REQUIRED_USE flag constraints are unsatisfied:
09:06:25      importd? ( curl )
09:06:25
09:06:25    The above constraints are a subset of the following complete expression:
09:06:25      dns-over-tls? ( any-of ( gnutls openssl ) ) homed? ( cryptsetup pam openssl ) importd? ( curl lzma any-of ( gcrypt openssl ) ) pwquality? ( homed )
```