### PR TITLE
ci-automation: Bring back the docker-cli package to docker sysext

### DIFF
--- a/ci-automation/base_sysexts.sh
+++ b/ci-automation/base_sysexts.sh
@@ -7,5 +7,5 @@ fi
 
 ciabs_base_sysexts=(
     'containerd-flatcar:app-containers/containerd'
-    'docker-flatcar:app-containers/docker'
+    'docker-flatcar:app-containers/docker&app-containers/docker-cli'
 )


### PR DESCRIPTION
The base_sysexts.sh file was based on old version of the default parameter of the ./build_image script. Sync them now.
