### PR TITLE
.github: Some action version bumps to avoid deprecation warnings

### DIFF
--- a/.github/workflows/cacerts-release.yaml
+++ b/.github/workflows/cacerts-release.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out main scripts branch for GitHub workflow scripts only
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.BOT_PR_TOKEN }}
           path: gha
@@ -23,7 +23,7 @@ jobs:
         run: gha/.github/workflows/figure-out-branch.sh '${{ matrix.channel }}'
       - name: Check out work scripts branch for updating
         if: steps.figure-out-branch.outputs.SKIP == 0
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.BOT_PR_TOKEN }}
           path: work
@@ -57,7 +57,7 @@ jobs:
         run: gha/.github/workflows/cacerts-apply-patch.sh
       - name: Create pull request
         if: (steps.figure-out-branch.outputs.SKIP == 0) && (steps.apply-patch.outputs.UPDATE_NEEDED == 1)
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.BOT_PR_TOKEN }}
           path: work

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,13 +65,13 @@ jobs:
           sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
 
       - name: Checkout scripts
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: scripts
           fetch-depth: 0
 
       - name: Checkout build scripts
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: flatcar/flatcar-build-scripts
           path: flatcar-build-scripts
@@ -160,7 +160,7 @@ jobs:
 
       - name: Upload build logs
         if: always() && !cancelled()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           retention-days: 7
           name: ${{ matrix.arch }}-build-logs
@@ -240,7 +240,7 @@ jobs:
         run: .github/workflows/image_changes.sh ${{ matrix.arch }} nightly
 
       - name: Upload binpkgs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           retention-days: 7
           name: ${{ matrix.arch }}-binpkgs
@@ -248,7 +248,7 @@ jobs:
             scripts/binpkgs.tar
 
       - name: Upload update image (used with kola tests later)
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           retention-days: 7
           name: ${{ matrix.arch }}-test-update
@@ -256,7 +256,7 @@ jobs:
             scripts/artifacts/images/flatcar_test_update.gz
 
       - name: Upload generic image
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           retention-days: 7
           name: ${{ matrix.arch }}-generic-image
@@ -271,7 +271,7 @@ jobs:
             scripts/artifacts/images/flatcar_production_*_efi_*.fd
 
       - name: Upload developer container
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           retention-days: 7
           name: ${{ matrix.arch }}-devcontainer
@@ -279,7 +279,7 @@ jobs:
             scripts/artifacts/images/flatcar_developer_container*
 
       - name: Upload reports
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           retention-days: 7
           name: ${{ matrix.arch }}-image-changes-reports
@@ -299,7 +299,7 @@ jobs:
                 artifacts/images/flatcar_production_update*
 
       - name: Upload vendor images
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           retention-days: 7
           name: ${{ matrix.arch }}-vm-images

--- a/.github/workflows/containerd-release-main.yaml
+++ b/.github/workflows/containerd-release-main.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out scripts
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.BOT_PR_TOKEN }}
           path: scripts
@@ -38,7 +38,7 @@ jobs:
           TARGET_BRANCH: main
         run: scripts/.github/workflows/containerd-apply-patch.sh
       - name: Create pull request for main
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v6
         if: steps.apply-patch-main.outputs.UPDATE_NEEDED == 1
         with:
           token: ${{ secrets.BOT_PR_TOKEN }}

--- a/.github/workflows/firmware-release-main.yaml
+++ b/.github/workflows/firmware-release-main.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out scripts
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.BOT_PR_TOKEN }}
           path: scripts
@@ -35,7 +35,7 @@ jobs:
           TARGET_BRANCH: main
         run: scripts/.github/workflows/firmware-apply-patch.sh
       - name: Create pull request for main
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v6
         if: steps.apply-patch-main.outputs.UPDATE_NEEDED == 1
         with:
           token: ${{ secrets.BOT_PR_TOKEN }}

--- a/.github/workflows/go-release-main.yaml
+++ b/.github/workflows/go-release-main.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out scripts
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.BOT_PR_TOKEN }}
           path: scripts
@@ -36,7 +36,7 @@ jobs:
           TARGET_BRANCH: main
         run: scripts/.github/workflows/go-apply-patch.sh
       - name: Create pull request for main
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v6
         if: steps.apply-patch-main.outputs.UPDATE_NEEDED == 1
         with:
           token: ${{ secrets.BOT_PR_TOKEN }}

--- a/.github/workflows/kernel-release.yaml
+++ b/.github/workflows/kernel-release.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out main scripts branch for GitHub workflow scripts only
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.BOT_PR_TOKEN }}
           path: gha
@@ -23,7 +23,7 @@ jobs:
         run: gha/.github/workflows/figure-out-branch.sh '${{ matrix.channel }}'
       - name: Check out work scripts branch for updating
         if: steps.figure-out-branch.outputs.SKIP == 0
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.BOT_PR_TOKEN }}
           path: work
@@ -58,7 +58,7 @@ jobs:
         run: gha/.github/workflows/kernel-apply-patch.sh
       - name: Create pull request
         if: (steps.figure-out-branch.outputs.SKIP == 0) && (steps.apply-patch.outputs.UPDATE_NEEDED == 1)
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.BOT_PR_TOKEN }}
           path: work

--- a/.github/workflows/mantle-releases-main.yml
+++ b/.github/workflows/mantle-releases-main.yml
@@ -45,7 +45,7 @@ jobs:
           fi
           echo "BRANCH=${branch}" >>"${GITHUB_OUTPUT}"
           echo "SKIP=${skip}" >>"${GITHUB_OUTPUT}"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: ${{ steps.figure-out-branch.outputs.SKIP == 0 }}
         with:
           token: ${{ secrets.BOT_PR_TOKEN }}
@@ -69,7 +69,7 @@ jobs:
           fi
       - name: Create pull request for branch
         if: ${{ steps.figure-out-branch.outputs.SKIP == 0 }}
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.BOT_PR_TOKEN }}
           base: ${{ steps.figure-out-branch.outputs.BRANCH }}

--- a/.github/workflows/run-kola-tests.yaml
+++ b/.github/workflows/run-kola-tests.yaml
@@ -54,7 +54,7 @@ jobs:
           sudo iptables -I FORWARD -o $DEFAULT_ROUTE_DEVICE -j ACCEPT
           sudo iptables -I FORWARD -i $DEFAULT_ROUTE_DEVICE -j ACCEPT
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: scripts
           fetch-depth: 0
@@ -77,25 +77,25 @@ jobs:
 
       - name: Download binpkgs
         if: ${{ !inputs.workflow_run_id }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.arch }}-binpkgs
 
       - name: Download test update image
         if: ${{ !inputs.workflow_run_id }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.arch }}-test-update
 
       - name: Download generic image
         if: ${{ !inputs.workflow_run_id }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.arch }}-generic-image
 
       - name: Download developer container
         if: ${{ !inputs.workflow_run_id }}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.arch }}-devcontainer
 
@@ -222,7 +222,7 @@ jobs:
 
       - name: Upload detailed test logs
         if: always() && !cancelled()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.arch }}-test-logs-and-results
           path: |
@@ -234,7 +234,7 @@ jobs:
 
       - name: Upload raw TAP files of all runs for later merging
         if: always() && !cancelled()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.arch }}-raw-tapfiles
           path: |
@@ -261,7 +261,7 @@ jobs:
           sudo ln -s /bin/bash /bin/sh
           sudo apt-get install -y ca-certificates curl gnupg lsb-release git bzip2 jq sqlite3
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           path: scripts
           fetch-depth: 0
@@ -286,13 +286,13 @@ jobs:
       # This is clunky. Haven't figured out how to re-use matrix.arch here for downloads,
       #  so we download each arch individually.
       - name: Download amd64 tapfiles
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: amd64-raw-tapfiles
           path: scripts/__TAP__/amd64
 
       - name: Download arm64 tapfiles
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: arm64-raw-tapfiles
           path: scripts/__TAP__/arm64

--- a/.github/workflows/rust-release-main.yaml
+++ b/.github/workflows/rust-release-main.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out scripts
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.BOT_PR_TOKEN }}
           path: scripts
@@ -36,7 +36,7 @@ jobs:
         run: scripts/.github/workflows/rust-apply-patch.sh
       - name: Create pull request for main
         id: create-pull-request
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v6
         if: steps.apply-patch-main.outputs.UPDATE_NEEDED == 1
         with:
           token: ${{ secrets.BOT_PR_TOKEN }}

--- a/.github/workflows/update-metadata-glsa.yaml
+++ b/.github/workflows/update-metadata-glsa.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out scripts
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.BOT_PR_TOKEN }}
       - name: Update GLSA metadata
@@ -22,7 +22,7 @@ jobs:
           todaydate=$(date +%Y-%m-%d)
           echo "TODAYDATE=${todaydate}" >>"${GITHUB_OUTPUT}"
       - name: Create pull request for main branch
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.BOT_PR_TOKEN }}
           branch: buildbot/monthly-glsa-metadata-updates-${{steps.update-glsa-metadata.outputs.TODAYDATE }}

--- a/.github/workflows/update-portage-stable-packages-from-list.yaml
+++ b/.github/workflows/update-portage-stable-packages-from-list.yaml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out scripts
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           path: ./scripts
       - name: Check out Gentoo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: gentoo/gentoo
           path: gentoo
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 250000
           ref: master
       - name: Check out build scripts
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: flatcar/flatcar-build-scripts
           path: flatcar-build-scripts
@@ -68,7 +68,7 @@ jobs:
           echo "UPDATED=${updated}" >>"${GITHUB_OUTPUT}"
           echo "TODAYDATE=${todaydate}" >>"${GITHUB_OUTPUT}"
       - name: Create pull request for main branch
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v6
         if: steps.update-listed-packages.outputs.UPDATED == 1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/update-sdk.yaml
+++ b/.github/workflows/update-sdk.yaml
@@ -67,7 +67,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         id: step2
         with:
           path: scripts

--- a/.github/workflows/vmware-release-main.yaml
+++ b/.github/workflows/vmware-release-main.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out scripts
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.BOT_PR_TOKEN }}
           path: scripts
@@ -38,7 +38,7 @@ jobs:
           TARGET_BRANCH: main
         run: scripts/.github/workflows/vmware-apply-patch.sh
       - name: Create pull request for main
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v6
         if: steps.apply-patch-main.outputs.UPDATE_NEEDED == 1
         with:
           token: ${{ secrets.BOT_PR_TOKEN }}


### PR DESCRIPTION
Some actions bumped their version when switching to the newer version of nodejs. `mshick/add-pr-comment@v2` was an exception - it stayed at `v2`.