### PR TITLE
image: add kubevirt image build

### DIFF
--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -19,6 +19,7 @@ VALID_IMG_TYPES=(
     hyperv
     hyperv_vhdx
     iso
+    kubevirt
     openstack
     openstack_mini
     packet
@@ -51,6 +52,7 @@ VALID_OEM_PACKAGES=(
     gce
     hetzner
     hyperv
+    kubevirt
     openstack
     packet
     qemu
@@ -314,6 +316,14 @@ IMG_scaleway_OEM_PACKAGE=common-oem-files
 IMG_scaleway_OEM_USE=scaleway
 IMG_scaleway_OEM_SYSEXT=oem-scaleway
 IMG_scaleway_DISK_EXTENSION=qcow2
+
+## kubevirt
+IMG_kubevirt_DISK_FORMAT=qcow2
+IMG_kubevirt_DISK_LAYOUT=vm
+IMG_kubevirt_OEM_PACKAGE=common-oem-files
+IMG_kubevirt_OEM_USE=kubevirt
+IMG_kubevirt_OEM_SYSEXT=oem-kubevirt
+IMG_kubevirt_DISK_EXTENSION=qcow2
 
 ###########################################################
 

--- a/changelog/changes/2024-04-29-kubevirt-images.md
+++ b/changelog/changes/2024-04-29-kubevirt-images.md
@@ -1,0 +1,1 @@
+- Added KubeVirt qcow2 image for amd64/arm64 ([flatcar/scripts#1962](https://github.com/flatcar/scripts/pull/1962))

--- a/sdk_container/src/third_party/coreos-overlay/coreos-base/afterburn/files/coreos-metadata.service
+++ b/sdk_container/src/third_party/coreos-overlay/coreos-base/afterburn/files/coreos-metadata.service
@@ -21,6 +21,8 @@ ConditionKernelCommandLine=|flatcar.oem.id=scaleway
 
 ConditionKernelCommandLine=|flatcar.oem.id=hetzner
 
+ConditionKernelCommandLine=|flatcar.oem.id=kubevirt
+
 Description=Flatcar Metadata Agent
 
 [Service]

--- a/sdk_container/src/third_party/coreos-overlay/coreos-base/common-oem-files/common-oem-files-0-r8.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/coreos-base/common-oem-files/common-oem-files-0-r8.ebuild
@@ -36,6 +36,7 @@ COMMON_OEMIDS=(
     packet
     qemu
     scaleway
+    kubevirt
 )
 
 ARM64_ONLY_OEMIDS=(

--- a/sdk_container/src/third_party/coreos-overlay/coreos-base/oem-kubevirt/metadata.xml
+++ b/sdk_container/src/third_party/coreos-overlay/coreos-base/oem-kubevirt/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/sdk_container/src/third_party/coreos-overlay/coreos-base/oem-kubevirt/oem-kubevirt-0.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/coreos-base/oem-kubevirt/oem-kubevirt-0.ebuild
@@ -1,0 +1,15 @@
+# Copyright (c) 2013 CoreOS, Inc.. All rights reserved.
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="OEM suite for KubeVirt"
+HOMEPAGE="https://kubevirt.io/"
+SRC_URI=""
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="amd64 arm64"
+IUSE=""
+
+OEM_NAME="KubeVirt"

--- a/sdk_container/src/third_party/coreos-overlay/sys-kernel/bootengine/bootengine-9999.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/sys-kernel/bootengine/bootengine-9999.ebuild
@@ -10,7 +10,7 @@ CROS_WORKON_REPO="https://github.com"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	CROS_WORKON_COMMIT="78d94b311ddb047b280c5ee180410b48ec04ea39" # flatcar-master
+	CROS_WORKON_COMMIT="8da532c809c89a9c434ada0fa9532a1c1bf49f4c" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
As Ignition supports KubeVirt, add a custom oem for it and also the required parts to be able to build an image in .qcow2 format and .gz compression.

Fixes: https://github.com/flatcar/Flatcar/issues/1358