### PR TITLE
coreos-base/update_engine: Support updating old airgapped clients

### DIFF
--- a/changelog/bugfixes/2024-02-08-airgapped-updates.md
+++ b/changelog/bugfixes/2024-02-08-airgapped-updates.md
@@ -1,0 +1,1 @@
+- Added a workaround for old airgapped/proxied update-engine clients to be able to update to this release ([Flatcar#1332](https://github.com/flatcar/Flatcar/issues/1332), [update_engine#38](https://github.com/flatcar/update_engine/pull/38))

--- a/sdk_container/src/third_party/coreos-overlay/coreos-base/update_engine/update_engine-9999.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/coreos-base/update_engine/update_engine-9999.ebuild
@@ -8,7 +8,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="367f1fd96cdf9d7f7f281ca132d02813be123d01" # flatcar-master
+	CROS_WORKON_COMMIT="f627c4def9ff42cc6bf4b04cf211e11a42b34f31" # flatcar-master
 	KEYWORDS="amd64 arm64"
 fi
 


### PR DESCRIPTION
This pulls in https://github.com/flatcar/update_engine/pull/38 with two workarounds to read out proxy env vars from the service unit and to read out the XML response from the journal logs, because the XML passing and the passing of proxy env vars is not present in old clients.


## How to use

Backport to Stable

## Testing done

See PR

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
