### PR TITLE
.github: Disable debug output for image-changes

### DIFF
--- a/.github/workflows/image_changes.sh
+++ b/.github/workflows/image_changes.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -x
+#set -x
 set -euo pipefail
 
 source ci-automation/image_changes.sh


### PR DESCRIPTION
The "set -x" bash debug output is very noisy and one doesn't even see the actual output in this noise.

