### PR TITLE
Small fixes

### DIFF
--- a/build_library/build_image_util.sh
+++ b/build_library/build_image_util.sh
@@ -529,7 +529,8 @@ insert_extra_slsa() {
     if [ -f "${binpkg}" ]; then
       info "Found ${atom} at ${binpkg}"
       qtbz2 -O -t "${binpkg}" | \
-        sudo tar -C "${rootfs}" -xj --wildcards './usr/share/SLSA'
+        lbzcat -d -c - | \
+        sudo tar -C "${rootfs}" -x --wildcards './usr/share/SLSA'
       continue
     fi
     warn "Missing SLSA information for ${atom}"

--- a/build_library/prod_image_util.sh
+++ b/build_library/prod_image_util.sh
@@ -44,7 +44,8 @@ extract_prod_gcc() {
     #  /usr/lib/gcc/x86_64-cros-linux-gnu/$version/*
     # Instead we extract them to plain old /usr/lib
     qtbz2 -O -t "${pkg}" | \
-        sudo tar -C "${root_fs_dir}" -xj \
+        lbzcat -d -c - | \
+        sudo tar -C "${root_fs_dir}" -x \
         --transform 's#/usr/lib/.*/#/usr/lib64/#' \
         --wildcards './usr/lib/gcc/*.so*' \
         --wildcards './usr/share/SLSA'

--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -695,7 +695,7 @@ _write_cpio_common() {
 
     # Build the squashfs, embed squashfs into a gzipped cpio
     pushd "${cpio_target}" >/dev/null
-    sudo mksquashfs "${base_dir}" "./usr.squashfs" -pf "${VM_TMP_DIR}/extra"
+    sudo mksquashfs "${base_dir}" "./usr.squashfs" -pf "${VM_TMP_DIR}/extra" -xattrs-exclude '^btrfs.'
     find . | cpio -o -H newc | gzip > "$2"
     popd >/dev/null
 

--- a/ci-automation/test.sh
+++ b/ci-automation/test.sh
@@ -167,7 +167,7 @@ function _test_run_impl() {
         #  determine success based on test results (tapfile).
         set +e
         touch sdk_container/.env
-        docker run --rm --name="${container_name}" --privileged --net host -v /dev:/dev \
+        docker run --pull always --rm --name="${container_name}" --privileged --net host -v /dev:/dev \
           -w /work -v "$PWD":/work "${mantle_ref}" \
          bash -c "git config --global --add safe.directory /work && \
                   source sdk_container/.env && \
@@ -176,7 +176,7 @@ function _test_run_impl() {
         rm -f "${work_dir}/first_run"
 
         # Note: git safe.directory is not set in this run as it does not use git
-        docker run --rm --name="${container_name}" --privileged --net host -v /dev:/dev \
+        docker run --pull always --rm --name="${container_name}" --privileged --net host -v /dev:/dev \
           -w /work -v "$PWD":/work "${mantle_ref}" \
             ci-automation/test_update_reruns.sh \
                 "${arch}" "${vernum}" "${image}" "${retry}" \

--- a/sdk_container/src/third_party/coreos-overlay/coreos/config/env/sys-libs/ncurses
+++ b/sdk_container/src/third_party/coreos-overlay/coreos/config/env/sys-libs/ncurses
@@ -1,0 +1,5 @@
+cros_post_src_install_tmux_terminfo() {
+	mkdir -p "${ED}/usr/share/terminfo/t"
+	cp "${ED}/usr/share/terminfo/"{s/screen,t/tmux}
+	cp "${ED}/usr/share/terminfo/"{s/screen-256color,t/tmux-256color}
+}


### PR DESCRIPTION
# Small fixes
- install terminfo files for tmux
- slightly speed up `./build_image` by using lbzip2 instead of bzip2 when decompressing gcc.tbz2
- 
## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
