### PR TITLE
bootengine: fix kmod-static-nodes

### DIFF
--- a/changelog/bugfixes/2024-02-13-fix-kmod-static-nodes-creation.md
+++ b/changelog/bugfixes/2024-02-13-fix-kmod-static-nodes-creation.md
@@ -1,0 +1,2 @@
+- Resolved kmod static nodes creation in bootengine ([bootengine#85](https://github.com/flatcar/bootengine/pull/85))
+- Fixes kubevirt vm creation by ensuring that /dev/vhost-net exists ([Flatcar#1336](https://github.com/flatcar/Flatcar/issues/1336))

--- a/sdk_container/src/third_party/coreos-overlay/sys-kernel/bootengine/bootengine-9999.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/sys-kernel/bootengine/bootengine-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="0b32311f0067d6747eed12e8dd858ad4a6986974" # flatcar-master
+	CROS_WORKON_COMMIT="a85e1977b29dbe8315733dbe1b1ab3ab84d039a2" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
Update the bootengine commit id to use the fix from: https://github.com/flatcar/bootengine/pull/85

Fixes: https://github.com/flatcar/Flatcar/issues/1336

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [x] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
