### PR TITLE
Allow injecting coreos-cargo.eclass into portage-stable ebuilds

### DIFF
--- a/sdk_container/src/third_party/coreos-overlay/coreos/config/env/sys-apps/zram-generator
+++ b/sdk_container/src/third_party/coreos-overlay/coreos/config/env/sys-apps/zram-generator
@@ -1,0 +1,8 @@
+cros_pre_src_unpack_coreos_unpack() {
+  local _COREOS_CARGO_SKIP_INHERIT=1
+  source "${CROS_ADDONS_TREE}"/../eclass/coreos-cargo.eclass
+  src_unpack() {
+    einfo "Running coreos-cargo_src_unpack"
+    coreos-cargo_src_unpack
+  }
+}

--- a/sdk_container/src/third_party/coreos-overlay/coreos/config/env/sys-block/thin-provisioning-tools
+++ b/sdk_container/src/third_party/coreos-overlay/coreos/config/env/sys-block/thin-provisioning-tools
@@ -1,0 +1,16 @@
+cros_pre_src_unpack_coreos_unpack() {
+  local _COREOS_CARGO_SKIP_INHERIT=1
+  source "${CROS_ADDONS_TREE}"/../eclass/coreos-cargo.eclass
+  src_unpack() {
+    einfo "Running coreos-cargo_src_unpack"
+    coreos-cargo_src_unpack
+  }
+}
+
+cros_pre_src_install_rust_cross() {
+  pushd "${S}"
+  local rust_target="$(ls -d target/*-unknown-linux-gnu)"
+  rust_target="${rust_target#target/}"
+  ln -f target/{"${rust_target}",}/"$(usex debug debug release)/pdata_tools" || die
+  popd
+}

--- a/sdk_container/src/third_party/coreos-overlay/eclass/coreos-cargo.eclass
+++ b/sdk_container/src/third_party/coreos-overlay/eclass/coreos-cargo.eclass
@@ -12,10 +12,12 @@ if [[ -z ${_COREOS_CARGO_ECLASS} ]]; then
 _COREOS_CARGO_ECLASS=1
 
 # XXX: Don't require host dependencies to also be in the sysroot.
-CATEGORY=dev-util PN=cargo inherit cargo
-inherit toolchain-funcs
+if [[ -z ${_COREOS_CARGO_SKIP_INHERIT} ]]; then
+  CATEGORY=dev-util PN=cargo inherit cargo
+  inherit toolchain-funcs
 
-EXPORT_FUNCTIONS src_unpack
+  EXPORT_FUNCTIONS src_unpack
+fi
 
 # @FUNCTION: coreos-cargo_src_unpack
 # @DESCRIPTION:


### PR DESCRIPTION
# Allow injecting coreos-cargo.eclass into portage-stable ebuilds

Ebuilds in portage-stable that use cargo.eclass don't cross-compile cleanly. Arm64 builds produce host binaries. Modify coreos-cargo.eclass slightly to allow it to be sourced from cros hooks, which allows us to override src_unpack cleanly. This is equivalent to injecting coreos-cargo.eclass into unmodified ebuilds.

Tested that with this change `zram-generator` and `thin-provisioning-tools` now produce arm64 binaries. This resolves the following `build_image` warning from arm64 builds:
```
[2024-03-21T03:45:55.114Z] sys-block/thin-provisioning-tools-1.0.10 is missing libraries:
[2024-03-21T03:45:55.114Z] 	x86_64: libc.so.6
[2024-03-21T03:45:55.114Z] 	x86_64: ld-linux-x86-64.so.2
[2024-03-21T03:45:55.114Z] 	x86_64: libgcc_s.so.1
[2024-03-21T03:45:55.114Z] 	x86_64: libm.so.6
```

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

```
$ emerge-arm64-usr thin-provisioning-tools
$ file /build/arm64-usr/usr/sbin/pdata_tools
/build/arm64-usr/usr/sbin/pdata_tools: ELF 64-bit LSB pie executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 3.7.0, stripped
```

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->

- [ ] TODO: figure out how to upstream cross compilation support into cargo.eclass.
