### PR TITLE
build_library/grub.cfg: Enable TPM module by default

### DIFF
--- a/build_library/grub_install.sh
+++ b/build_library/grub_install.sh
@@ -60,7 +60,7 @@ case "${FLAGS_target}" in
         CORE_NAME="core.img"
         ;;
     x86_64-efi)
-        CORE_MODULES+=( serial linux efi_gop efinet pgp http tftp )
+        CORE_MODULES+=( serial linux efi_gop efinet pgp http tftp tpm )
         CORE_NAME="core.efi"
         SBAT_ARG=( --sbat "${BOARD_ROOT}/usr/share/grub/sbat.csv" )
         ;;
@@ -68,7 +68,7 @@ case "${FLAGS_target}" in
         CORE_NAME="core.elf"
         ;;
     arm64-efi)
-        CORE_MODULES+=( serial linux efi_gop efinet pgp http tftp )
+        CORE_MODULES+=( serial linux efi_gop efinet pgp http tftp tpm )
         CORE_NAME="core.efi"
         BOARD_GRUB=1
         SBAT_ARG=( --sbat "${BOARD_ROOT}/usr/share/grub/sbat.csv" )

--- a/changelog/changes/2024-04-09-grub-tpm.md
+++ b/changelog/changes/2024-04-09-grub-tpm.md
@@ -1,0 +1,1 @@
+- Enabled the GRUB TPM2 module to measure the boot code path and files into PCR 8+9 in UEFI ([scripts#1861](https://github.com/flatcar/scripts/pull/1861))


### PR DESCRIPTION
For binding a secret to the OS we need TPM PCRs that measure the kernel and boot configuration. Used for:
https://github.com/flatcar/flatcar-website/pull/317


## How to use

Backport to Alpha

## Testing done

When booting with the UEFI script the first boot has PCR 8 and 9 set without any `grub.cfg` customization.

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
