### PR TITLE
coreos-base/common-oem-files: Enable flatcar.autologin for OpenStack

### DIFF
--- a/changelog/changes/2024-04-11-openstack-autologin.md
+++ b/changelog/changes/2024-04-11-openstack-autologin.md
@@ -1,0 +1,1 @@
+- OpenStack, Brightbox: Added the `flatcar.autologin` kernel cmdline parameter by default as the hypervisor manages access to the console ([scripts#1866](https://github.com/flatcar/scripts/pull/1866))

--- a/sdk_container/src/third_party/coreos-overlay/coreos-base/common-oem-files/files/openstack/grub.cfg.frag
+++ b/sdk_container/src/third_party/coreos-overlay/coreos-base/common-oem-files/files/openstack/grub.cfg.frag
@@ -1,0 +1,1 @@
+set linux_append="flatcar.autologin"


### PR DESCRIPTION
So far the console in OpenStack (or Brightbox which shares the image) was not usable well until one issues a reboot to add the autologin in the GRUB menu.
Add it by default so that one doesn't need this reboot trick.

## How to use


## Testing done

```$ cat grub.cfg 
# Flatcar GRUB settings

set oem_id="openstack"
set linux_append="flatcar.autologin"
```

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
