### PR TITLE
grub cfg tweaks

### DIFF
--- a/build_library/grub_install.sh
+++ b/build_library/grub_install.sh
@@ -43,7 +43,7 @@ GRUB_DIR="flatcar/grub/${FLAGS_target}"
 GRUB_SRC="/usr/lib/grub/${FLAGS_target}"
 
 # Modules required to boot a standard CoreOS configuration
-CORE_MODULES=( normal search test fat part_gpt search_fs_uuid gzio search_part_label terminal gptprio configfile memdisk tar echo read )
+CORE_MODULES=( normal search test fat part_gpt search_fs_uuid gzio search_part_label terminal gptprio configfile memdisk tar echo read btrfs )
 
 # Name of the core image, depends on target
 CORE_NAME=

--- a/build_library/grub_install.sh
+++ b/build_library/grub_install.sh
@@ -141,10 +141,11 @@ done
 info "Generating ${GRUB_DIR}/load.cfg"
 # Include a small initial config in the core image to search for the ESP
 # by filesystem ID in case the platform doesn't provide the boot disk.
-# The existing $root value is given as a hint so it is searched first.
+# $root points to memdisk here so instead use hd0,gpt1 as a hint so it is
+# searched first.
 ESP_FSID=$(sudo grub-probe -t fs_uuid -d "${LOOP_DEV}p1")
 sudo_clobber "${ESP_DIR}/${GRUB_DIR}/load.cfg" <<EOF
-search.fs_uuid ${ESP_FSID} root \$root
+search.fs_uuid ${ESP_FSID} root hd0,gpt1
 set prefix=(memdisk)
 set
 EOF


### PR DESCRIPTION
# grub cfg tweaks

These changes are not user visible but slightly improve our grub configuration:
- pass a useful hint to the memdisk grub config so that it searches the most likely boot partition path first
- include btrfs grub module in CORE_MODULES, since btrfs is used by the oem partition

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
