### PR TITLE
Skip non-UEFI qemu image symlink/script for arm64

### DIFF
--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -594,9 +594,12 @@ write_vm_disk() {
         local qemu_uefi_secure="${VM_DST_IMG/qemu_uefi/qemu_uefi_secure}"
         local target_basename
         target_basename=$(basename "${VM_DST_IMG}")
-        ln -fs "${target_basename}" "${qemu}"
+        if [ "${BOARD}" = amd64-usr ]; then
+          ln -fs "${target_basename}" "${qemu}"
+          VM_GENERATED_FILES+=( "${qemu}" )
+        fi
         ln -fs "${target_basename}" "${qemu_uefi_secure}"
-        VM_GENERATED_FILES+=( "${qemu}" "${qemu_uefi_secure}" )
+        VM_GENERATED_FILES+=( "${qemu_uefi_secure}" )
     fi
 
     # Add disk image to final file list if it isn't going to be bundled
@@ -809,7 +812,9 @@ _write_qemu_uefi_conf() {
     # We now only support building qemu_uefi and generate the
     # other artifacts from here
     if [ "${VM_IMG_TYPE}" = qemu_uefi ]; then
-      VM_IMG_TYPE=qemu _write_qemu_conf
+      if [ "${BOARD}" = amd64-usr ]; then
+        VM_IMG_TYPE=qemu _write_qemu_conf
+      fi
       VM_IMG_TYPE=qemu_uefi_secure _write_qemu_uefi_secure_conf
     fi
 }


### PR DESCRIPTION
We didn't generate this before and don't need it.

## How to use

When backporting we should also disable the uefi_secure arm64 image because this is not working on older branches.

## Testing done
