### PR TITLE
ci-automation/vm: do not compress KubeVirt images

### DIFF
--- a/ci-automation/vms.sh
+++ b/ci-automation/vms.sh
@@ -138,7 +138,7 @@ function _vm_build_impl() {
             COMPRESSION_FORMAT="bz2,none"
         elif [[ "${format}" =~ ^(hyperv|hyperv_vhdx)$ ]];then
             COMPRESSION_FORMAT="zip"
-        elif [[ "${format}" =~ ^(scaleway)$ ]];then
+        elif [[ "${format}" =~ ^(scaleway|kubevirt)$ ]];then
             COMPRESSION_FORMAT="none"
         fi
         ./run_sdk_container -n "${vms_container}" -C "${packages_image}" \


### PR DESCRIPTION
As the .qcow2 is already compressed, there is no need to provide a .bz2 compression on top.
Also, the cdi importer for KubeVirt does only support gz or xz compression.
