### PR TITLE
build_sysext: Remove any opaque directory markers

### DIFF
--- a/build_sysext
+++ b/build_sysext
@@ -275,6 +275,10 @@ all_fields=(
   "ARCHITECTURE=${ARCH}"
 )
 printf '%s\n' "${all_fields[@]}" >"${BUILD_DIR}/install-root/usr/lib/extension-release.d/extension-release.${SYSEXTNAME}"
+
+info "Removing opaque directory markers to always merge all contents"
+find "${BUILD_DIR}/install-root" -xdev -type d -exec sh -c 'if [ "$(attr -R -q -g overlay.opaque {} 2>/dev/null)" = y ]; then attr -R -r overlay.opaque {}; fi' \;
+
 mksquashfs "${BUILD_DIR}/install-root" "${BUILD_DIR}/${SYSEXTNAME}.raw" \
                -noappend -comp "${FLAGS_compression}" ${FLAGS_mksquashfs_opts}
 rm -rf "${BUILD_DIR}"/{fs-root,install-root,workdir}

--- a/changelog/bugfixes/2024-03-05-ensure-sysext-contents-merge.md
+++ b/changelog/bugfixes/2024-03-05-ensure-sysext-contents-merge.md
@@ -1,0 +1,1 @@
+- Fixed that systemd-sysext images can extend directories where Flatcar extensions are also shipping files, e.g., that the sysext-bakery Kubernetes extension works when OEM extensions are present ([sysext-bakery#50](https://github.com/flatcar/sysext-bakery/issues/50))


### PR DESCRIPTION
The Flatcar extension images built with build_sysext created directories in the overlay in a way that masked contents from other layers. Instead of fixing the way we create directories, make use of postprocessing to avoid any similar problems show up again in the future.

## How to use

Backport

Fixes https://github.com/flatcar/sysext-bakery/issues/50

## Testing done

Tested that the squashfs has no opaque markers:
```
sudo systemd-dissect --with oem-azure.raw find usr/ -xdev -type d -exec sh -c 'if [ "$(attr -R -q -g overlay.opaque {} 2>/dev/null)" = y ]; then echo {}; fi' \;
```
Tested that the Azure OEM extension works with the Kubernetes extension such that `/usr/lib/systemd/system/multi-user.target.d` has the containerd and kubernetes entries.
Jenkins: http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/3586/cldsv/