### PR TITLE
overlay coreos/config: Drop overrides for packages we do not have

### DIFF
--- a/sdk_container/src/third_party/coreos-overlay/coreos/config/env/app-admin/setools
+++ b/sdk_container/src/third_party/coreos-overlay/coreos/config/env/app-admin/setools
@@ -1,2 +1,0 @@
-export ac_cv_file__build_amd64_usr__usr_lib64_libsepol_a=yes
-

--- a/sdk_container/src/third_party/coreos-overlay/coreos/config/env/app-emulation/xen
+++ b/sdk_container/src/third_party/coreos-overlay/coreos/config/env/app-emulation/xen
@@ -1,5 +1,0 @@
-# Creating symlinks on FAT doesn't work, so don't do that
-INSTALL_MASK="${INSTALL_MASK}
-    /boot/xen-?.?.gz
-    /boot/xen-?.gz
-    /boot/xen.gz"

--- a/sdk_container/src/third_party/coreos-overlay/coreos/config/env/app-emulation/xen-tools
+++ b/sdk_container/src/third_party/coreos-overlay/coreos/config/env/app-emulation/xen-tools
@@ -1,6 +1,0 @@
-# We provide xenstore as a standalone package
-INSTALL_MASK="${INSTALL_MASK}
-    /usr/bin/xenstore
-    /usr/lib/debug/usr/bin/xenstore.debug
-    /usr/lib/debug/usr/lib*/libxenstore.so*
-    /usr/lib*/libxenstore.so*"

--- a/sdk_container/src/third_party/coreos-overlay/coreos/config/env/sys-apps/busybox
+++ b/sdk_container/src/third_party/coreos-overlay/coreos/config/env/sys-apps/busybox
@@ -1,5 +1,0 @@
-# savedconfig by default saves the currently generated config into
-# /etc/portage/savedconfig. However we want to avoid placing it here
-# so that every re-emerge will pick up the configs from
-# chromeos-base/busybox-config
-INSTALL_MASK+=" /etc/portage/savedconfig"

--- a/sdk_container/src/third_party/coreos-overlay/coreos/config/env/sys-apps/efunctions
+++ b/sdk_container/src/third_party/coreos-overlay/coreos/config/env/sys-apps/efunctions
@@ -1,3 +1,0 @@
-# Don't filter out /etc/init.d/functions.sh
-PKG_INSTALL_MASK="${PKG_INSTALL_MASK/\/etc\/init.d}"
-INSTALL_MASK="${INSTALL_MASK/\/etc\/init.d}"


### PR DESCRIPTION
Just cleaning some unused files I spotted.