### PR TITLE
Update coreos-cloudinit to latest main branch

### DIFF
--- a/changelog/bugfixes/2024-03-25-disable-user-configdrive-on-openstack.md
+++ b/changelog/bugfixes/2024-03-25-disable-user-configdrive-on-openstack.md
@@ -1,1 +1,1 @@
-- Disable user-configdrive.service on OpenStack when config drive is used. The coreos-cloudinit.service unit already runs on OpenStack if the system is not configured via ignition. ([Flatcar#1385](https://github.com/flatcar/Flatcar/issues/1385))
+- Disabled user-configdrive.service on OpenStack when config drive is used, which caused the hostname to be overwritten. The coreos-cloudinit.service unit already runs on OpenStack if the system is not configured via ignition. ([Flatcar#1385](https://github.com/flatcar/Flatcar/issues/1385))

--- a/changelog/bugfixes/2024-03-25-disable-user-configdrive-on-openstack.md
+++ b/changelog/bugfixes/2024-03-25-disable-user-configdrive-on-openstack.md
@@ -1,0 +1,1 @@
+- Disable user-configdrive.service on OpenStack when config drive is used. The coreos-cloudinit.service unit already runs on OpenStack if the system is not configured via ignition. ([Flatcar#1385](https://github.com/flatcar/Flatcar/issues/1385))

--- a/sdk_container/src/third_party/coreos-overlay/coreos-base/coreos-cloudinit/coreos-cloudinit-9999.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/coreos-base/coreos-cloudinit/coreos-cloudinit-9999.ebuild
@@ -12,7 +12,7 @@ inherit cros-workon systemd toolchain-funcs udev coreos-go
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm64"
 else
-	CROS_WORKON_COMMIT="a7bc5f0050ab3493807ec69977cda26b882b4aad" # flatcar-master
+	CROS_WORKON_COMMIT="f78b9f7b484497c610c8a159aa971234d384d215" # flatcar-master
 	KEYWORDS="amd64 arm64"
 fi
 


### PR DESCRIPTION
# Update coreos-cloudinit to the latest flatcar-master commit

This change disables user-configdrive.service on OpenStack, as coreos-cloudinit.service already runs on OpenStack when the system is not configured via ignition.

## How to use

Deploy a virtual machine on OpenStack with config drive, verify that the unit is disabled.

## Testing done

Built a fresh flatcar image and deployed it on a local OpenStack. Checked that `user-configdrive.service` was not started.

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [x] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.


/build-image
