### PR TITLE
sys-kernel/dracut: add systemd-executor binary

### DIFF
--- a/sdk_container/src/third_party/coreos-overlay/sys-kernel/dracut/dracut-053-r1.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/sys-kernel/dracut/dracut-053-r1.ebuild
@@ -67,6 +67,8 @@ PATCHES=(
 	"${FILESDIR}"/gentoo-ldconfig-paths.patch
 	# Flatcar: override iscsi network dependency
 	"${FILESDIR}"/050-change-network-dep-iscsi.patch
+	# Add required systemd 255 binary
+	"${FILESDIR}"/059-systemd-executor.patch
 )
 
 src_configure() {

--- a/sdk_container/src/third_party/coreos-overlay/sys-kernel/dracut/files/059-systemd-executor.patch
+++ b/sdk_container/src/third_party/coreos-overlay/sys-kernel/dracut/files/059-systemd-executor.patch
@@ -1,0 +1,31 @@
+From bee1c4824a8cd47ce6c01892a548bdc07b1fa678 Mon Sep 17 00:00:00 2001
+From: Frantisek Sumsal <frantisek@sumsal.cz>
+Date: Sat, 14 Oct 2023 23:45:57 +0200
+Subject: [PATCH] feat(systemd): install systemd-executor
+
+In [0] systemd gained a new binary - systemd-executor - that's used to
+spawn processes forked off systemd. Let's copy it into the initrd if
+it's available.
+
+[0] https://github.com/systemd/systemd/pull/27890
+
+Signed-off-by: Brian Harring <ferringb@gmail.com>
+---
+ modules.d/00systemd/module-setup.sh | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/modules.d/00systemd/module-setup.sh b/modules.d/00systemd/module-setup.sh
+index 554c25a08..9a13a1dbb 100755
+--- a/modules.d/00systemd/module-setup.sh
++++ b/modules.d/00systemd/module-setup.sh
+@@ -34,6 +34,7 @@ install() {
+         "$systemdutildir"/systemd \
+         "$systemdutildir"/systemd-coredump \
+         "$systemdutildir"/systemd-cgroups-agent \
++        "$systemdutildir"/systemd-executor \
+         "$systemdutildir"/systemd-shutdown \
+         "$systemdutildir"/systemd-reply-password \
+         "$systemdutildir"/systemd-fsck \
+-- 
+2.41.0
+


### PR DESCRIPTION
Without the systemd-executor binary, the upgrade to systemd 255 is not possible,
as it leads to a failure during the initramfs stage - executable not found systemd-executor.

Upgrade of dracut will be left for the future: https://github.com/flatcar/scripts/pull/1665, as dracut has to be upgraded after systemd 255 has been already upgraded, because of these two commits that will break bootengine and the CI:

https://github.com/dracutdevs/dracut/commit/7528d84de84d9c1fb7d5f54712c692600e21b044
https://github.com/dracutdevs/dracut/commit/5912f4fbc036cc36b9507c16dddef1ded1556572
