### PR TITLE
Shrink /boot by removing duplicate and unused grub binaries/modules

### DIFF
--- a/build_library/grub_install.sh
+++ b/build_library/grub_install.sh
@@ -183,6 +183,12 @@ sudo grub-mkimage \
     --output "${ESP_DIR}/${GRUB_DIR}/${CORE_NAME}" \
     "${CORE_MODULES[@]}"
 
+if [[ "${FLAGS_target}" != i386-pc ]]; then
+    for mod in "${CORE_MODULES[@]}"; do
+      sudo rm "${ESP_DIR}/${GRUB_DIR}/${mod}.mod"
+    done
+fi
+
 # Now target specific steps to make the system bootable
 case "${FLAGS_target}" in
     i386-pc)

--- a/build_library/grub_install.sh
+++ b/build_library/grub_install.sh
@@ -204,8 +204,9 @@ case "${FLAGS_target}" in
             sudo sbsign --key /usr/share/sb_keys/shim.key \
                 --cert /usr/share/sb_keys/shim.pem \
                 "${ESP_DIR}/${GRUB_DIR}/${CORE_NAME}"
-            sudo cp "${ESP_DIR}/${GRUB_DIR}/${CORE_NAME}.signed" \
+            sudo mv "${ESP_DIR}/${GRUB_DIR}/${CORE_NAME}.signed" \
                 "${ESP_DIR}/EFI/boot/grubx64.efi"
+            sudo rm "${ESP_DIR}/${GRUB_DIR}/${CORE_NAME}"
             # Sign the mokmanager(mm) with the shim-embedded key
             sudo sbsign --key /usr/share/sb_keys/shim.key \
                 --cert /usr/share/sb_keys/shim.pem \
@@ -218,7 +219,7 @@ case "${FLAGS_target}" in
                 --output "${ESP_DIR}/EFI/boot/bootx64.efi" \
                 "/usr/lib/shim/shim.efi"
         else
-            sudo cp "${ESP_DIR}/${GRUB_DIR}/${CORE_NAME}" \
+            sudo mv "${ESP_DIR}/${GRUB_DIR}/${CORE_NAME}" \
                 "${ESP_DIR}/EFI/boot/grubx64.efi"
             sudo cp "/usr/lib/shim/shim.efi" \
                 "${ESP_DIR}/EFI/boot/bootx64.efi"
@@ -238,7 +239,7 @@ case "${FLAGS_target}" in
     x86_64-xen)
         info "Installing default x86_64 Xen bootloader."
         sudo mkdir -p "${ESP_DIR}/xen" "${ESP_DIR}/boot/grub"
-        sudo cp "${ESP_DIR}/${GRUB_DIR}/${CORE_NAME}" \
+        sudo mv "${ESP_DIR}/${GRUB_DIR}/${CORE_NAME}" \
             "${ESP_DIR}/xen/pvboot-x86_64.elf"
         sudo cp "${BUILD_LIBRARY_DIR}/menu.lst" \
             "${ESP_DIR}/boot/grub/menu.lst"
@@ -247,7 +248,7 @@ case "${FLAGS_target}" in
         info "Installing default arm64 UEFI bootloader."
         sudo mkdir -p "${ESP_DIR}/EFI/boot"
         #FIXME(andrejro): shim not ported to aarch64
-        sudo cp "${ESP_DIR}/${GRUB_DIR}/${CORE_NAME}" \
+        sudo mv "${ESP_DIR}/${GRUB_DIR}/${CORE_NAME}" \
             "${ESP_DIR}/EFI/boot/bootaa64.efi"
         if [[ -n "${FLAGS_copy_efi_grub}" ]]; then
             # copying from vfat so ignore permissions

--- a/build_library/grub_install.sh
+++ b/build_library/grub_install.sh
@@ -183,11 +183,9 @@ sudo grub-mkimage \
     --output "${ESP_DIR}/${GRUB_DIR}/${CORE_NAME}" \
     "${CORE_MODULES[@]}"
 
-if [[ "${FLAGS_target}" != i386-pc ]]; then
-    for mod in "${CORE_MODULES[@]}"; do
-      sudo rm "${ESP_DIR}/${GRUB_DIR}/${mod}.mod"
-    done
-fi
+for mod in "${CORE_MODULES[@]}"; do
+    sudo rm "${ESP_DIR}/${GRUB_DIR}/${mod}.mod"
+done
 
 # Now target specific steps to make the system bootable
 case "${FLAGS_target}" in

--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -728,13 +728,13 @@ _write_cpio_disk() {
     # Pull the kernel and loader out of the filesystem
     ln -fs flatcar_production_image.vmlinuz "${dst_dir}/${vmlinuz_name}"
 
-    local grub_arch
+    local efi_file
     case $BOARD in
-        amd64-usr) grub_arch="x86_64-efi" ;;
-        arm64-usr) grub_arch="arm64-efi" ;;
+        amd64-usr) efi_file="grubx64.efi" ;;
+        arm64-usr) efi_file="bootaa64.efi" ;;
     esac
 
-    cp "${base_dir}/boot/flatcar/grub/${grub_arch}/core.efi" "${dst_dir}/${grub_name}"
+    cp "${base_dir}/boot/EFI/boot/${efi_file}" "${dst_dir}/${grub_name}"
     VM_GENERATED_FILES+=( "${dst_dir}/${vmlinuz_name}" "${dst_dir}/${grub_name}" )
 }
 

--- a/changelog/changes/2024-06-21-remove-unused-grub-files.md
+++ b/changelog/changes/2024-06-21-remove-unused-grub-files.md
@@ -1,0 +1,1 @@
+- Removed unused grub executable duplicate files and removed grub modules that are already assembled in the grub executable ([#1955](https://github.com/flatcar/scripts/pull/1955)).


### PR DESCRIPTION
# Shrink /boot

Remove grub modules from disk that are assembled into the grub executable.
Remove grub executables that are copies that are not used in the boot path.

This should have no user visible impact.

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
