### PR TITLE
build_library/sysext_prod_builder: Add debug output

### DIFF
--- a/build_library/sysext_prod_builder
+++ b/build_library/sysext_prod_builder
@@ -67,7 +67,14 @@ create_prod_sysext() {
   sudo mv "${workdir}/sysext-build/${name}.raw" "${workdir}/sysext-build/${name}_pkginfo.raw" \
                               "${workdir}/sysext-build/${name}"_*.txt "${output_dir}"
 
-  sudo mkdir -p "${install_root}"/usr/share/flatcar/sysext
+  sudo mkdir -p "${install_root}"/usr/share/flatcar/sysext || {
+    echo "DEBUG OUTPUT:"
+    mount
+    df -h
+    sudo dmesg
+    echo "END DEBUG OUTPUT"
+    exit 1
+  }
   sudo install -m 0644 -D "${output_dir}/${name}.raw" "${install_root}"/usr/share/flatcar/sysext/
 
   sudo mkdir -p "${install_root}"/etc/extensions/


### PR DESCRIPTION
We see occasional failures due to a read-only filesystem on GitHub Action runners:
  mkdir: cannot create directory ‘/home/sdk/trunk/src/scripts/artifacts/amd64-usr/developer-3790.0.0+nightly-20231116-2100-5-g49eb1a4c07-a1/rootfs/usr/share/flatcar/sysext’: Read-only file system

Add commands for a debug output.

