### PR TITLE
T lo/build dev packages

### DIFF
--- a/build_dev_binpkgs
+++ b/build_dev_binpkgs
@@ -46,10 +46,7 @@ fi
 # --
 
 function my_board_emerge() {
-	export PORTAGE_CONFIGROOT="/build/${FLAGS_board}"
-	export SYSROOT="${SYSROOT:-/build/${FLAGS_board}}"
-	export ROOT="/build/${FLAGS_board}"
-	sudo -E emerge --root-deps=rdeps "${@}"
+	PORTAGE_CONFIGROOT="/build/${FLAGS_board}" SYSROOT="${SYSROOT:-/build/${FLAGS_board}}" ROOT="/build/${FLAGS_board}" sudo -E emerge --root-deps=rdeps "${@}"
 }
 # --
 

--- a/build_dev_binpkgs
+++ b/build_dev_binpkgs
@@ -1,0 +1,91 @@
+#!/bin/bash
+# Copyright (c) 2023 by the Flatcar Maintainers.
+# Use of this source code is governed by the Apache 2.0 license.
+
+. "$(dirname "$0")/common.sh" || exit 1
+
+# Script must run inside the chroot
+assert_inside_chroot
+assert_not_root_user
+
+# Dependencies and packages to include by default.
+packages_default=( "coreos-devel/board-packages" )
+
+# Packages that are rdeps of the above but should not be included.
+# (mostly large packages, e.g. programming languages etc.)
+skip_packages_default="dev-lang/rust,virtual/rust,dev-lang/go,dev-lang/go-bootstrap,dev-go/go-md2man"
+
+
+# Developer-visible flags.
+DEFINE_string board "${DEFAULT_BOARD}" \
+  "The board to build packages for."
+DEFINE_string skip_packages "${skip_packages_default[@]}" \
+  "Comma-separated list of packages in the dependency tree to skip."
+DEFINE_boolean pretend "${FLAGS_FALSE}" \
+	"List packages that would be built but do not actually build."
+
+FLAGS_HELP="usage: $(basename $0) [flags] [packages]
+
+build_dev_binpkgs builds binary packages for all dependencies of [packages]
+that are not present in '/build/<board>/var/lib/portage/pkgs/'.
+Useful for publishing a complete set of packages to a binhost.
+
+[packages] defaults to '${packages_default}' if not specified.
+"
+
+# Parse command line
+FLAGS "$@" || exit 1
+eval set -- "${FLAGS_ARGV}"
+
+# Die on any errors.
+switch_to_strict_mode
+
+if [[ $# -eq 0 ]]; then
+  set -- "${packages_default[@]}"
+fi
+# --
+
+function my_board_emerge() {
+	export PORTAGE_CONFIGROOT="/build/${FLAGS_board}"
+	export SYSROOT="${SYSROOT:-/build/${FLAGS_board}}"
+	export ROOT="/build/${FLAGS_board}"
+	sudo -E emerge --root-deps=rdeps "${@}"
+}
+# --
+
+pkg_build_list="$(mktemp)"
+pkg_skipped_list="${pkg_build_list}-skip"
+trap 'rm -f "${pkg_build_list}" "${pkg_skipped_list}"' EXIT
+
+info "Collecting list of binpkgs to build"
+
+my_board_emerge --pretend --root-deps=rdeps --emptytree ${@}  \
+  | grep '\[ebuild' \
+  | sed 's/^\[[^]]\+\] \([^ :]\+\)*:.*/\1/' \
+  | while read pkg; do
+  if [ -f "/build/${FLAGS_board}/var/lib/portage/pkgs/${pkg}.tbz2" ] ; then
+		continue
+	fi
+  skip=""
+  for s in ${FLAGS_skip_packages//,/ }; do
+    if [[ ${pkg} = ${s}-* ]] ; then
+    	echo -n "${pkg} " >> "${pkg_skipped_list}"
+        skip="true"
+        break
+    fi
+  done
+  [[ -z ${skip} ]] || continue
+  echo "=${pkg}" | tee -a "${pkg_build_list}" | sed 's/^/      /'
+done
+# --
+
+if [ -f "${pkg_skipped_list}" ] ; then
+  info "Skipping binpkgs '$(cat "${pkg_skipped_list}")' because these are in the skip list."
+fi
+
+pretend=""
+if [[ "${FLAGS_pretend}" -eq "${FLAGS_TRUE}" ]]; then
+	pretend="--pretend"
+fi
+
+my_board_emerge --buildpkg ${pretend} $(cat "${pkg_build_list}")

--- a/build_packages
+++ b/build_packages
@@ -36,6 +36,8 @@ DEFINE_boolean skip_toolchain_update "${FLAGS_FALSE}" \
   "Don't update toolchain automatically."
 DEFINE_boolean skip_chroot_upgrade "${FLAGS_FALSE}" \
   "Don't run the chroot upgrade automatically; use with care."
+DEFINE_boolean only_resolve_circular_deps "${FLAGS_FALSE}" \
+  "Don't build all packages; only resolve circular dependencies, then stop."
 
 # include upload options
 . "${BUILD_LIBRARY_DIR}/release_util.sh" || exit 1
@@ -273,6 +275,11 @@ if [[ "${FLAGS_usepkgonly}" -eq "${FLAGS_FALSE}" ]]; then
                  sys-apps/systemd cryptsetup \
                  net-misc/curl http2 \
                  net-libs/nghttp2 systemd
+fi
+
+if [[ "${FLAGS_only_resolve_circular_deps}" -eq "${FLAGS_TRUE}" ]]; then
+  info "Circular dependencies resolved. Stopping as requested."
+  exit
 fi
 
 export KBUILD_BUILD_USER="${BUILD_USER:-build}"


### PR DESCRIPTION
This change introduces `build_dev_binpkgs`, a script to build binary packages for all dependencies of the devcontainer. This works around an issue with `build_packages`, which doesn't - leading to build issues with the devcontainer later on. This particularly happens for more complex builds with the devcontainer.

Additionally, a call to `build_dev_binpkgs` has been added to the package publishing step in ci-automation before binary packages are published.

Lastly, this change adds a command line option to `build_packages` to stop execution of the script after breaking circular dependencies (i.e. before board packages are built). This option was very helpful while working on `build_dev_binpkgs` and is likely to be similarly useful for other package build related development.

Fixes https://github.com/flatcar/Flatcar/issues/1292.

## How to use

```shell
./run_sdk_container -t
./build_packages
./build_dev_binpkgs
```

## Testing done

Successfully built devcontainer packages for amd64 and arm64.

# Backporting and cherry-picking

Should be backported / cherry-picked to all maintenance branches: flatcar-3033, flatcar-3510, flatcar-3602, flatcar-3760, flatcar-3815.