### PR TITLE
Migrate release AMI gc to ci-automation

### DIFF
--- a/ci-automation/garbage_collect.sh
+++ b/ci-automation/garbage_collect.sh
@@ -256,6 +256,7 @@ function _garbage_collect_impl() {
     docker run --pull always --rm --net host \
       --env AZURE_AUTH_CREDENTIALS --env AZURE_PROFILE \
       --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY \
+      --env AWS_CREDENTIALS \
       --env DIGITALOCEAN_TOKEN_JSON \
       --env EQUINIXMETAL_KEY --env EQUINIXMETAL_PROJECT \
       --env GCP_JSON_KEY \

--- a/ci-automation/garbage_collect_cloud.sh
+++ b/ci-automation/garbage_collect_cloud.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -euo pipefail
+source ci-automation/ci_automation_common.sh
 timeout --signal=SIGQUIT 60m ore aws gc --access-id "${AWS_ACCESS_KEY_ID}" --secret-key "${AWS_SECRET_ACCESS_KEY}"
 timeout --signal=SIGQUIT 60m ore do gc --config-file=<(echo "${DIGITALOCEAN_TOKEN_JSON}" | base64 --decode)
 timeout --signal=SIGQUIT 60m ore gcloud gc --json-key <(echo "${GCP_JSON_KEY}" | base64 --decode)
@@ -10,3 +11,17 @@ timeout --signal=SIGQUIT 60m ore openstack gc --duration 6h \
   --config-file=<(echo "${OPENSTACK_CREDS}" | base64 --decode)
 timeout --signal=SIGQUIT 60m ore brightbox gc --duration 6h \
   --brightbox-client-id="${BRIGHTBOX_CLIENT_ID}" --brightbox-client-secret="${BRIGHTBOX_CLIENT_SECRET}"
+secret_to_file aws_credentials_config_file "${AWS_CREDENTIALS}"
+for channel in alpha beta stable lts; do
+  for arch in amd64 arm64; do
+    timeout --signal=SIGQUIT 240m plume prune --days 365 \
+      --keep-last 2 \
+      --days-soft-deleted 21 \
+      --check-last-launched \
+      --days-last-launched 60 \
+      --verbose \
+      --board="${arch}-usr" \
+      --channel="${channel}" \
+      --aws-credentials="${aws_credentials_config_file}"
+  done
+done

--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -1,11 +1,1 @@
-The scripts in this directory are run from [OS Jenkins jobs][jenkins-os].  By
-storing the Jenkins scripts in this repository, they are more tightly coupled
-to the release branch of the SDK scripts that they require.  The Jenkins jobs
-are responsible for setting up the environment and securely initializing an SDK
-in the workspace before running these scripts.
-
-The special files named `formats-${BOARD}.txt` are space-separated lists of VM
-image formats that should be built for releases on this branch; i.e. the script
-`vm.sh` is run for each item in the list.
-
-[jenkins-os]: https://github.com/coreos/jenkins-os
+This folder is unused.


### PR DESCRIPTION
The deletion of old release AMIs was still relying on the previous Jenkins setup. Move this to the ci-automation folder.

## How to use

## Testing done

It worked on a manual run in Jenkins: `Pruning complete: {total:508 kept:42 skipped:420 recentlyUsed:4 softDeleted:42 deleted:0}` and similar showed up 8 times.