### PR TITLE
ci-automation/vms: provide Hyper-V images with .zip compression

### DIFF
--- a/changelog/changes/2024-04-11-hyperv-images-compression.md
+++ b/changelog/changes/2024-04-11-hyperv-images-compression.md
@@ -1,0 +1,1 @@
+- Hyper-V images, both .vhd and .vhdx files are available as `zip` compressed, switching from `bzip2` to a built-in available Windows compression - `zip` ([scripts#1878](https://github.com/flatcar/scripts/pull/1878))

--- a/ci-automation/vms.sh
+++ b/ci-automation/vms.sh
@@ -136,6 +136,8 @@ function _vm_build_impl() {
             COMPRESSION_FORMAT="gz,bz2,none"
         elif [[ "${format}" =~ ^(qemu|qemu_uefi)$ ]];then
             COMPRESSION_FORMAT="bz2,none"
+        elif [[ "${format}" =~ ^(hyperv|hyperv_vhdx)$ ]];then
+            COMPRESSION_FORMAT="zip"
         fi
         ./run_sdk_container -n "${vms_container}" -C "${packages_image}" \
             -v "${vernum}" \


### PR DESCRIPTION
On Windows, the .bz2 compression format is not supported by native tooling and external tools like 7zip need to be installed.

Switching to .zip compression, there will be no need for the extra step of having external tools.

See: https://github.com/flatcar/Flatcar/issues/1009
