### PR TITLE
app-emulation/wa-linux-agent: Use networkctl to propagate hostname

### DIFF
--- a/sdk_container/src/third_party/coreos-overlay/app-emulation/wa-linux-agent/files/0001-flatcar-changes.patch
+++ b/sdk_container/src/third_party/coreos-overlay/app-emulation/wa-linux-agent/files/0001-flatcar-changes.patch
@@ -1,4 +1,4 @@
-From 7382c63bb2c90a1173393faf093002341f830a09 Mon Sep 17 00:00:00 2001
+From 948c6075656fde25703ba402f8cd94715feaa774 Mon Sep 17 00:00:00 2001
 From: Krzesimir Nowak <knowak@microsoft.com>
 Date: Mon, 27 Feb 2023 15:59:21 +0100
 Subject: [PATCH] flatcar changes
@@ -12,9 +12,9 @@ Signed-off-by: Jeremi Piotrowski <jpiotrowski@microsoft.com>
  .../common/persist_firewall_rules.py          |   1 +
  config/flatcar/waagent.conf                   | 122 ++++++++++++++++++
  init/flatcar/10-waagent-sysext.conf           |   2 +
- init/flatcar/waagent.service                  |  30 +++++
+ init/flatcar/waagent.service                  |  31 +++++
  setup.py                                      |  20 ++-
- 9 files changed, 312 insertions(+), 43 deletions(-)
+ 9 files changed, 313 insertions(+), 43 deletions(-)
  create mode 100644 azurelinuxagent/common/osutil/coreoscommon.py
  create mode 100644 azurelinuxagent/common/osutil/flatcar.py
  create mode 100644 config/flatcar/waagent.conf
@@ -83,7 +83,7 @@ index 373727e2..63578932 100644
          pass
 diff --git a/azurelinuxagent/common/osutil/coreoscommon.py b/azurelinuxagent/common/osutil/coreoscommon.py
 new file mode 100644
-index 00000000..66eae16e
+index 00000000..9008ff20
 --- /dev/null
 +++ b/azurelinuxagent/common/osutil/coreoscommon.py
 @@ -0,0 +1,59 @@
@@ -169,7 +169,7 @@ index 83123e3f..b9257a9b 100644
      if distro_name in ("suse", "sle_hpc", "sles", "opensuse"):
 diff --git a/azurelinuxagent/common/osutil/flatcar.py b/azurelinuxagent/common/osutil/flatcar.py
 new file mode 100644
-index 00000000..e31b2923
+index 00000000..eeaf25ce
 --- /dev/null
 +++ b/azurelinuxagent/common/osutil/flatcar.py
 @@ -0,0 +1,78 @@
@@ -242,7 +242,7 @@ index 00000000..e31b2923
 +        """
 +        retry_limit = retries + 1
 +        for attempt in range(1, retry_limit):
-+            return_code = shellutil.run("ip link set {0} down && ip link set {0} up".format(ifname))
++            return_code = shellutil.run("networkctl reconfigure {0}".format(ifname))
 +            if return_code == 0:
 +                return
 +            logger.warn("failed to restart {0}: return code {1}".format(ifname, return_code))
@@ -401,7 +401,7 @@ index 00000000..f756dbc9
 +Upholds=waagent.service
 diff --git a/init/flatcar/waagent.service b/init/flatcar/waagent.service
 new file mode 100644
-index 00000000..d0d6f7c8
+index 00000000..8d2c1f09
 --- /dev/null
 +++ b/init/flatcar/waagent.service
 @@ -0,0 +1,31 @@
@@ -469,5 +469,5 @@ index 8f5d92b4..35400e09 100755
          set_bin_files(data_files, dest=agent_bin_path)
          set_conf_files(data_files, dest="/usr/share/defaults/waagent",
 -- 
-2.39.2
+2.45.0
 

--- a/sdk_container/src/third_party/coreos-overlay/app-emulation/wa-linux-agent/files/0001-flatcar-changes.patch
+++ b/sdk_container/src/third_party/coreos-overlay/app-emulation/wa-linux-agent/files/0001-flatcar-changes.patch
@@ -172,7 +172,7 @@ new file mode 100644
 index 00000000..e31b2923
 --- /dev/null
 +++ b/azurelinuxagent/common/osutil/flatcar.py
-@@ -0,0 +1,80 @@
+@@ -0,0 +1,78 @@
 +#
 +# Copyright 2023 Microsoft Corporation
 +#
@@ -240,8 +240,6 @@ index 00000000..e31b2923
 +        Restart an interface by bouncing the link. systemd-networkd observes
 +        this event, and forces a renew of DHCP.
 +        """
-+        logger.info("not restarting interface {}".format(ifname))
-+        return
 +        retry_limit = retries + 1
 +        for attempt in range(1, retry_limit):
 +            return_code = shellutil.run("ip link set {0} down && ip link set {0} up".format(ifname))


### PR DESCRIPTION
The if-up-down to trigger the DHCP request causes problems. It's better
    to directly ask systemd-networkd to issue the request. It seems that
    one needs to use "reconfigure" instead of "forcerenew", so I went with
    only that instead of somehow trying to see if "forcerenew" has an
    effect.


## How to use

For this comment https://github.com/flatcar/scripts/pull/1950#issuecomment-2092741939

## Testing done

Used `flatcar-update -P … -E …` to switch to the built image, and checked that waagent triggers the DHCP renewal:
```
May 03 14:06:56 newname systemd-hostnamed[2482]: Hostname set to <newname> (static)
May 03 14:06:56 newname systemd-resolved[1538]: System hostname changed to 'newname'.
May 03 14:06:56 newname sudo[2479]: pam_unix(sudo:session): session closed for user root
May 03 14:07:06 newname waagent[2401]: 2024-05-03T14:07:06.006518Z INFO EnvHandler ExtHandler EnvMonitor: Detected hostname change: hello2 -> newname
May 03 14:07:06 newname waagent[2401]: 2024-05-03T14:07:06.007770Z INFO EnvHandler ExtHandler Examine /proc/net/route for primary interface
May 03 14:07:06 newname waagent[2401]: 2024-05-03T14:07:06.007969Z INFO EnvHandler ExtHandler Primary interface is [eth0]
May 03 14:07:06 newname systemd-networkd[1736]: eth0: found matching network '/usr/lib/systemd/network/zz-default.network', based on potentially unpredictable interface name.
May 03 14:07:06 newname systemd-networkd[1736]: eth0: Configuring with /usr/lib/systemd/network/zz-default.network.
May 03 14:07:06 newname systemd-networkd[1736]: eth0: DHCP lease lost
May 03 14:07:06 newname systemd-networkd[1736]: eth0: DHCPv6 lease lost
May 03 14:07:06 newname systemd-networkd[1736]: eth0: DHCPv4 address 10.0.0.4/24, gateway 10.0.0.1 acquired from 168.63.129.16
```
There is no `Link DOWN`, `Lost carrier` anymore for `eth0` and  `enP52305s1`.