### PR TITLE
build_library: Use original qemu image name in qemu script

### DIFF
--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -812,10 +812,14 @@ _write_qemu_uefi_conf() {
     # We now only support building qemu_uefi and generate the
     # other artifacts from here
     if [ "${VM_IMG_TYPE}" = qemu_uefi ]; then
+      local qemu="${VM_DST_IMG/qemu_uefi/qemu}"
+      local qemu_uefi_secure="${VM_DST_IMG/qemu_uefi/qemu_uefi_secure}"
+      local qemu_name="${VM_NAME/qemu_uefi/qemu}"
+      local qemu_uefi_secure_name="${VM_NAME/qemu_uefi/qemu_uefi_secure}"
       if [ "${BOARD}" = amd64-usr ]; then
-        VM_IMG_TYPE=qemu _write_qemu_conf
+        VM_IMG_TYPE=qemu VM_DST_IMG="${qemu}" VM_NAME="${qemu_name}" _write_qemu_conf
       fi
-      VM_IMG_TYPE=qemu_uefi_secure _write_qemu_uefi_secure_conf
+      VM_IMG_TYPE=qemu_uefi_secure VM_DST_IMG="${qemu_uefi_secure}" VM_NAME="${qemu_uefi_secure_name}" _write_qemu_uefi_secure_conf
     fi
 }
 


### PR DESCRIPTION
The move to symlinking to the qemu-uefi image also resulted in the qemu-uefi image being referenced in the qemu-bios and qemu-uefi-secure scripts instead of referencing the image symlinks. Same for the VM name shown in the qemu window title.
When generating the qemu scripts, use the original qemu image name and VM name.

## How to use

Backport

## Testing done

GitHub Actions and [Jenkins](http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/3861/cldsv/)

```
curl -fsSL https://bincache.flatcar-linux.net/images/amd64/9999.9.9+kai-qemu-script-img-name/flatcar_production_qemu_uefi_secure.sh|grep -m2 -P "(VM_NAME|VM_IMAGE)"
VM_NAME='flatcar_production_qemu_uefi_secure-9999-9-9-kai-qemu-script-img-name'
VM_IMAGE='flatcar_production_qemu_uefi_secure_image.img'

curl -fsSL https://bincache.flatcar-linux.net/images/amd64/9999.9.9+kai-qemu-script-img-name/flatcar_production_qemu.sh|grep -m2 -P "(VM_NAME|VM_IMAGE)"
VM_NAME='flatcar_production_qemu-9999-9-9-kai-qemu-script-img-name'
VM_IMAGE='flatcar_production_qemu_image.img'
```