### PR TITLE
ci-automation/garbage_collect.sh: Add min age, remove orphan directories

### DIFF
--- a/ci-automation/garbage_collect.sh
+++ b/ci-automation/garbage_collect.sh
@@ -143,7 +143,7 @@ function _garbage_collect_impl() {
         local os_docker_vernum="$(vernum_to_docker_image_version "${FLATCAR_VERSION}")"
 
         # Remove container image tarballs and SDK tarball (if applicable)
-        # Keep in sync with "orphaned direcrories" clean-up below.
+        # Keep in sync with "orphaned directories" clean-up below.
         local rmpat=""
         rmpat="${BUILDCACHE_PATH_PREFIX}/sdk/*/${os_vernum}/"
         rmpat="${rmpat} ${BUILDCACHE_PATH_PREFIX}/containers/${os_docker_vernum}/flatcar-sdk-*"

--- a/ci-automation/garbage_collect.sh
+++ b/ci-automation/garbage_collect.sh
@@ -24,6 +24,8 @@
 #  - Number of (recent) versions to keep. Defaults to 50.
 #           Explicitly setting this value will reset the minimum age (see below) to 0 days.
 #  - Minimum age of version tag to be purged, in days. Defaults to 14.
+#           Only artifacts older than this AND exceeding the builds to keep threshold
+#           will be removed.
 #  - PURGE_VERSIONS (Env variable). Space-separated list of versions to purge
 #            instead of all but the 50 most recent ones.
 #            Setting this will IGNORE minimum age and number of versions to keep.
@@ -269,6 +271,6 @@ function _garbage_collect_impl() {
     echo
 
     source ci-automation/garbage_collect_github_ci_sdk.sh
-    garbage_collect_github_ci
+    garbage_collect_github_ci 1 "${min_age_days}"
 }
 # --


### PR DESCRIPTION
This change improves the build cache garbage collector to remove orphaned artifact directories - i.e. directories to which no version tag exists in the scripts repo.

SDK containers built by Github actions (using update_sdk_container) are igored by this change because these are handled in a separate garbage collection script.

Also, a new command line parameter has been added to remove artifacts older than the specified number of days (defaulting to 14):
- If neither number of builds nor max age is specified, the script defaults to 50 builds to keep, and a max age of 14 days. The max age overrides the number of builds to keep, so more than 50 builds may be kept.
- If only the number of builds to keep is specified, the max age is set to "0" (i.e. today).
- If both are specified, max age again overrides number of builds to keep.

Lastly, the change updates `ci-automation/garbage_collect_github_ci_sdk.sh` to also feature a min_age parameter and passes the parameter from ``garbage_collect.sh` to `ci-automation/garbage_collect_github_ci_sdk.sh`.

## How to use

```bash
bash -c "source ci-automation/garbage_collect.sh ; DRY_RUN=y garbage_collect ; "
bash -c "source ci-automation/garbage_collect.sh ; DRY_RUN=y garbage_collect 45; "
bash -c "source ci-automation/garbage_collect.sh ; DRY_RUN=y garbage_collect 1 12; "

bash -c "source ci-automation/garbage_collect_github_ci_sdk.sh ; DRY_RUN=y garbage_collect_github_ci 1 236; "
bash -c "source ci-automation/garbage_collect_github_ci_sdk.sh ; DRY_RUN=y garbage_collect_github_ci 10 200; "
```

## Testing done

Ran the above 5 commands and attached logs:
* remove orphans - [remove_orphans_run.txt](https://github.com/flatcar/scripts/files/14065698/remove_orphans_run.txt) (GH clean-up removed from log for readability)
* remove all but last 45 builds (orphan purging and GH clean-up removed from log for readability) - [remove_all_but_45_run.txt](https://github.com/flatcar/scripts/files/14065726/remove_all_but_45_run.txt)
* remove all but 1 builds but minimum age set to 12 days (orphan purging and GH clean-up removed from log for readability) -  [remove_all_older_than_12_days_run.txt](https://github.com/flatcar/scripts/files/14065727/remove_all_older_than_12_days_run.txt)
* Github actions cleanup of artifacts older than 236 days - [remove_gh_ci_sdk_older_236_run.txt](https://github.com/flatcar/scripts/files/14066268/remove_gh_ci_sdk_older_236_run.txt)
* Github actions cleanup of artifacts older than 200 days, keep at least 10 - [remove_gh_ci_sdk_older_200_keep_10_run.txt](https://github.com/flatcar/scripts/files/14066273/remove_gh_ci_sdk_older_200_keep_10_run.txt)


## Follow-up tasks
- [ ] Integrate max age parameter with jenkins-os
