### PR TITLE
changelog: improved messaging for torcx removal and docker 24 upgrade

### DIFF
--- a/changelog/changes/2023-10-19-torcx-removal.md
+++ b/changelog/changes/2023-10-19-torcx-removal.md
@@ -1,4 +1,6 @@
 - **torcx was replaced by systemd-sysext in the OS image**. Learn more about sysext and how to customise OS images [here](https://www.flatcar.org/docs/latest/provisioning/sysext/).
+  - Torcx entered deprecation 2 years ago in favour of [deploying plain Docker binaries](https://www.flatcar.org/docs/latest/container-runtimes/use-a-custom-docker-or-containerd-version/)
+    (which is now also a legacy option because systemd-sysext offers a more robust and better structured way of customisation, including OS independent updates).
   - Torcx has been removed entirely; if you use torcx to extend the Flatcar base OS image, please refer to our [conversion script](https://www.flatcar.org/docs/latest/provisioning/sysext/#torcx-deprecation) and to the sysext documentation mentioned above for migrating.
   - Consequently, `update_engine` will not perform torcx sanity checks post-update anymore.
   - Relevant changes: [scripts#1216](https://github.com/flatcar/scripts/pull/1216), [update_engine#30](https://github.com/flatcar/update_engine/pull/30), [Mantle#466](https://github.com/flatcar/mantle/pull/466), [Mantle#465](https://github.com/flatcar/mantle/pull/465).

--- a/changelog/changes/2023-10-25-docker-gentoo-upstream.md
+++ b/changelog/changes/2023-10-25-docker-gentoo-upstream.md
@@ -1,4 +1,4 @@
-- cri-tools, runc, containerd, docker, and docker-cli are now shipped without debugging symbols and built from Gentoo upstream ebuilds. Docker was updated to Docker 24 (see "updates").
+- cri-tools, runc, containerd, docker, and docker-cli are now built from Gentoo upstream ebuilds. Docker received a major version upgrade - it was updated to Docker 24 (from Docker 20; see “updates”).
   - **NOTE** The docker btrfs storage driver has been de-prioritised; BTRFS backed storage will now default to the `overlay2` driver
     ([changelog](https://docs.docker.com/engine/release-notes/23.0/#bug-fixes-and-enhancements-6), [upstream pr](https://github.com/moby/moby/pull/42661)).
     Using the btrfs driver can still be enforced by creating a respective [docker config](https://docs.docker.com/storage/storagedriver/btrfs-driver/#configure-docker-to-use-the-btrfs-storage-driver) at `/etc/docker/daemon.json`.


### PR DESCRIPTION
During the release of Alpha-3794.0.0 we further improved changelog messages for the docker 24 upgrade and the torcx removal. This PR updates the respective changelog entries in the repository.

See release announcement here:
https://hackmd.io/nG2pd4iKQ9GTazucHH5U9Q?view#New-Alpha-Release-379400

**Cherry-pick** to flatcar-3794 after approval.