### PR TITLE
ci-automation/vms: Download vmlinuz file before building VM images

### DIFF
--- a/ci-automation/vms.sh
+++ b/ci-automation/vms.sh
@@ -113,7 +113,7 @@ function _vm_build_impl() {
     local images_in="images-in/"
     local file
     rm -rf "${images_in}"
-    for file in flatcar_production_image.bin.bz2 flatcar_production_image_sysext.squashfs version.txt; do
+    for file in flatcar_production_image.bin.bz2 flatcar_production_image_sysext.squashfs flatcar_production_image.vmlinuz version.txt; do
         copy_from_buildcache "images/${arch}/${vernum}/${file}" "${images_in}"
     done
     lbunzip2 "${images_in}/flatcar_production_image.bin.bz2"
@@ -156,8 +156,12 @@ function _vm_build_impl() {
         mv "${CONTAINER_IMAGE_ROOT}/${arch}-usr/" "./${images_out}/"
 
     ( cd images/latest ; ln -s flatcar_production_openstack_image.img.bz2 flatcar_production_brightbox_image.img.bz2 )
+    # For the digest creation we need the vmlinuz at the same folder
+    # because the PXE vmlinuz is a symlink to it
+    mv images/latest-input/flatcar_production_image.vmlinuz images/latest/
     create_digests "${SIGNER}" "images/latest/"*
     sign_artifacts "${SIGNER}" "images/latest/"*
+    mv images/latest/flatcar_production_image.vmlinuz* images/latest-input/
     copy_to_buildcache "images/${arch}/${vernum}/" "images/latest/"*
 }
 # --


### PR DESCRIPTION
After making flatcar_production_pxe.vmlinuz a symlink to flatcar_production_image.vmlinuz the signature creation didn't work because the target could not be found.
As we do with the generic image, download the kernel from bincache, too, before starting the VM image build.

## How to use

Backport

## Testing done

[Jenkins](http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/3873/cldsv/)
Digest/signature files are present now: http://bincache.flatcar-linux.net/images/arm64/9999.9.9+kai-pxe-vmlinuz-sign/flatcar_production_pxe.vmlinuz.DIGESTS