### PR TITLE
.github: Add Flatcar extensions to vm-images artifact

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -319,6 +319,7 @@ jobs:
             scripts/artifacts/images/*.bin
             scripts/artifacts/images/flatcar_production_*_efi_*.fd
             scripts/artifacts/images/*.txt
+            scripts/artifacts/images/flatcar-*.raw
             scripts/artifacts/images/flatcar_production_*.sh
             scripts/artifacts/images/flatcar_production_pxe_image.cpio.gz
             scripts/artifacts/images/flatcar_production_pxe.vmlinuz


### PR DESCRIPTION
The Flatcar extensions get built by the GitHub PR CI but only their content files get archived. Add the .raw image itself so that one can copy it into the image (downloading it at boot time won't work because this uses bincache - so one could get an extension image in case the but version happens to match but it won't be the one that was built in the GitHub CI).

## How to use

For testing PRs like https://github.com/flatcar/scripts/pull/1964

## Testing done

Checked that `flatcar-zfs.raw` is part of `amd64-vm-images.zip`