### PR TITLE
sys-fs/multipath-tools: Disable realtime scheduling for multipathd

### DIFF
--- a/sdk_container/src/third_party/coreos-overlay/coreos/config/env/sys-fs/multipath-tools
+++ b/sdk_container/src/third_party/coreos-overlay/coreos/config/env/sys-fs/multipath-tools
@@ -1,0 +1,13 @@
+cros_post_src_install_add_dropin() {
+	mkdir -p "${D}$(systemd_get_systemunitdir)/multipathd.service.d"
+	cat <<EOF >"${D}$(systemd_get_systemunitdir)/multipathd.service.d/flatcar.conf"
+[Service]
+# Multipathd sets itself to sched_rr with highest priority.
+# Cgroups2 doesn't support realtime processes outside the root cgroup,
+# if any such process exists then cpu controller can't be enabled.
+# This poses a bit of a dilemma.
+# Block realtime control for the process, but give it highest non-rt priority.
+RestrictRealtime=yes
+Nice=-20
+EOF
+}


### PR DESCRIPTION
# sys-fs/multipath-tools: Disable realtime scheduling for multipathd

Add a dropin that prevents the service from controlling its own scheduling. On newer Flatcar releases, service ordering seems to have changed and multipathd is able to configure realtime scheduling before systemd tries (and fails) to enable the cpu controller.  The dropin is meant to enforce sane behavior, and matches older Flatcar releases where cpu controller was enabled before multipathd tries (and fails) to configure realtime scheduling.


## How to use

[ describe what reviewers need to do in order to validate this PR ]
TODO: mantle test case
TODO: changelog

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
