### PR TITLE
test_image_content.sh: remove 202209-12 exception (grub)

### DIFF
--- a/build_library/test_image_content.sh
+++ b/build_library/test_image_content.sh
@@ -4,7 +4,6 @@
 
 GLSA_ALLOWLIST=(
 	201412-09 # incompatible CA certificate version numbers
-	202209-12 # grub 2.06 is still in progress
 )
 
 glsa_image() {


### PR DESCRIPTION
We updated grub to >=2.06 and thus 202209-12 can be removed from the GLSA allowlist.

A GLSA check is run during `build_packages` so if the grub GLSA would still apply then the CI build would fail.