### PR TITLE
run_local_tests.sh: unquote tests var so lists and kola options can pass

### DIFF
--- a/run_local_tests.sh
+++ b/run_local_tests.sh
@@ -104,7 +104,7 @@ function run_local_tests() (
   if [[ -n "${tests}" ]] ; then
     echo "================================="
     echo "Running qemu_uefi tests"
-    test_run "${arch}" qemu_uefi "${tests}"
+    test_run "${arch}" qemu_uefi ${tests}
   fi
 
   if ${update_tests} ; then


### PR DESCRIPTION
This one-line change un-quotes the list of user supplied tests so it actually arrives as a list to the test script instead of a single string. We simply unquote instead of using `${test@Q}` because the latter breaks a neat little hack in which users can pass parameters like `--log-level=DEBUG`  to kola.