### PR TITLE
coreos-base/update_engine: Fix iterating over signatures

### DIFF
--- a/changelog/bugfixes/2023-11-02-oem-update.md
+++ b/changelog/bugfixes/2023-11-02-oem-update.md
@@ -1,0 +1,1 @@
+- Fixed iterating over the OEM update payload signatures which prevented the AWS OEM update to 3745.x.y ([update-engine#31](https://github.com/flatcar/update_engine/pull/31))

--- a/sdk_container/src/third_party/coreos-overlay/coreos-base/update_engine/update_engine-9999.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/coreos-base/update_engine/update_engine-9999.ebuild
@@ -8,7 +8,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="e4b55716dc08be6211026730f0bbf94e6ce44d51" # flatcar-master
+	CROS_WORKON_COMMIT="d262b46e4c0595e6cefa726a19b8b8c1cdf167a5" # flatcar-master
 	KEYWORDS="amd64 arm64"
 fi
 


### PR DESCRIPTION
This pulls in
https://github.com/flatcar/update_engine/pull/31
to correctly skip over signature entries that cause errors which can be the case for the dummy signatures.

## How to use

Backport to Beta

## Testing done

Manually
