### PR TITLE
image_to_vm: add support for hyperv_vhdx format

### DIFF
--- a/build_library/release_util.sh
+++ b/build_library/release_util.sh
@@ -89,7 +89,7 @@ compress_disk_images() {
     # We want to compress images, but we also want to remove the uncompressed files
     # from the list of uploadable files.
     for filename in "${local_files_to_evaluate[@]}"; do
-        if [[ "${filename}" =~ \.(img|bin|vdi|vhd|vmdk)$ ]]; then
+        if [[ "${filename}" =~ \.(img|bin|vdi|vhd|vhdx|vmdk)$ ]]; then
             # Parse the formats as an array. This will yield an extra empty
             # array element at the end.
             readarray -td, FORMATS<<<"${FLAGS_image_compression_formats},"

--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -16,6 +16,7 @@ VALID_IMG_TYPES=(
     exoscale
     gce
     hyperv
+    hyperv_vhdx
     iso
     openstack
     openstack_mini
@@ -297,6 +298,11 @@ IMG_azure_OEM_SYSEXT=oem-azure
 IMG_hyperv_DISK_FORMAT=vhd
 IMG_hyperv_OEM_PACKAGE=oem-hyperv
 
+## hyper-v vhdx
+IMG_hyperv_vhdx_DISK_FORMAT=vhdx
+IMG_hyperv_vhdx_OEM_PACKAGE=oem-hyperv
+
+
 ## cloudsigma
 IMG_cloudsigma_DISK_FORMAT=qcow2
 IMG_cloudsigma_OEM_PACKAGE=oem-cloudsigma
@@ -431,7 +437,9 @@ _disk_ext() {
         vmdk_scsi) echo vmdk;;
         vmdk_stream) echo vmdk;;
         hdd) echo hdd;;
-        vhd*) echo vhd;;
+        vhd) echo vhd;;
+        vhd_fixed) echo vhd;;
+        vhdx) echo vhdx;;
         *) echo "${disk_format}";;
     esac
 }
@@ -618,6 +626,11 @@ _write_vhd_disk() {
 _write_vhd_fixed_disk() {
     qemu-img convert -f raw "$1" -O vpc -o subformat=fixed,force_size "$2"
     assert_image_size "$2" vpc
+}
+
+_write_vhdx_disk() {
+    qemu-img convert -f raw "$1" -O vhdx -o subformat=dynamic "$2"
+    assert_image_size "$2" vhdx
 }
 
 _write_vmdk_ide_disk() {

--- a/changelog/changes/2024-03-26-hyperv-vhdx-images.md
+++ b/changelog/changes/2024-03-26-hyperv-vhdx-images.md
@@ -1,0 +1,1 @@
+- Added Hyper-V VHDX image ([flatcar/scripts#1791](https://github.com/flatcar/scripts/pull/1791))


### PR DESCRIPTION
Add support for Gen 2 Hyper-V VMs.

See: https://github.com/flatcar/Flatcar/issues/1009

`./image_to_vm` tool has now a new supported format: `hyperv_vhdx`, that produces .vhdx dynamic disks.

## How to use

```
 ./image_to_vm.sh --from ../build/images/amd64-usr/developer-latest/ --format hyperv_vhdx
```

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [x] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

