### PR TITLE
.github: Remove bz2 compression layer from zip artifacts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -279,6 +279,7 @@ jobs:
             scripts/artifacts/images/flatcar_production_image*.json
             scripts/artifacts/images/flatcar_production_image_pcr_policy.zip
             scripts/artifacts/images/flatcar_production_*_efi_*.fd
+            scripts/artifacts/images/flatcar_production_qemu.sh
 
       - name: Upload developer container
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -225,7 +225,7 @@ jobs:
               ./run_sdk_container -n "${container_name}" \
                   ./image_to_vm.sh --format "${format}" --board="${arch}-usr" \
                       --from "${CI_CONTAINER_ARTIFACT_ROOT}/${arch}-usr/latest" \
-                      --image_compression_formats=bz2
+                      --image_compression_formats=none
           done
 
           # Zip doesn't handle symlinks well, remove them
@@ -271,7 +271,7 @@ jobs:
           retention-days: 7
           name: ${{ matrix.arch }}-generic-image
           path: |
-            scripts/artifacts/images/flatcar_production_image.bin.bz2
+            scripts/artifacts/images/flatcar_production_image.bin
             scripts/artifacts/images/flatcar_production_image.grub
             scripts/artifacts/images/flatcar_production_image.shim
             scripts/artifacts/images/flatcar_production_image.vmlinuz
@@ -314,8 +314,8 @@ jobs:
           retention-days: 7
           name: ${{ matrix.arch }}-vm-images
           path: |
-            scripts/artifacts/images/*.img.bz2
-            scripts/artifacts/images/*.bin.bz2
+            scripts/artifacts/images/*.img
+            scripts/artifacts/images/*.bin
             scripts/artifacts/images/flatcar_production_*_efi_*.fd
             scripts/artifacts/images/*.txt
             scripts/artifacts/images/flatcar_production_*.sh

--- a/.github/workflows/run-kola-tests.yaml
+++ b/.github/workflows/run-kola-tests.yaml
@@ -162,7 +162,6 @@ jobs:
           # Extract the generic image we'll use for qemu tests.
           # Note that the qemu[_uefi] tests use the generic image instead of the
           #  qemu vendor VM image ("Astronaut: [...] Always have been.").
-          bzip2 --decompress flatcar_production_image.bin.bz2
           mv flatcar_production_image.bin flatcar_production_qemu_uefi_efi_code.fd scripts/
 
           mv flatcar_test_update.gz scripts/


### PR DESCRIPTION
The GitHub Action artifacts are compressed zip files which include bz2 files which are either the raw .bin images that have many zero bytes in the rootfs but the main data in /usr is using zstd compression, or they are the qcow2 .img images which are compressed themselves (and of course have the same /usr compression). The bz2 compression doesn't help in our case.
Remove the bz2 compression layer. If in the future non-zip artifacts are supported we can add it back for the .bin image only by using explicit calls only for that file instead of the
--image_compression_formats= flag for all images.

## How to use

Backporting if possible, otherwise fine if not

## Testing done

```
$ wzip "https://…amd64-generic-image.zip"
2024-04-10 13:18:40    4756340736     515297761 D flatcar_production_image.bin
2024-04-10 13:18:40        787960        260124 D flatcar_production_image.grub
2024-04-10 13:18:40        949440        384036 D flatcar_production_image.shim
2024-04-10 13:18:40      56039928      55901911 D flatcar_production_image.vmlinuz
2024-04-10 13:18:40       3573284        318105 D flatcar_production_image_contents.txt
2024-04-10 13:18:40       2677532        370144 D flatcar_production_image_contents_wtd.txt
2024-04-10 13:18:40           173           134 D flatcar_production_image_disk_usage.txt
2024-04-10 13:18:40        175638         17181 D flatcar_production_image_initrd_contents.txt
2024-04-10 13:18:40        132190         19974 D flatcar_production_image_initrd_contents_wtd.txt
2024-04-10 13:18:40        165681         38851 D flatcar_production_image_kernel_config.txt
2024-04-10 13:18:40       2870946        709976 D flatcar_production_image_licenses.json
2024-04-10 13:18:40         12543          3163 D flatcar_production_image_packages.txt
2024-04-10 13:18:40         25159         24601 D flatcar_production_image_pcr_policy.zip
2024-04-10 13:18:40       1202126         56147 D flatcar_production_image_sbom.json
2024-04-10 13:18:40            65            54 D flatcar_production_image_verity.txt
2024-04-10 13:18:40          9992          3381 D flatcar_production_qemu.sh
2024-04-10 13:18:40       1966080       1074871 D flatcar_production_qemu_uefi_efi_code.fd
2024-04-10 13:18:40        131072           285 D flatcar_production_qemu_uefi_efi_vars.fd
2024-04-10 13:18:40       1966080       1388522 D flatcar_production_qemu_uefi_secure_efi_code.fd
2024-04-10 13:18:40        131072          2450 D flatcar_production_qemu_uefi_secure_efi_vars.fd
heads=1 gets=2 bytes_read=3748
kai@kai:/var/tmp(0)$ wzip "https://…amd64-vm-images.zip…"
2024-04-10 13:19:38         29121          3120 D flatcar-zfs_contents.txt
2024-04-10 13:19:38         17982          3165 D flatcar-zfs_contents_wtd.txt
2024-04-10 13:19:38            70            58 D flatcar-zfs_disk_usage.txt
2024-04-10 13:19:38            74            47 D flatcar-zfs_packages.txt
2024-04-10 13:19:38         10016          3393 D flatcar_production_pxe.sh
2024-04-10 13:19:38      56039928      55901911 D flatcar_production_pxe.vmlinuz
2024-04-10 13:19:38     378237307     378350951 D flatcar_production_pxe_image.cpio.gz
2024-04-10 13:19:38          9992          3381 D flatcar_production_qemu.sh
2024-04-10 13:19:38         10076          3398 D flatcar_production_qemu_uefi.sh
2024-04-10 13:19:38       1966080       1074871 D flatcar_production_qemu_uefi_efi_code.fd
2024-04-10 13:19:38        131072           285 D flatcar_production_qemu_uefi_efi_vars.fd
2024-04-10 13:19:38     517341184     513379851 D flatcar_production_qemu_uefi_image.img
2024-04-10 13:19:38         10090          3402 D flatcar_production_qemu_uefi_secure.sh
2024-04-10 13:19:38       1966080       1388522 D flatcar_production_qemu_uefi_secure_efi_code.fd
2024-04-10 13:19:38        131072          2450 D flatcar_production_qemu_uefi_secure_efi_vars.fd
2024-04-10 13:19:38           628           179 D oem-qemu_contents.txt
2024-04-10 13:19:38           373           166 D oem-qemu_contents_wtd.txt
2024-04-10 13:19:38            70            58 D oem-qemu_disk_usage.txt
2024-04-10 13:19:38            35            34 D oem-qemu_packages.txt
2024-04-10 13:19:38           247           112 D version.txt
```
and the kola tests started.