### PR TITLE
coreos-overlay/profiles: Add keywords for arm64 sdk

### DIFF
--- a/sdk_container/src/third_party/coreos-overlay/coreos-devel/fero-client/fero-client-9999.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/coreos-devel/fero-client/fero-client-9999.ebuild
@@ -8,10 +8,10 @@ CROS_WORKON_LOCALNAME="fero"
 CROS_WORKON_REPO="https://github.com"
 
 if [[ ${PV} == 9999 ]]; then
-	KEYWORDS="~amd64"
+	KEYWORDS="~amd64 ~arm64"
 else
 	CROS_WORKON_COMMIT="1fb33da499e51b2699394d158b0b66d36fc52974" # v0.1.1
-	KEYWORDS="amd64"
+	KEYWORDS="amd64 arm64"
 fi
 
 inherit cargo cros-workon

--- a/sdk_container/src/third_party/coreos-overlay/profiles/coreos/base/package.accept_keywords
+++ b/sdk_container/src/third_party/coreos-overlay/profiles/coreos/base/package.accept_keywords
@@ -14,6 +14,9 @@
 # Seems to be the only available ebuild in portage-stable right now.
 =app-crypt/adcli-0.9.2 ~amd64 ~arm64
 
+# Needed by arm64-native SDK
+=app-crypt/ccid-1.5.4 ~arm64
+
 # The only available ebuild (from GURU) has ~amd64 and no keyword for arm64 yet.
 =app-crypt/clevis-19-r1 **
 

--- a/sdk_container/src/third_party/coreos-overlay/profiles/coreos/base/package.accept_keywords
+++ b/sdk_container/src/third_party/coreos-overlay/profiles/coreos/base/package.accept_keywords
@@ -29,9 +29,6 @@
 # Required for addressing CVE-2022-3715.
 =app-shells/bash-5.2_p26 ~amd64 ~arm64
 
-# No keyword for arm64 yet.
-=coreos-devel/fero-client-0.1.1 **
-
 # Needed by arm64-native SDK.
 =dev-embedded/u-boot-tools-2021.04_rc2 ~arm64
 =dev-lang/nasm-2.15.05 ~arm64


### PR DESCRIPTION
# Add arm64 keywords for sdk packages
- fero-client was previously keyworded but a revbump due to a dependency change resulted in the keyword not matching any longer
- ccid is a new dep that is still marked ~arm64 in the Gentoo tree.


## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

Testing with bootstrap_sdk when starting from dev container tarball as seed. These missing keywords show up in stage4.

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
