### PR TITLE
Improve git worktree handling when creating SDK containers

### DIFF
--- a/run_sdk_container
+++ b/run_sdk_container
@@ -164,13 +164,51 @@ if [[ -z ${stat} ]] ; then
         call_docker pull "${container_image_name}" || true
     fi
 
+    source sdk_lib/git_worktree_handling.sh
+    main_scripts_repo=''
+    declare -A linked_scripts_repos=()
+    discover_repo_layout . main_scripts_repo linked_scripts_repos
+    scripts_mounts=()
+    if [[ ${#linked_scripts_repos[@]} -gt 0 ]]; then
+        this_name=''
+        linked_repo_name '.' "${main_scripts_repo}" linked_scripts_repos this_name
+        if [[ -n ${this_name} ]]; then
+            base_directory='/mnt/host/scripts-worktrees'
+            declare -A scripts_overrides=(["${this_name}"]="/mnt/host/source/src/scripts")
+            main_scripts_repo_sdk=''
+            declare -A linked_scripts_repos_sdk=()
+            repo_layout_inside_sdk \
+                "${base_directory}" \
+                scripts_overrides \
+                main_scripts_repo_sdk \
+                linked_scripts_repos_sdk \
+                "${!linked_scripts_repos[@]}"
+            repo_layouts_to_docker_volumes \
+                "${main_scripts_repo}" \
+                "${main_scripts_repo_sdk}" \
+                linked_scripts_repos \
+                linked_scripts_repos_sdk \
+                scripts_mounts
+            # sdk_entry will read this directory and remove it afterwards
+            mkdir -p .replacements
+            replacements_file=$(mktemp --tmpdir=.replacements replacements-XXXXXXXXXX)
+            repo_layout_to_replacements \
+                "${main_scripts_repo_sdk}" \
+                linked_scripts_repos_sdk \
+                "${replacements_file}"
+        fi
+    fi
+    if [[ ${#scripts_mounts[@]} -eq 0 ]]; then
+        scripts_mounts+=(-v "${PWD}:/mnt/host/source/src/scripts")
+    fi
+
     docker_flags=(
         "${tty[@]}"
         -i
         -v /dev:/dev
         -v "${PWD}/sdk_container:/mnt/host/source/"
         -v "${PWD}/__build__/images:/mnt/host/source/src/build"
-        -v "${PWD}:/mnt/host/source/src/scripts"
+        "${scripts_mounts[@]}"
         "${gpg_volumes[@]}"
         "${mounts[@]}"
         --privileged

--- a/run_sdk_container
+++ b/run_sdk_container
@@ -115,6 +115,36 @@ if [[ -n ${cleanup} ]] ; then
     echo "${docker_a[@]@Q} container rm -f ${name@Q}" >>"${cleanup}"
 fi
 
+function prev_trap_cmd {
+    local sig=${1}; shift
+    local cmd=$(trap -p "${sig}")
+
+    if [[ -z ${cmd} ]]; then
+        echo ':'
+    fi
+
+    cmd=${cmd#'trap -- '}
+    cmd=${cmd%" ${sig}"}
+
+    # This unquotes the trap cmd. So the following:
+    #
+    # 'echo '\''foo'\'''
+    #
+    # becomes:
+    #
+    # echo 'foo'
+    xargs <<<"${cmd}"
+}
+
+function add_trap {
+    local cmd sig
+    cmd=${1}; shift
+    sig=${1}; shift
+
+    full_cmd="$(prev_trap_cmd "${sig}"); ${cmd}"
+    trap "${full_cmd}" "${sig}"
+}
+
 if [[ -z ${stat} ]] ; then
     yell "Creating a new container '$name'"
 
@@ -159,12 +189,10 @@ fi
 
 if [[ ${stat} != "Up" ]] ; then
     yell "Starting stopped container '$name'"
+    add_trap "call_docker stop -t 0 ${name@Q}" EXIT
     if [[ -n ${remove} ]]; then
-      remove_command="call_docker rm -f ${name@Q}"
-    else
-      remove_command=":"
+        add_trap "call_docker rm -f ${name@Q}" EXIT
     fi
-    trap "call_docker stop -t 0 ${name@Q} ; ${remove_command}" EXIT
     call_docker start "${name}"
 fi
 

--- a/run_sdk_container
+++ b/run_sdk_container
@@ -19,10 +19,11 @@ tty=()
 remove=""
 cleanup=""
 mounts=()
+git_repos=()
 
 usage() {
     echo "  Usage:"
-    echo "  $0 [-t] [-v <version>] [-V <SDK version>] [-a <amd64|arm64|all>] [-n <name> ] [-x <script>] [-C <custom-container>] [--rm] [-U] [-m <src>:<dest>] [<container-command>]"
+    echo "  $0 [-t] [-v <version>] [-V <SDK version>] [-a <arch>] [-n <name> ] [-x <script>] [-C <custom-container>] [--rm] [-U] [-m <src>:<dest>] [-g <name>:<src>:<dest>] [<container-command>]"
     echo "       Start an SDK container of a given SDK release version."
     echo "       This will create the container if it does not exist, otherwise start the existing container."
     echo "       If the container is already running then it will exec into the container."
@@ -49,6 +50,11 @@ usage() {
     echo "      -U             Do not update the versionfile. Instead, use the version from the versionfile as-is."
     echo "      -m <src>:<dest> - Mount local file or directory inside the container."
     echo "                     Can be specified multiple times."
+    echo "      -g <name:><src>:<dest> - Mount local git repository inside the container."
+    echo "                     Takes care of properly mounting and setting up "
+    echo "                     other worktrees of the git repo inside the container."
+    echo "                     Can be specified multiple times, but each with different name."
+    echo "                     <name> can't be 'scripts'"
     echo "      -h             Print this help."
     echo
 }
@@ -72,6 +78,7 @@ while [[ $# -gt 0 ]] ; do
         update_versionfile=
         shift;;
     -m) mounts+=( -v "$2" ); shift; shift;;
+    -g) git_repos+=( "$2" ); shift; shift;;
     *) break;;
     esac
 done
@@ -165,42 +172,54 @@ if [[ -z ${stat} ]] ; then
     fi
 
     source sdk_lib/git_worktree_handling.sh
-    main_scripts_repo=''
-    declare -A linked_scripts_repos=()
-    discover_repo_layout . main_scripts_repo linked_scripts_repos
-    scripts_mounts=()
-    if [[ ${#linked_scripts_repos[@]} -gt 0 ]]; then
-        this_name=''
-        linked_repo_name '.' "${main_scripts_repo}" linked_scripts_repos this_name
-        if [[ -n ${this_name} ]]; then
-            base_directory='/mnt/host/scripts-worktrees'
-            declare -A scripts_overrides=(["${this_name}"]="/mnt/host/source/src/scripts")
-            main_scripts_repo_sdk=''
-            declare -A linked_scripts_repos_sdk=()
-            repo_layout_inside_sdk \
-                "${base_directory}" \
-                scripts_overrides \
-                main_scripts_repo_sdk \
-                linked_scripts_repos_sdk \
-                "${!linked_scripts_repos[@]}"
-            repo_layouts_to_docker_volumes \
-                "${main_scripts_repo}" \
-                "${main_scripts_repo_sdk}" \
-                linked_scripts_repos \
-                linked_scripts_repos_sdk \
-                scripts_mounts
-            # sdk_entry will read this directory and remove it afterwards
-            mkdir -p .replacements
-            replacements_file=$(mktemp --tmpdir=.replacements replacements-XXXXXXXXXX)
-            repo_layout_to_replacements \
-                "${main_scripts_repo_sdk}" \
-                linked_scripts_repos_sdk \
-                "${replacements_file}"
+    declare -A linked_repos repo_overrides linked_repos_sdk
+    declare -a repo_mounts=() fields
+    for git_repo in "scripts:${PWD}:/mnt/host/source/src/scripts" "${git_repos[@]}"; do
+        mapfile -t fields <<<${git_repo//:/$'\n'}
+        if [[ ${#fields[@]} -ne 3 ]]; then
+            echo "invalid -g parameter, should have 3 fields, has ${#fields[@]}: ${git_repo}" >&2
+            exit 1
         fi
-    fi
-    if [[ ${#scripts_mounts[@]} -eq 0 ]]; then
-        scripts_mounts+=(-v "${PWD}:/mnt/host/source/src/scripts")
-    fi
+        main_name=${fields[0]}
+        path=${fields[1]}
+        sdk_path=${fields[2]}
+        main_repo=''
+        linked_repos=()
+        discover_repo_layout "${path}" main_repo linked_repos
+        if [[ ${#linked_repos[@]} -gt 0 ]]; then
+            this_name=''
+            linked_repo_name "${path}" "${main_repo}" linked_repos this_name
+            if [[ -n ${this_name} ]]; then
+                base_directory="/mnt/host/all-worktrees/${main_name}"
+                repo_overrides=(["${this_name}"]="${sdk_path}")
+                main_repo_sdk=''
+                linked_repos_sdk=()
+                new_repo_mounts=()
+                repo_layout_inside_sdk \
+                    "${base_directory}" \
+                    repo_overrides \
+                    main_repo_sdk \
+                    linked_repos_sdk \
+                    "${!linked_repos[@]}"
+                repo_layouts_to_docker_volumes \
+                    "${main_repo}" \
+                    "${main_repo_sdk}" \
+                    linked_repos \
+                    linked_repos_sdk \
+                    new_repo_mounts
+                repo_mounts+=( "${new_repo_mounts[@]}" )
+                # sdk_entry will read this directory and remove it afterwards
+                mkdir -p .replacements
+                replacements_file=$(mktemp --tmpdir=.replacements replacements-XXXXXXXXXX)
+                repo_layout_to_replacements \
+                    "${main_repo_sdk}" \
+                    linked_repos_sdk \
+                    "${replacements_file}"
+            fi
+        else
+            repo_mounts+=( -v "${path}:${sdk_path}" )
+        fi
+    done
 
     docker_flags=(
         "${tty[@]}"
@@ -208,7 +227,7 @@ if [[ -z ${stat} ]] ; then
         -v /dev:/dev
         -v "${PWD}/sdk_container:/mnt/host/source/"
         -v "${PWD}/__build__/images:/mnt/host/source/src/build"
-        "${scripts_mounts[@]}"
+        "${repo_mounts[@]}"
         "${gpg_volumes[@]}"
         "${mounts[@]}"
         --privileged

--- a/sdk_lib/git_worktree_handling.sh
+++ b/sdk_lib/git_worktree_handling.sh
@@ -1,0 +1,232 @@
+#!/bin/bash
+
+if [[ -z ${WORKAROUND_WORKTREES_SH_INCLUDED:-} ]]; then
+
+WORKAROUND_WORKTREES_SH_INCLUDED=x
+
+# 1 - path to a git repository
+# 2 - name of a variable that contain a path to the main repo
+# 3 - name of a variable that will be a linked repos map (names to paths)
+function discover_repo_layout {
+    local path main_repo_var_name linked_repos_map_var_name
+    path=${1}; shift
+    main_repo_var_name=${1}; shift
+    linked_repos_map_var_name=${1}; shift
+    local -n main_repo_ref=${main_repo_var_name}
+    local -n linked_repos_map_ref=${linked_repos_map_var_name}
+
+    local dot_git=${path}/.git
+    local main_repo_path
+    if [[ -d ${dot_git} ]]; then
+        main_repo_path=$(realpath "${path}")
+    elif [[ -f ${dot_git} ]]; then
+        main_repo_path=$(head -n1 "${dot_git}")
+        main_repo_path=${main_repo_path#* }
+        local found base
+        found=
+        while [[ ${main_repo_path%/*} != "${main_repo_path}" ]]; do
+            base=${main_repo_path##*/}
+            main_repo_path=${main_repo_path%/*}
+            if [[ ${base} = '.git' ]]; then
+                found=x
+                break
+            fi
+        done
+        if [[ -z ${found} ]]; then
+            echo "${FUNCNAME[0]}: possibly corrupted linked repo .git file ${dot_git@Q}, could not figure out path to the main repo" >&2
+            return 1
+        fi
+        unset found base
+    fi
+    main_repo_ref=${main_repo_path}
+    linked_repos_map_ref=()
+    local in_worktree_gitdir_file in_worktree_gitdir_dir
+    local bogus entry linked_repo_name linked_repo_path
+    while read -r in_worktree_gitdir_file; do
+        in_worktree_gitdir_dir=${in_worktree_gitdir_file%/gitdir}
+        bogus=
+        for entry in commondir HEAD index; do
+            if [[ ! -e ${in_worktree_gitdir_dir}/${entry} ]]; then
+                bogus=x
+                break
+            fi
+        done
+        if [[ ! -d ${in_worktree_gitdir_dir}/logs ]]; then
+            bogus=x
+        fi
+        if [[ -n ${bogus} ]]; then
+            echo "${FUNCNAME[0]}: ${in_worktree_gitdir_file@Q} is bogus, skipping" >&2
+            continue
+        fi
+        linked_repo_name=${in_worktree_gitdir_file}
+        linked_repo_name=${linked_repo_name#"${main_repo_path}/.git/worktrees/"}
+        linked_repo_name=${linked_repo_name%/gitdir}
+        linked_repo_path=$(cat "${in_worktree_gitdir_file}")
+        linked_repo_path=${linked_repo_path%/.git}
+        linked_repos_map_ref["${linked_repo_name}"]=${linked_repo_path}
+    done < <(find "${main_repo_path}/.git/worktrees" -name gitdir)
+    return 0
+}
+
+# 1 - path to repo
+# 2 - main repo path
+# 3 - name of a variable that is a linked repos map (names to paths)
+# 4 - name of a variable that will contain the linked repo name,
+#     prefixed with "ex-"; will empty if not found, will be just "ex-" for main repo
+function linked_repo_name {
+    local path main_repo_path linked_repos_map_var_name repo_name_var_name
+    path=${1}; shift
+    main_repo_path=${1}; shift
+    linked_repos_map_var_name=${1}; shift
+    repo_name_var_name=${1}; shift
+    local -n linked_repos_map_ref=${linked_repos_map_var_name}
+    local -n repo_name_ref=${repo_name_var_name}
+
+    repo_name_ref=''
+    # git is using real paths
+    local real_path=$(realpath "${path}")
+    if [[ ${real_path} = "${main_repo_path}" ]]; then
+        repo_name_ref='ex-'
+    else
+        local name linked_path
+        for name in "${!linked_repos_map_ref[@]}"; do
+            linked_path=${linked_repos_map_ref["${name}"]}
+            if [[ ${linked_path} == "${real_path}" ]]; then
+                repo_name_ref="ex-${name}"
+                break
+            fi
+        done
+    fi
+}
+
+# 1 - base directory in SDK
+# 2 - name of a variable that is an overrides map (names to paths),
+#     names should be "ex-${name}", for main repo - just "ex-"
+# 3 - name of a variable that will contain path to main repo inside SDK
+# 4 - name of a variable that will be a linked repos map inside SDK (names to paths)
+# @ - linked repo names
+function repo_layout_inside_sdk {
+    local base_directory_sdk
+    local overrides_map_var_name main_repo_path_sdk_var_name linked_repos_sdk_map_var_name
+    base_directory_sdk=${1}; shift
+    overrides_map_var_name=${1}; shift
+    main_repo_path_sdk_var_name=${1}; shift
+    linked_repos_sdk_map_var_name=${1}; shift
+    # rest are names
+    local -n overrides_map_ref=${overrides_map_var_name}
+    local -n main_repo_path_sdk_ref=${main_repo_path_sdk_var_name}
+    local -n linked_repos_sdk_map_ref=${linked_repos_sdk_map_var_name}
+
+    local override=${overrides_map_ref['ex-']:-}
+    if [[ -n ${override} ]]; then
+        main_repo_path_sdk_ref=${override}
+    else
+        main_repo_path_sdk_ref=${base_directory_sdk}/main-repo
+    fi
+
+    local name
+    linked_repos_sdk_map_ref=()
+    for name; do
+        override=${overrides_map_ref["ex-${name}"]:-}
+        if [[ -n ${override} ]]; then
+            linked_repos_sdk_map_ref["${name}"]=${override}
+        else
+            linked_repos_sdk_map_ref["${name}"]=${base_directory_sdk}/linked/${name}
+        fi
+    done
+}
+
+# 1 - main repo path
+# 2 - main repo path in SDK
+# 3 - name of a variable that is a linked repos map (names to paths)
+# 4 - name of a variable that is a linked repos map in SDK (names to paths)
+# 5 - name of a variable that will be a volumes array
+function repo_layouts_to_docker_volumes {
+    local main_repo_path main_repo_path_sdk
+    local linked_repos_map_var_name linked_repos_sdk_map_var_name volumes_var_name
+    main_repo_path=${1}; shift
+    main_repo_path_sdk=${1}; shift
+    linked_repos_map_var_name=${1}; shift
+    linked_repos_sdk_map_var_name=${1}; shift
+    volumes_var_name=${1}; shift
+    local -n linked_repos_map_ref=${linked_repos_map_var_name}
+    local -n linked_repos_sdk_map_ref=${linked_repos_sdk_map_var_name}
+    local -n volumes_ref=${volumes_var_name}
+
+    volumes_ref=( -v "${main_repo_path}:${main_repo_path_sdk}" )
+    local name path path_sdk
+    for name in "${!linked_repos_map_ref[@]}"; do
+        path=${linked_repos_map_ref["${name}"]}
+        path_sdk=${linked_repos_sdk_map_ref["${name}"]}
+        volumes_ref+=( -v "${path}:${path_sdk}" )
+    done
+}
+
+# 1 - main repo path (usually the one in SDK)
+# 2 - name of a variable that is a linked repos map (usually the one in SDK) (names to paths)
+# 3 - path to file with replacements
+function repo_layout_to_replacements {
+    local main_repo_path linked_repos_map_var_name replacements_path
+    main_repo_path=${1}; shift
+    linked_repos_map_var_name=${1}; shift
+    replacements_path=${1}; shift
+    local -n linked_repos_map_ref=${linked_repos_map_var_name}
+
+    {
+        cat <<'EOF'
+if [[ ${1} = 'local' ]]; then
+    local -A REPLACEMENTS
+fi
+
+REPLACEMENTS=(
+EOF
+        local -a pairs
+        pairs=()
+        local name path
+        for name in "${!linked_repos_map_ref[@]}"; do
+            path=${linked_repos_map_ref["${name}"]}
+            pairs+=(
+                "${main_repo_path}/.git/worktrees/${name}/gitdir" "${path}/.git"
+                "${path}/.git" "gitdir: ${main_repo_path}/.git/worktrees/${name}"
+            )
+        done
+        printf '    [%s]=%s\n' "${pairs[@]@Q}"
+        cat <<'EOF'
+)
+EOF
+    } >"${replacements_path}"
+}
+
+# 1 - path to replacements file (to be sourced)
+# 2 - path a scrap directory
+# 3 - path to undo file
+function replacements_to_bind_mounts {
+    local replacements_path scrap_dir undo_path
+    replacements_path=${1}; shift
+    scrap_dir=${1}; shift
+    undo_path=${1}; shift
+
+    # Brings in REPLACEMENTS.
+    source "${replacements_path}" 'local'
+
+    local -a paths
+    paths=()
+
+    local path contents scrap_file ug
+    for path in "${!REPLACEMENTS[@]}"; do
+        contents=${REPLACEMENTS["${path}"]}
+        scrap_file=$(mktemp --tmpdir="${scrap_dir}" scrap-XXXXXXXXXX)
+        ug=$(stat --format='%u:%g' "${path}")
+        echo "${contents}" >"${scrap_file}"
+        sudo chown "${ug}" "${scrap_file}"
+        sudo mount --bind "${scrap_file}" "${path}"
+        rm -f "${scrap_file}"
+        paths+=( "${path}" )
+    done
+
+    {
+        echo "sudo umount ${paths[@]@Q}"
+    }>"${undo_path}"
+}
+
+fi

--- a/sdk_lib/sdk_entry.sh
+++ b/sdk_lib/sdk_entry.sh
@@ -8,6 +8,17 @@ if [ -n "${SDK_GROUP_ID:-}" ] ; then
     groupmod --non-unique -g $SDK_GROUP_ID sdk
 fi
 
+if [[ -d /mnt/host/source/src/scripts/.replacements ]]; then
+    mv /mnt/host/source/src/scripts/.replacements /root/replacements
+    (
+        source /home/sdk/trunk/src/scripts/sdk_lib/git_worktree_handling.sh
+        for path in /root/replacements/*; do
+            replacements_to_bind_mounts "${path}" /root /dev/null
+        done
+    )
+    rm -rf /root/replacements
+fi
+
 chown -R sdk:sdk /home/sdk
 
 # Check if the OS image version we're working on is newer than


### PR DESCRIPTION
This mounts all related worktrees of the scripts repo and of any extra git repo passed through the -g option into the SDK container, so:
- git can be used on the worktree without errors
- worktrees won't be treated as stale and eventually pruned

For more details, please see the commit messages, especially the one that adds the git worktree handling library.

Tested locally.