### PR TITLE
profiles: slsa: Remove quadratic complexity in SRC_URI iteration

### DIFF
--- a/sdk_container/src/third_party/coreos-overlay/profiles/coreos/base/profile.bashrc.slsa-provenance
+++ b/sdk_container/src/third_party/coreos-overlay/profiles/coreos/base/profile.bashrc.slsa-provenance
@@ -77,29 +77,34 @@ __slsa_provenance_materials() {
         # There can be multiple, and can be used conditionally based on use flags,
         #  and even replaced with different local names ("http://... -> othername.tgz"). So
         #  we go through what's actually used ($A), then find the corresponding source URI.
+        declare -A uri_dict
         local src="" prev_uri="" rename="false" orig_name=""
+        for uri in ${SRC_URI}; do
+            if [ "${uri}" = "->" ] ; then
+                rename="true"
+                continue
+            fi
+            local base_name="$(basename "${uri}")"
+            if [ "${rename}" = "true" ] ; then
+                prev_base_name="$(basename "${prev_uri}")"
+                unset uri_dict["${prev_base_name}"]
+                uri="${prev_uri}"
+            fi
+            uri_dict["${base_name}"]="${uri}"
+            rename="false"
+            prev_uri="${uri}"
+        done
         for src in ${A}; do
             local found="false"
-            for uri in ${SRC_URI}; do
-                if [ "${uri}" = "->" ] ; then
-                    rename="true"
-                    continue
-                fi
-                if [ "${src}" = "$(basename "${uri}")" ] ; then
-                    orig_name="${src}"
-                    if [ "${rename}" = "true" ] ; then
-                        uri="${prev_uri}"
-                        orig_name="$(basename "${uri}")"
-                    fi
-                    einfo "    Provenance: recording tarball material (input) '${src}' ('${orig_name}')"
-                    csum="$(sha512sum "${DISTDIR}/${src}" | cut -d' ' -f1)"
-                    echo -e ",\n      { \"uri\": \"${uri}\","
-                    echo -n "        \"digest\": {\"sha512\":\"${csum}\"} }"
-                    found="true"
-                fi
-                rename="false"
-                prev_uri="${uri}"
-            done
+            uri="${uri_dict["${src}"]}"
+            if [ -n "${uri}" ] ; then
+                orig_name="${src}"
+                einfo "    Provenance: recording tarball material (input) '${src}' ('${orig_name}')"
+                csum="$(sha512sum "${DISTDIR}/${src}" | cut -d' ' -f1)"
+                echo -e ",\n      { \"uri\": \"${uri}\","
+                echo -n "        \"digest\": {\"sha512\":\"${csum}\"} }"
+                found="true"
+            fi
             if [ "${found}" != "true" ] ; then
                 die "No SRC_URI found for source '${src}', unable to record provenance!"
             fi


### PR DESCRIPTION
# speed up slsa provenance generation for some packages

SLSA provenance generation iterates over $A (which is a subset of $SRC_URI) and for each of those tries to find a match in $SRC_URI. That's quadratic complexity, and the performance impact is bad because we shell out to a helper utility (basename) for every entry. This is leading to long stalls when generating SLSA for packages with long distfile lists, like go and rust packages. Iterate over SRC_URI once and create a dictionary to speed up subsequent lookups. dev-db/etcdctl is a good candidate for testing.

## How to use

```
time emerge-amd64-usr etcdtctl
```

## Testing done

Before: >10min on my laptop
After: 1min on my laptop (includes build time)

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
