### PR TITLE
switch xen to PVH mode

### DIFF
--- a/build_library/build_image_util.sh
+++ b/build_library/build_image_util.sh
@@ -874,6 +874,9 @@ EOF
       )
     fi
     for target in ${target_list}; do
+      if [[ "${target}" = "i386-xen_pvh" ]]; then
+        grub_args+=(--copy_xen_grub="${BUILD_DIR}/${image_grub%.grub}-grub-xen_pvh.bin")
+      fi
       ${BUILD_LIBRARY_DIR}/grub_install.sh \
           --board="${BOARD}" \
           --target="${target}" \

--- a/build_library/build_image_util.sh
+++ b/build_library/build_image_util.sh
@@ -857,7 +857,7 @@ EOF
   # This script must mount the ESP partition differently, so run it after unmount
   if [[ "${install_grub}" -eq 1 ]]; then
     local target
-    local target_list="i386-pc x86_64-efi x86_64-xen"
+    local target_list="i386-pc x86_64-efi i386-xen_pvh"
     if [[ ${BOARD} == "arm64-usr" ]]; then
       target_list="arm64-efi"
     fi

--- a/build_library/grub_install.sh
+++ b/build_library/grub_install.sh
@@ -64,7 +64,7 @@ case "${FLAGS_target}" in
         CORE_NAME="core.efi"
         SBAT_ARG=( --sbat "${BOARD_ROOT}/usr/share/grub/sbat.csv" )
         ;;
-    x86_64-xen)
+    i386-xen_pvh)
         CORE_NAME="core.elf"
         ;;
     arm64-efi)
@@ -234,9 +234,10 @@ case "${FLAGS_target}" in
                 "${FLAGS_copy_shim}"
         fi
         ;;
-    x86_64-xen)
+    i386-xen_pvh)
         info "Installing default x86_64 Xen bootloader."
         sudo mkdir -p "${ESP_DIR}/xen" "${ESP_DIR}/boot/grub"
+        # keep the pvboot name for chainloading?
         sudo cp "${ESP_DIR}/${GRUB_DIR}/${CORE_NAME}" \
             "${ESP_DIR}/xen/pvboot-x86_64.elf"
         sudo cp "${BUILD_LIBRARY_DIR}/menu.lst" \

--- a/build_library/grub_install.sh
+++ b/build_library/grub_install.sh
@@ -26,6 +26,8 @@ DEFINE_string copy_efi_grub "" \
   "Copy the EFI GRUB image to the specified path."
 DEFINE_string copy_shim "" \
   "Copy the shim image to the specified path."
+DEFINE_string copy_xen_grub "" \
+  "Copy Xen PVH grub to the specified path."
 
 # Parse flags
 FLAGS "$@" || exit 1
@@ -242,6 +244,10 @@ case "${FLAGS_target}" in
             "${ESP_DIR}/xen/pvboot-x86_64.elf"
         sudo cp "${BUILD_LIBRARY_DIR}/menu.lst" \
             "${ESP_DIR}/boot/grub/menu.lst"
+        if [[ -n "${FLAGS_copy_xen_grub}" ]]; then
+            cp --no-preserve=mode "${ESP_DIR}/xen/pvboot-x86_64.elf" \
+                "${FLAGS_copy_xen_grub}"
+        fi
         ;;
     arm64-efi)
         info "Installing default arm64 UEFI bootloader."

--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -1004,9 +1004,9 @@ _write_xl_conf() {
     echo 'extra = "(hd0,0)/boot/grub/menu.lst"' >> "${pvgrub}"
 
     # The rest is the same
-    tee -a "${pygrub}" >> "${pvgrub}" <<EOF
+    tee -a "${pygrub}" "${pvgrub}" >/dev/null <<EOF
+type = "pvh"
 
-builder = "generic"
 name = "${VM_NAME}"
 
 memory = "${vm_mem}"

--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -994,6 +994,7 @@ _write_xl_conf() {
     local grub_name="flatcar_production_image-grub-xen_pvh.bin"
     local pygrub="${dst_dir}/$(_src_to_dst_name "${src_name}" "_pygrub.cfg")"
     local pvgrub="${dst_dir}/$(_src_to_dst_name "${src_name}" "_pvgrub.cfg")"
+    local hvm="${dst_dir}/$(_src_to_dst_name "${src_name}" "_hvm.cfg")"
     local disk_format=$(_get_vm_opt DISK_FORMAT)
 
     # Set up the few differences between pygrub and pvgrub
@@ -1003,9 +1004,14 @@ _write_xl_conf() {
     echo '# Xen PV config using pvgrub' > "${pvgrub}"
     echo "kernel = \"${grub_name}\"" >> "${pvgrub}"
 
+    echo 'type = "hvm"'> "${hvm}"
     # The rest is the same
     tee -a "${pygrub}" "${pvgrub}" >/dev/null <<EOF
 type = "pvh"
+EOF
+
+    # The rest is the same
+    tee -a "${pygrub}" "${hvm}" "${pvgrub}" >/dev/null <<EOF
 
 name = "${VM_NAME}"
 
@@ -1024,13 +1030,16 @@ xl create -c "${pygrub##*/}"
 Or with pvgrub instead:
 xl create -c "${pvgrub##*/}"
 
+For HVM:
+xl create -c "${hvm##*/}"
+
 Detach from the console with ^] and reattach with:
 xl console ${VM_NAME}
 
 Kill the vm with:
 xl destroy ${VM_NAME}
 EOF
-    VM_GENERATED_FILES+=( "${pygrub}" "${pvgrub}" "${VM_README}" )
+    VM_GENERATED_FILES+=( "${pygrub}" "${pvgrub}" "${hvm}" "${VM_README}" )
 }
 
 _write_ovf_virtualbox_conf() {

--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -991,6 +991,7 @@ _write_xl_conf() {
     local src_name=$(basename "$VM_SRC_IMG")
     local dst_name=$(basename "$VM_DST_IMG")
     local dst_dir=$(dirname "$VM_DST_IMG")
+    local grub_name="flatcar_production_image-grub-xen_pvh.bin"
     local pygrub="${dst_dir}/$(_src_to_dst_name "${src_name}" "_pygrub.cfg")"
     local pvgrub="${dst_dir}/$(_src_to_dst_name "${src_name}" "_pvgrub.cfg")"
     local disk_format=$(_get_vm_opt DISK_FORMAT)
@@ -1000,8 +1001,7 @@ _write_xl_conf() {
     echo 'bootloader = "pygrub"' >> "${pygrub}"
 
     echo '# Xen PV config using pvgrub' > "${pvgrub}"
-    echo 'kernel = "/usr/lib/xen/boot/pv-grub-x86_64.gz"' >> "${pvgrub}"
-    echo 'extra = "(hd0,0)/boot/grub/menu.lst"' >> "${pvgrub}"
+    echo "kernel = \"${grub_name}\"" >> "${pvgrub}"
 
     # The rest is the same
     tee -a "${pygrub}" "${pvgrub}" >/dev/null <<EOF

--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -133,6 +133,7 @@ IMG_qemu_uefi_OEM_SYSEXT=oem-qemu
 
 ## xen
 IMG_xen_CONF_FORMAT=xl
+IMG_xen_OEM_PACKAGE=oem-xen
 
 ## virtualbox
 IMG_virtualbox_DISK_FORMAT=vmdk_ide

--- a/changelog/bugfixes/2024-04-11-xen.md
+++ b/changelog/bugfixes/2024-04-11-xen.md
@@ -1,0 +1,2 @@
+- Fixes for running Flatcar as xen domU in PV(H) mode. This required switching
+  to xen-pvh so only PVH and HVM modes are supported.

--- a/sdk_container/src/third_party/coreos-overlay/coreos-base/oem-xen/files/grub.cfg
+++ b/sdk_container/src/third_party/coreos-overlay/coreos-base/oem-xen/files/grub.cfg
@@ -1,0 +1,3 @@
+# Flatcar GRUB settings
+set linux_console="console=hvc0"
+set linux_append="flatcar.autologin"

--- a/sdk_container/src/third_party/coreos-overlay/coreos-base/oem-xen/files/oem-release
+++ b/sdk_container/src/third_party/coreos-overlay/coreos-base/oem-xen/files/oem-release
@@ -1,0 +1,4 @@
+ID=xen
+VERSION_ID=@@OEM_VERSION_ID@@
+NAME="Xen"
+BUG_REPORT_URL="https://issues.flatcar.org"

--- a/sdk_container/src/third_party/coreos-overlay/coreos-base/oem-xen/metadata.xml
+++ b/sdk_container/src/third_party/coreos-overlay/coreos-base/oem-xen/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/sdk_container/src/third_party/coreos-overlay/coreos-base/oem-xen/oem-xen-0.0.1.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/coreos-base/oem-xen/oem-xen-0.0.1.ebuild
@@ -1,0 +1,28 @@
+# Copyright (c) 2013 CoreOS, Inc.. All rights reserved.
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+DESCRIPTION="OEM suite for Xen"
+HOMEPAGE=""
+SRC_URI=""
+
+LICENSE="Apache-2.0"
+SLOT="0"
+KEYWORDS="amd64"
+IUSE=""
+
+# no source directory
+S="${WORKDIR}"
+
+src_prepare() {
+	default
+	sed -e "s\\@@OEM_VERSION_ID@@\\${PVR}\\g" \
+		"${FILESDIR}/oem-release" > "${T}/oem-release" || die
+}
+
+src_install() {
+	insinto "/oem"
+	doins "${FILESDIR}/grub.cfg"
+	doins "${T}/oem-release"
+}

--- a/sdk_container/src/third_party/coreos-overlay/profiles/coreos/amd64/make.defaults
+++ b/sdk_container/src/third_party/coreos-overlay/profiles/coreos/amd64/make.defaults
@@ -5,4 +5,4 @@ BOOTSTRAP_USE="${BOOTSTRAP_USE} -pax_kernel -xtpax"
 USE="-pax_kernel -urandom -xtpax"
 
 # Enable our assorted Grub targets
-GRUB_PLATFORMS="efi-64 pc xen"
+GRUB_PLATFORMS="efi-64 pc xen-pvh"


### PR DESCRIPTION
# switch xen to PVH mode

zstd compressed kernels in Xen are only supported when the host provides the kernel or using grub-xen-pvh. The previous configuration using pvgrub(2) didn't work at all. To make it work again, switch to grub-xen-pvh. Flatcar now only supports booting with pvh or hvm mode. I also added an hvm config for quick usage.

## How to use

```
./build_image
./img_to_vm.sh --format=xen
xl create -c flatcar_production_xen_pvgrub.cfg
# or
xl create -c flatcar_production_xen_pvgrub.cfg
```

## Testing done

Tested the steps above on a Debian 12 dom0.

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
