### PR TITLE
qemu_template.sh: Add support for attaching a software TPM

### DIFF
--- a/build_library/qemu_template.sh
+++ b/build_library/qemu_template.sh
@@ -26,6 +26,8 @@ Options:
     -c FILE     Config drive as an iso or fat filesystem image.
     -a FILE     SSH public keys for login access. [~/.ssh/id_{dsa,rsa}.pub]
     -p PORT     The port on localhost to map to the VM's sshd. [2222]
+    -I FILE     Set a custom image file.
+    -M MB       Set VM memory in MBs.
     -s          Safe settings: single simple cpu and no KVM.
     -h          this ;-)
 
@@ -76,6 +78,12 @@ while [ $# -ge 1 ]; do
         -s|-safe)
             SAFE_ARGS=1
             shift ;;
+        -I|-image-file)
+            VM_IMAGE="$2"
+            shift 2 ;;
+        -M|-memory)
+            VM_MEMORY="$2"
+            shift 2 ;;
         -v|-verbose)
             set -x
             shift ;;

--- a/build_library/qemu_template.sh
+++ b/build_library/qemu_template.sh
@@ -35,6 +35,8 @@ Options:
                 (see https://github.com/stefanberger/swtpm/wiki/Certificates-created-by-swtpm_setup).
     -R FILE     Set up pflash ro content, e.g., for UEFI (with -W).
     -W FILE     Set up pflash rw content, e.g., for UEFI (with -R).
+    -K FILE     Set kernel for direct boot used to simulate a PXE boot (with -R).
+    -R FILE     Set initrd for direct boot used to simulate a PXE boot (with -K).
     -s          Safe settings: single simple cpu and no KVM.
     -h          this ;-)
 
@@ -99,6 +101,12 @@ while [ $# -ge 1 ]; do
             shift 2 ;;
         -W|-pflash-rw)
             VM_PFLASH_RW="$2"
+            shift 2 ;;
+        -K|-kernel-file)
+            VM_KERNEL="$2"
+            shift 2 ;;
+        -R|-initrd-file)
+            VM_INITRD="$2"
             shift 2 ;;
         -v|-verbose)
             set -x

--- a/build_library/qemu_template.sh
+++ b/build_library/qemu_template.sh
@@ -31,6 +31,8 @@ Options:
     -M MB       Set VM memory in MBs.
     -T DIR      Add a software TPM2 device through swtpm which stores secrets
                 and the control socket to the given directory.
+    -R FILE     Set up pflash ro content, e.g., for UEFI (with -W).
+    -W FILE     Set up pflash rw content, e.g., for UEFI (with -R).
     -s          Safe settings: single simple cpu and no KVM.
     -h          this ;-)
 
@@ -89,6 +91,12 @@ while [ $# -ge 1 ]; do
             shift 2 ;;
         -T|-tpm)
             SWTPM_DIR="$2"
+            shift 2 ;;
+        -R|-pflash-ro)
+            VM_PFLASH_RO="$2"
+            shift 2 ;;
+        -W|-pflash-rw)
+            VM_PFLASH_RW="$2"
             shift 2 ;;
         -v|-verbose)
             set -x

--- a/build_library/qemu_template.sh
+++ b/build_library/qemu_template.sh
@@ -30,7 +30,9 @@ Options:
     -I FILE     Set a custom image file.
     -M MB       Set VM memory in MBs.
     -T DIR      Add a software TPM2 device through swtpm which stores secrets
-                and the control socket to the given directory.
+                and the control socket to the given directory. This may need
+                some configuration first with 'swtpm_setup --tpmstate DIR ...'
+                (see https://github.com/stefanberger/swtpm/wiki/Certificates-created-by-swtpm_setup).
     -R FILE     Set up pflash ro content, e.g., for UEFI (with -W).
     -W FILE     Set up pflash rw content, e.g., for UEFI (with -R).
     -s          Safe settings: single simple cpu and no KVM.

--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -119,7 +119,7 @@ IMG_DEFAULT_CONF_FORMAT=
 IMG_DEFAULT_BUNDLE_FORMAT=
 
 # Memory size to use in any config files
-IMG_DEFAULT_MEM=1024
+IMG_DEFAULT_MEM=2048
 
 # Number of CPUs to use in any config files
 IMG_DEFAULT_CPUS=2

--- a/changelog/changes/2024-04-03-qemu-script.md
+++ b/changelog/changes/2024-04-03-qemu-script.md
@@ -1,0 +1,1 @@
+- The default VM memory was bumped to 2 GB in the Qemu script and for VMware OVFs


### PR DESCRIPTION
- qemu_template.sh: Add support for attaching a software TPM
    
    For testing TPM2-backed rootfs encryption it is handy to have a software
    TPM option for the qemu script.
    Add a flag for a software TPM with swtpm like kola also does. The user
    has to specify a folder for the secret state and this won't be removed
    because the same store should be able to be passed when booting the VM
    again after shutdown.
- vm_image_util.sh: Bump default VM memory to 2 GB
    
    While Flatcar itself runs fine with 1 GB, many workloads do not and
    having to debug this is time consuming when one forgets to bump the VM
    memory, e.g., in the Qemu script.
    Default to 2 GB as known-good setting for things like Kubernetes or
    setting up LUKS devices.
- qemu_template.sh: Allow parameters for VM image and memory
    
    When testing multiple images one always has to copy them to the
    expected file name, and when trying to run two VMs this means one needs
    to either use separate directories or modify the qemu script. One also
    needs to modify the qemu script to bump the memory for K8s or for LUKS.
    
    Support parameters for the VM image name and the VM memory.

(Note that the kola tests for qemu and vmware all use 2 GB or slightly more. Thus it makes sense to default to this as well in the release artifacts we provide to the users.)

## How to use

```
./flatcar_production_qemu.sh -T myswtpmdir
```

## Testing done

The above and verified that the swtpm process gets cleaned up even when qemu doesn't start, e.g., `./flatcar_production_qemu.sh -T swtpm-dir -- -unknown-arg`

Downloaded rendered template and checked that memory and image location settings work.

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
