### PR TITLE
Fix publishing of dev binpkgs

### DIFF
--- a/build_dev_binpkgs
+++ b/build_dev_binpkgs
@@ -58,7 +58,7 @@ info "Collecting list of binpkgs to build"
 
 my_board_emerge --pretend --root-deps=rdeps --emptytree ${@}  \
   | grep '\[ebuild' \
-  | sed 's/^\[[^]]\+\] \([^ :]\+\)*:.*/\1/' \
+  | sed 's/^\[[^]]\+\] \([^ :]\+\)*.*/\1/' \
   | while read pkg; do
   if [ -f "/build/${FLAGS_board}/var/lib/portage/pkgs/${pkg}.tbz2" ] ; then
 		continue

--- a/sdk_container/src/third_party/portage-stable/dev-util/glib-utils/glib-utils-2.74.4.ebuild
+++ b/sdk_container/src/third_party/portage-stable/dev-util/glib-utils/glib-utils-2.74.4.ebuild
@@ -14,7 +14,7 @@ LICENSE="LGPL-2.1+"
 SLOT="0" # /usr/bin utilities that can't be parallel installed by their nature
 REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
-KEYWORDS="~alpha amd64 ~arm ~arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ppc64 ~riscv ~s390 sparc ~x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris ~x86-winnt"
+KEYWORDS="~alpha amd64 ~arm arm64 ~hppa ~ia64 ~loong ~m68k ~mips ~ppc ppc64 ~riscv ~s390 sparc ~x86 ~x64-cygwin ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos ~sparc-solaris ~sparc64-solaris ~x64-solaris ~x86-solaris ~x86-winnt"
 
 RDEPEND="${PYTHON_DEPS}"
 DEPEND="${RDEPEND}"


### PR DESCRIPTION
The format of emerge output differs a bit, as it is missing the repo name (which came after `::`).

CI: http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/3426/cldsv/