### PR TITLE
changelog: Update a security entry for openssl

### DIFF
--- a/changelog/security/2024-01-05-openssl-update.md
+++ b/changelog/security/2024-01-05-openssl-update.md
@@ -1,1 +1,1 @@
-- openssl ([CVE-2023-3817](https://nvd.nist.gov/vuln/detail/CVE-2023-3817), [CVE-2023-5363](https://nvd.nist.gov/vuln/detail/CVE-2023-5363), [CVE-2023-5678](https://nvd.nist.gov/vuln/detail/CVE-2023-5678))
+- openssl ([CVE-2023-3817](https://nvd.nist.gov/vuln/detail/CVE-2023-3817), [CVE-2023-5363](https://nvd.nist.gov/vuln/detail/CVE-2023-5363), [CVE-2023-5678](https://nvd.nist.gov/vuln/detail/CVE-2023-5678), [CVE-2023-6237](https://nvd.nist.gov/vuln/detail/CVE-2023-6237))


### PR DESCRIPTION
The release with this changelog was yet done, so we can safely update it.

Closes https://github.com/flatcar/Flatcar/issues/1320.