### PR TITLE
overlay coreos-base/common-oem-files: Move gce to amd64-only OEMID list

### DIFF
--- a/sdk_container/src/third_party/coreos-overlay/coreos-base/common-oem-files/common-oem-files-0-r5.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/coreos-base/common-oem-files/common-oem-files-0-r5.ebuild
@@ -31,7 +31,6 @@ fi
 COMMON_OEMIDS=(
     ami
     azure
-    gce
     openstack
     packet
     qemu
@@ -42,6 +41,7 @@ ARM64_ONLY_OEMIDS=(
 
 AMD64_ONLY_OEMIDS=(
     digitalocean
+    gce
     vmware
 )
 


### PR DESCRIPTION
We are not building gce OEM images for arm64 at all, so gce being in common OEM ID list resulted in arm64 image reports printing errors for it.

Example run with errors: http://jenkins.infra.kinvolk.io:8080/job/container/job/image_changes/4008/consoleFull (search for "gce").