### PR TITLE
ci-automation: add brightbox testing

### DIFF
--- a/ci-automation/ci-config.env
+++ b/ci-automation/ci-config.env
@@ -155,3 +155,8 @@ AZURE_LOCATION="${AZURE_LOCATION:-westeurope}"
 # -- Openstack --
 : ${OPENSTACK_IMAGE_NAME:='flatcar_production_openstack_image.img.gz'}
 OPENSTACK_PARALLEL="${PARALLEL_TESTS:-3}"
+
+# -- Brightbox --
+: ${BRIGHTBOX_IMAGE_NAME:='flatcar_production_openstack_image.img'}
+BRIGHTBOX_PARALLEL="${PARALLEL_TESTS:-1}"
+: ${BRIGHTBOX_SERVER_TYPE:="2gb.ssd"}

--- a/ci-automation/garbage_collect.sh
+++ b/ci-automation/garbage_collect.sh
@@ -160,6 +160,7 @@ function _garbage_collect_impl() {
       --env GCP_JSON_KEY \
       --env VMWARE_ESX_CREDS \
       --env OPENSTACK_CREDS \
+      --env BRIGHTBOX_CLIENT_ID --env BRIGHTBOX_CLIENT_SECRET \
       -w /work -v "$PWD":/work "${mantle_ref}" /work/ci-automation/garbage_collect_cloud.sh
 
     echo

--- a/ci-automation/garbage_collect_cloud.sh
+++ b/ci-automation/garbage_collect_cloud.sh
@@ -8,3 +8,5 @@ timeout --signal=SIGQUIT 60m ore equinixmetal gc --duration 6h \
   --project="${EQUINIXMETAL_PROJECT}" --gs-json-key=<(echo "${GCP_JSON_KEY}" | base64 --decode) --api-key="${EQUINIXMETAL_KEY}"
 timeout --signal=SIGQUIT 60m ore openstack gc --duration 6h \
   --config-file=<(echo "${OPENSTACK_CREDS}" | base64 --decode)
+timeout --signal=SIGQUIT 60m ore brightbox gc --duration 6h \
+  --brightbox-client-id="${BRIGHTBOX_CLIENT_ID}" --brightbox-client-secret="${BRIGHTBOX_CLIENT_SECRET}"

--- a/ci-automation/vendor-testing/brightbox.sh
+++ b/ci-automation/vendor-testing/brightbox.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Copyright (c) 2023 The Flatcar Maintainers.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+set -euo pipefail
+
+# Test execution script for the Brightbox vendor.
+# This script is supposed to run in the mantle container.
+
+source ci-automation/vendor_test.sh
+
+# ARM64 is not supported on Brightbox, so for now fail it as an
+# unsupported option.
+if [[ "${CIA_ARCH}" == "arm64" ]]; then
+    echo "1..1" > "${CIA_TAPFILE}"
+    echo "not ok - all qemu tests" >> "${CIA_TAPFILE}"
+    echo "  ---" >> "${CIA_TAPFILE}"
+    echo "  ERROR: ARM64 tests not supported on Brightbox." | tee -a "${CIA_TAPFILE}"
+    echo "  ..." >> "${CIA_TAPFILE}"
+    break_retest_cycle
+    exit 1
+fi
+
+# BRIGHTBOX_CLIENT_ID, BRIGHTBOX_CLIENT_SECRET should be provided by sdk_container/.env
+
+# Upload the image on Brightbox.
+IMAGE_ID=$(ore brightbox create-image \
+  --name=flatcar-"${CIA_VERNUM}" \
+  --url="https://${BUILDCACHE_SERVER}/images/${CIA_ARCH}/${CIA_VERNUM}/${BRIGHTBOX_IMAGE_NAME}" \
+  --brightbox-client-id="${BRIGHTBOX_CLIENT_ID}" \
+  --brightbox-client-secret="${BRIGHTBOX_CLIENT_SECRET}"
+)
+
+# Remove any left-over servers.
+ore brightbox remove-servers \
+  --brightbox-client-id="${BRIGHTBOX_CLIENT_ID}" \
+  --brightbox-client-secret="${BRIGHTBOX_CLIENT_SECRET}" || :
+
+# Remove any left-over IPs.
+ore brightbox remove-ips \
+  --brightbox-client-id="${BRIGHTBOX_CLIENT_ID}" \
+  --brightbox-client-secret="${BRIGHTBOX_CLIENT_SECRET}" || :
+
+# Delete the image once we exit.
+trap 'ore brightbox delete-image --brightbox-client-id="${BRIGHTBOX_CLIENT_ID}" --brightbox-client-secret="${BRIGHTBOX_CLIENT_SECRET}" --id "${IMAGE_ID}" || true' EXIT
+
+kola_test_basename="ci-${CIA_VERNUM//+/-}"
+kola_test_basename="${kola_test_basename//[+.]/-}"
+
+set -x
+
+timeout --signal=SIGQUIT 2h kola run \
+  --board="${CIA_ARCH}-usr" \
+  --parallel="${BRIGHTBOX_PARALLEL}" \
+  --tapfile="${CIA_TAPFILE}" \
+  --channel="${CIA_CHANNEL}" \
+  --basename="${kola_test_basename}" \
+  --platform=brightbox \
+  --brightbox-image="${IMAGE_ID}" \
+  --brightbox-client-id="${BRIGHTBOX_CLIENT_ID}" \
+  --brightbox-client-secret="${BRIGHTBOX_CLIENT_SECRET}" \
+  --brightbox-server-type="${BRIGHTBOX_SERVER_TYPE}" \
+  "${@}"
+
+set +x


### PR DESCRIPTION
In this PR, we add the logic to test Flatcar OpenStack images on Brightbox using the new Mantle platform - it has to be tested / merged with the Jenkins PR. 

Testing done here: http://jenkins.infra.kinvolk.io:8080/job/container/job/test/16818/console :green_circle: 