### PR TITLE
core_sign_update: Work with a mapped pcscd socket

### DIFF
--- a/core_sign_update
+++ b/core_sign_update
@@ -136,7 +136,7 @@ i=1
 signature_sizes=""
 for key in "${private_keys[@]}"; do
 	if [[ "${key}" == pkcs11* ]]; then
-		OPENSSL_CONF=/etc/ssl/pkcs11.cnf openssl pkeyutl -engine pkcs11 -sign -keyform engine -inkey "${key}" -in update.pkcs11-padhash -out "update.sig.${i}"
+		sudo OPENSSL_CONF=/etc/ssl/pkcs11.cnf openssl pkeyutl -engine pkcs11 -sign -keyform engine -inkey "${key}" -in update.pkcs11-padhash -out "update.sig.${i}"
 	elif [[ "${key}" == fero* ]]; then
 		fero-client \
 			--address $FLAGS_signing_server_address \


### PR DESCRIPTION
The sdk user in the container might rejected by the pcscd on the host. Work around that by running the openssl command as root.

## How to use


## Testing done

Used for current release
