### PR TITLE
ci-automation/image-changes: Get proper last release version for LTS channels

### DIFF
--- a/ci-automation/image_changes.sh
+++ b/ci-automation/image_changes.sh
@@ -528,6 +528,15 @@ function channel_version() (
     # traps.
     trap 'rm "${tmp_version_txt}"' EXIT
 
+    curl_to_stdout "https://${channel}.release.flatcar-linux.net/${board}/current/version.txt" >"${tmp_version_txt}"
+    source "${tmp_version_txt}"
+    echo "${FLATCAR_VERSION}"
+)
+# --
+
+function curl_to_stdout() {
+    local url=${1}; shift
+
     curl \
         -fsSL \
         --retry-delay 1 \
@@ -535,10 +544,8 @@ function channel_version() (
         --retry-connrefused \
         --retry-max-time 60 \
         --connect-timeout 20 \
-        "https://${channel}.release.flatcar-linux.net/${board}/current/version.txt" >"${tmp_version_txt}"
-    source "${tmp_version_txt}"
-    echo "${FLATCAR_VERSION}"
-)
+        "${url}"
+}
 # --
 
 # Prints some reports using scripts from the passed path to

--- a/ci-automation/image_changes.sh
+++ b/ci-automation/image_changes.sh
@@ -491,11 +491,11 @@ function get_channel_a_and_version_a() {
     local -n gcaava_version_a_ref="${gcaava_version_a_varname}"
     local major_a major_b channel version
 
-    major_a=$(echo "${new_channel_prev_version}" | cut -d . -f 1)
-    major_b=$(echo "${new_channel_new_version}" | cut -d . -f 1)
+    major_a=${new_channel_prev_version%%.*}
+    major_b=${new_channel_new_version%%.*}
     # When the major version for the new channel is different, a transition has happened and we can find the previous release in the old channel
-    if [ "${major_a}" != "${major_b}" ]; then
-        case "${new_channel}" in
+    if [[ ${major_a} != "${major_b}" ]]; then
+        case ${new_channel} in
           lts)
             channel=stable
             ;;


### PR DESCRIPTION
This script will be eventually (in couple years) run to get image changes for the old LTS channel, so make sure that it will fetch the last release of the old LTS channel, instead of a new LTS one.