### PR TITLE
coreos-base/update_engine: Forward proxy env for postinstall script

### DIFF
--- a/changelog/bugfixes/2024-01-24-update-proxy-setup.md
+++ b/changelog/bugfixes/2024-01-24-update-proxy-setup.md
@@ -1,0 +1,1 @@
+- Forwarded the proxy environment variables of `update-engine.service` to the postinstall script to support fetching OEM systemd-sysext payloads through a proxy ([Flatcar#1326](https://github.com/flatcar/Flatcar/issues/1326))

--- a/sdk_container/src/third_party/coreos-overlay/coreos-base/update_engine/update_engine-9999.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/coreos-base/update_engine/update_engine-9999.ebuild
@@ -8,7 +8,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="7b7d6b712e6aeb9cd3d01c7734c25927ea06da04" # flatcar-master
+	CROS_WORKON_COMMIT="367f1fd96cdf9d7f7f281ca132d02813be123d01" # flatcar-master
 	KEYWORDS="amd64 arm64"
 fi
 


### PR DESCRIPTION
This pulls in https://github.com/flatcar/update_engine/pull/37 to forward the proxy env vars for curl and ue-rs download_sysext (Flatcar Stable currently uses curl, Alpha uses ue-rs).

## How to use

Backport to Stable and LTS.

## Testing done

see PR

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
