### PR TITLE
Silence mksquashfs warnings by excluding btrfs attributes

### DIFF
--- a/build_library/prod_image_util.sh
+++ b/build_library/prod_image_util.sh
@@ -129,7 +129,7 @@ create_prod_image() {
 
   sudo cp -a "${root_fs_dir}" "${BUILD_DIR}/root_fs_dir2"
   sudo rsync -a --delete  "${BUILD_DIR}/configroot/etc/portage" "${BUILD_DIR}/root_fs_dir2/etc"
-  sudo mksquashfs "${BUILD_DIR}/root_fs_dir2"  "${BUILD_DIR}/${image_sysext_base}" -noappend
+  sudo mksquashfs "${BUILD_DIR}/root_fs_dir2"  "${BUILD_DIR}/${image_sysext_base}" -noappend -xattrs-exclude '^btrfs.'
   sudo rm -rf "${BUILD_DIR}/root_fs_dir2"
   
   # clean-ups of things we do not need

--- a/build_sysext
+++ b/build_sysext
@@ -233,7 +233,7 @@ if [[ "$FLAGS_generate_pkginfo" = "${FLAGS_TRUE}" ]] ; then
   mkdir -p "${BUILD_DIR}/img-pkginfo/var/db"
   cp -R "${BUILD_DIR}/install-root/var/db/pkg" "${BUILD_DIR}/img-pkginfo/var/db/"
   mksquashfs "${BUILD_DIR}/img-pkginfo" "${BUILD_DIR}/${SYSEXTNAME}_pkginfo.raw" \
-              -noappend -comp "${FLAGS_compression}" ${FLAGS_mksquashfs_opts}
+              -noappend -xattrs-exclude '^btrfs.' -comp "${FLAGS_compression}" ${FLAGS_mksquashfs_opts}
 fi
 
 info "Writing ${SYSEXTNAME}_packages.txt"
@@ -284,7 +284,7 @@ info "Removing opaque directory markers to always merge all contents"
 find "${BUILD_DIR}/install-root" -xdev -type d -exec sh -c 'if [ "$(attr -R -q -g overlay.opaque {} 2>/dev/null)" = y ]; then attr -R -r overlay.opaque {}; fi' \;
 
 mksquashfs "${BUILD_DIR}/install-root" "${BUILD_DIR}/${SYSEXTNAME}.raw" \
-               -noappend -comp "${FLAGS_compression}" ${FLAGS_mksquashfs_opts}
+               -noappend -xattrs-exclude '^btrfs.' -comp "${FLAGS_compression}" ${FLAGS_mksquashfs_opts}
 rm -rf "${BUILD_DIR}"/{fs-root,install-root,workdir}
 
 # Generate reports


### PR DESCRIPTION
When mksquashfs encounters btrfs attributes which indicate that the file is transparently compressed, it can't embed this info in the squashfs and prints a warning about that.
Silence the warnings by excluding btrfs attributes as done already in the rest of the code base. This aligns the mksquashfs invocation in this regard.

## How to use


## Testing done

