### PR TITLE
coreos-base/coreos-init: Update to latest ref

### DIFF
--- a/sdk_container/src/third_party/coreos-overlay/coreos-base/coreos-init/coreos-init-9999.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/coreos-base/coreos-init/coreos-init-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="32982439c691b6de6446f82b8713edb09451d97b" # flatcar-master
+	CROS_WORKON_COMMIT="f35d50bed4c6556fee3ee40fef0d35ee9f3bc2c5" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in https://github.com/flatcar/init/pull/119 just to have the latest commit ref. The change is not needed on new Flatcar versions but for those that download the flatcar-update script from git as raw file.

## How to use


## Testing done
See linked PR

↓ Not needed
- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
