### PR TITLE
Changelog and accept keywords fixes

### DIFF
--- a/changelog/security/2024-01-05-openssh-update.md
+++ b/changelog/security/2024-01-05-openssh-update.md
@@ -1,1 +1,1 @@
-- openssh ([CVE-2023-48795](https://nvd.nist.gov/vuln/detail/CVE-2023-48795))
+- openssh ([CVE-2023-48795](https://nvd.nist.gov/vuln/detail/CVE-2023-48795), [CVE-2023-51384](https://nvd.nist.gov/vuln/detail/CVE-2023-51384), [CVE-2023-51385](https://nvd.nist.gov/vuln/detail/CVE-2023-51385))

--- a/changelog/security/2024-01-05-weekly-updates.md
+++ b/changelog/security/2024-01-05-weekly-updates.md
@@ -5,4 +5,3 @@
 - gnutls ([CVE-2023-5981](https://nvd.nist.gov/vuln/detail/CVE-2023-5981))
 - curl ([CVE-2023-46218](https://nvd.nist.gov/vuln/detail/CVE-2023-46218), [CVE-2023-46219](https://nvd.nist.gov/vuln/detail/CVE-2023-46219))
 - binutils ([CVE-2023-1972](https://nvd.nist.gov/vuln/detail/CVE-2023-1972))
-- zlib ([CVE-2023-45853](https://nvd.nist.gov/vuln/detail/CVE-2023-45853))

--- a/sdk_container/src/third_party/coreos-overlay/profiles/coreos/base/package.accept_keywords
+++ b/sdk_container/src/third_party/coreos-overlay/profiles/coreos/base/package.accept_keywords
@@ -24,14 +24,11 @@
 # Needed by arm64-native SDK.
 =app-emulation/open-vmdk-1.0 *
 
-# Needed for addressing CVE-2023-50246 and CVE-2023-50268.
+# Needed for addressing CVE-2023-50246, CVE-2023-50268
 =app-misc/jq-1.7.1 ~amd64 ~arm64
 
 # Keep versions on both arches in sync.
 =app-misc/pax-utils-1.3.7 ~amd64
-
-# Needed for addressing CVE-2023-50246, CVE-2023-50268
-=app-misc/jq-1.7.1 ~amd64 ~arm64
 
 # Required for addressing CVE-2022-3715.
 =app-shells/bash-5.2_p21-r1 ~amd64 ~arm64


### PR DESCRIPTION
The PR adds missing CVE entries for openssh, drops an irrelevant one and drop a duplicated accept keywords entry. The last two items ought to be a part of the weekly updates PR - I made the changes locally, but forgot to push before merging the PR. Meh.

Closes https://github.com/flatcar/Flatcar/issues/1310