### PR TITLE
sys-kernel/bootengine: Ensure /run/ignition.env exists on every boot

### DIFF
--- a/sdk_container/src/third_party/coreos-overlay/sys-kernel/bootengine/bootengine-9999.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/sys-kernel/bootengine/bootengine-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="10341079dde4bf7f8fbdb8a01a73b94da355c1ba" # flatcar-master
+	CROS_WORKON_COMMIT="0b32311f0067d6747eed12e8dd858ad4a6986974" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 
@@ -35,6 +35,7 @@ src_install() {
 		"${D}"/usr/lib/dracut/modules.d/30disk-uuid/disk-uuid.sh \
 		"${D}"/usr/lib/dracut/modules.d/30ignition/ignition-generator \
 		"${D}"/usr/lib/dracut/modules.d/30ignition/ignition-setup.sh \
+		"${D}"/usr/lib/dracut/modules.d/30ignition/ignition-setup-pre.sh \
 		"${D}"/usr/lib/dracut/modules.d/30ignition/ignition-kargs-helper \
 		"${D}"/usr/lib/dracut/modules.d/30ignition/retry-umount.sh \
 		"${D}"/usr/lib/dracut/modules.d/99setup-root/initrd-setup-root \


### PR DESCRIPTION
This pulls in https://github.com/flatcar/bootengine/pull/86 to fix the previous rework that only created /run/ignition.env on the first boot while we rely on it to run cloud-init on every boot when no Ignition config was provided.

## How to use

Backport to flatcar-3874

## Testing done
See PR

Changelog depends on whether we can rebuild alpha with this today
- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
