### PR TITLE
sys-kernel/bootengine: Restore support for custom PXE OEM contents

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ on:
         description: |
           Space-separated vendor formats to build.
         required: true
-        default: qemu_uefi
+        default: qemu_uefi pxe
       custom_sdk_version:
         type: string
         required: false
@@ -21,7 +21,7 @@ on:
         description: |
           Space-separated vendor formats to build.
         required: true
-        default: qemu_uefi
+        default: qemu_uefi pxe
       custom_sdk_version:
         type: string
         required: false
@@ -96,7 +96,7 @@ jobs:
           arch="${{ matrix.arch }}"
           echo "arch=${arch}" >> $GITHUB_ENV
 
-          IMAGE_FORMATS="qemu_uefi"
+          IMAGE_FORMATS="qemu_uefi pxe"
           [ -z "${{ inputs.image_formats }}" ] || IMAGE_FORMATS="${{ inputs.image_formats }}"
           echo "IMAGE_FORMATS=${IMAGE_FORMATS}" >> $GITHUB_ENV
 
@@ -309,6 +309,8 @@ jobs:
             scripts/artifacts/images/flatcar_production_*_efi_*.fd
             scripts/artifacts/images/*.txt
             scripts/artifacts/images/flatcar_production_*.sh
+            scripts/artifacts/images/flatcar_production_pxe_image.cpio.gz
+            scripts/artifacts/images/flatcar_production_pxe.vmlinuz
 
   test:
     needs: packages

--- a/.github/workflows/pr-comment-build-dispatcher.yaml
+++ b/.github/workflows/pr-comment-build-dispatcher.yaml
@@ -77,4 +77,4 @@ jobs:
     uses: ./.github/workflows/ci.yaml
     with:
       custom_sdk_version: ${{ needs.update_sdk.outputs.sdk_version }}
-      image_formats: qemu_uefi
+      image_formats: qemu_uefi pxe

--- a/.github/workflows/pr-workflows.yaml
+++ b/.github/workflows/pr-workflows.yaml
@@ -46,4 +46,4 @@ jobs:
     uses: ./.github/workflows/ci.yaml
     with:
       custom_sdk_version: ${{ needs.update_sdk.outputs.sdk_version }}
-      image_formats: qemu_uefi
+      image_formats: qemu_uefi pxe

--- a/changelog/bugfixes/2024-02-27-pxe-oem-initrd.md
+++ b/changelog/bugfixes/2024-02-27-pxe-oem-initrd.md
@@ -1,0 +1,1 @@
+- Restored support for custom OEMs supplied in the PXE boot where `/usr/share/oem` brings the OEM partition contents ([Flatcar#1376](https://github.com/flatcar/Flatcar/issues/1376))

--- a/sdk_container/src/third_party/coreos-overlay/sys-kernel/bootengine/bootengine-9999.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/sys-kernel/bootengine/bootengine-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="a85e1977b29dbe8315733dbe1b1ab3ab84d039a2" # flatcar-master
+	CROS_WORKON_COMMIT="0bade95d3b33b75b6c827d2db2f9298aff0ca05f" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in https://github.com/flatcar/bootengine/pull/88 to restore looking at the documented /usr/share/oem path in a custom PXE OEM initrd instead of /oem.

## How to use

Backport to Stable

## Testing done

```
tree initrd/
initrd/
└── usr
    └── share
        └── oem
            └── config.ign
(cd initrd; find . -print0 | cpio --null --create --verbose --format=newc > ../merged.cpio )
zcat flatcar_production_pxe_image.cpio.gz >> merged.cpio
gzip merged.cpio
./flatcar_production_pxe.sh -- -append 'flatcar.first_boot=1' -initrd ../merged.cpio.gz
# checked that ignition config got applied
```

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
