### PR TITLE
OEM: Provide Hetzner Images

### DIFF
--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -15,6 +15,7 @@ VALID_IMG_TYPES=(
     digitalocean
     exoscale
     gce
+    hetzner
     hyperv
     hyperv_vhdx
     iso
@@ -48,6 +49,7 @@ VALID_OEM_PACKAGES=(
     digitalocean
     exoscale
     gce
+    hetzner
     hyperv
     openstack
     packet
@@ -277,6 +279,13 @@ IMG_azure_DISK_LAYOUT=azure
 IMG_azure_OEM_USE=azure
 IMG_azure_OEM_PACKAGE=common-oem-files
 IMG_azure_OEM_SYSEXT=oem-azure
+
+## hetzner
+IMG_hetzner_DISK_FORMAT=raw
+IMG_hetzner_DISK_LAYOUT=vm
+IMG_hetzner_OEM_USE=hetzner
+IMG_hetzner_OEM_PACKAGE=common-oem-files
+# IMG_hetzner_OEM_SYSEXT=
 
 ## hyper-v
 IMG_hyperv_DISK_FORMAT=vhd

--- a/sdk_container/src/third_party/coreos-overlay/coreos-base/afterburn/files/coreos-metadata.service
+++ b/sdk_container/src/third_party/coreos-overlay/coreos-base/afterburn/files/coreos-metadata.service
@@ -19,6 +19,9 @@ ConditionKernelCommandLine=|coreos.oem.id=packet
 
 ConditionKernelCommandLine=|flatcar.oem.id=scaleway
 
+ConditionKernelCommandLine=|flatcar.oem.id=hetzner
+ConditionKernelCommandLine=|coreos.oem.id=hetzner
+
 Description=Flatcar Metadata Agent
 
 [Service]

--- a/sdk_container/src/third_party/coreos-overlay/coreos-base/common-oem-files/common-oem-files-0-r6.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/coreos-base/common-oem-files/common-oem-files-0-r6.ebuild
@@ -31,6 +31,7 @@ fi
 COMMON_OEMIDS=(
     ami
     azure
+    hetzner
     openstack
     packet
     qemu

--- a/sdk_container/src/third_party/coreos-overlay/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -3,14 +3,14 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-CROS_WORKON_PROJECT="flatcar/init"
+CROS_WORKON_PROJECT="apricote/flatcar-init"
 CROS_WORKON_LOCALNAME="init"
 CROS_WORKON_REPO="https://github.com"
 
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="32982439c691b6de6446f82b8713edb09451d97b" # flatcar-master
+	CROS_WORKON_COMMIT="f2ee8abbd3fe4b530dd41a80a7b8f80c148f7773" # hetzner
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 

--- a/sdk_container/src/third_party/coreos-overlay/coreos-base/oem-hetzner/metadata.xml
+++ b/sdk_container/src/third_party/coreos-overlay/coreos-base/oem-hetzner/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/sdk_container/src/third_party/coreos-overlay/coreos-base/oem-hetzner/oem-hetzner-0.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/coreos-base/oem-hetzner/oem-hetzner-0.ebuild
@@ -1,0 +1,15 @@
+# Copyright (c) 2013 CoreOS, Inc.. All rights reserved.
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="OEM suite for Hetzner"
+HOMEPAGE="https://hetzner.com"
+SRC_URI=""
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="amd64 arm64"
+IUSE=""
+
+OEM_NAME="Hetzner"

--- a/sdk_container/src/third_party/coreos-overlay/sys-kernel/bootengine/bootengine-9999.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/sys-kernel/bootengine/bootengine-9999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
-CROS_WORKON_PROJECT="flatcar/bootengine"
+CROS_WORKON_PROJECT="apricote/flatcar-bootengine"
 CROS_WORKON_LOCALNAME="bootengine"
 CROS_WORKON_OUTOFTREE_BUILD=1
 CROS_WORKON_REPO="https://github.com"
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="6c2fba412dbce9a011535a9e57332e1307072855" # flatcar-master
+	CROS_WORKON_COMMIT="aaa9580d77931c7a6880f18cdbabf57e92415ebb" # hetzner
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
# Provide Hetzner OEM images

Adds build instructions for Hetzner Cloud images.

Pulls in https://github.com/flatcar/init/pull/118 and https://github.com/flatcar/bootengine/pull/94 in a temporary commit, will be removed once they are merged and used in `main`.

## How to use

The process to setup a server using these changes is described here: https://github.com/apricote/flatcar-packer-hcloud/blob/oem-image/README.md

## Testing done

I have built the image from this PR (based on an earlier nightly tag) and created a Hetzner Cloud server from it. I have tested the following (custom) functionality:

- Logging in with SSH Key
- Correct Hostname
- Afterburn Metadata File

For the usual Hetzner Cloud OS images, there is some "magic" happening through [hc-utils](https://github.com/hetznercloud/hc-utils) which is not included in this PR. I have not tested any functionality related to this.

Changelog Entry will be added closer to merge, as this needs a rebase anyway to get rid of the `tmp` commit.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
