### PR TITLE
coreos-base/coreos-init: Add flatcar-update flag to skip OEM payloads

### DIFF
--- a/changelog/changes/2024-01-25-flatcar-update-oem.md
+++ b/changelog/changes/2024-01-25-flatcar-update-oem.md
@@ -1,0 +1,1 @@
+- Added a `flatcar-update --oem-payloads <yes|no>` flag to skip providing OEM payloads, e.g., for downgrades ([init#114](https://github.com/flatcar/init/pull/114))

--- a/sdk_container/src/third_party/coreos-overlay/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="db7a12ed8b5cbfc3023b01af1ed2666c210ba78d" # flatcar-master
+	CROS_WORKON_COMMIT="7e30bf5baa1abc5113024f2238d9c235aedaf62e" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in https://github.com/flatcar/init/pull/114 to support a flag to skip providing OEM payloads, with the goal of easing downgrades to non-sysext-OEM releases or, when backported to LTS with the default behavior switched, to opt-in to OEM payloads for airgapped updates that can't use the fallback download.

## How to use

Backport to all channels (with backport branches for the init repo to only pick the flatcar-update changes, and its dependencies, but not changes for the rest of the init repo)

## Testing done

see PR

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
