### PR TITLE
build_sysext: enable build of OEM images for releases

### DIFF
--- a/build_sysext
+++ b/build_sysext
@@ -213,6 +213,7 @@ for package; do
     --sysroot="/build/${FLAGS_board}"  \
     --root-deps=rdeps \
     --usepkgonly \
+    --getbinpkg \
     --verbose \
     "${package}"
 done


### PR DESCRIPTION
This one-line change enables building OEM images from releases without rebuilding all board packages.

It adds an option to the `emerge` command in `build_sysext` that allows emerge to download binary packages. Since we publish binpkgs for each release, the change allows users to build OEM images based on the generic OS image and sysext squashfs of a release.

Without this change, OEM builds require a full OS packages build locally, even for releases.

# Testing Done

Tested for the Azure OEM image. Cloned the SDK, checked out a release, downloaded generic image and sysext quashfs, ran `image_to_vm.sh`:
```bash
git clone https://github.com/flatcar/scripts.git
cd scripts
git checkout stable-3815.2.0
wget https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_image.bin.bz2
wget https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_image_sysext.squashfs
COREOS_OFFICIAL=1 ./run_sdk_container ./image_to_vm.sh --from=./ --to=./ --board=amd64-usr --getbinpkg --format=azure
```

# Backport / cherry-pick

This change should be cherry-picked to all maintenance branches.