### PR TITLE
ci-automation/release: add support for Managed idenities

### DIFF
--- a/ci-automation/release.sh
+++ b/ci-automation/release.sh
@@ -108,8 +108,7 @@ function _inside_mantle() {
           --debug \
           --platform="${platform}" \
           --aws-credentials="${aws_credentials_config_file}" \
-          --azure-profile="${azure_profile_config_file}" \
-          --azure-auth="${azure_auth_config_file}" \
+          --azure-identity \
           --gce-json-key=none \
           --board="${arch}-usr" \
           --channel="${CHANNEL}" \
@@ -138,8 +137,7 @@ function _inside_mantle() {
         --publish-marketplace \
         --access-role-arn="${AWS_MARKETPLACE_ARN}" \
         --product-ids="${pid}" \
-        --azure-profile="${azure_profile_config_file}" \
-        --azure-auth="${azure_auth_config_file}" \
+        --azure-identity \
         --gce-json-key="${gcp_json_key_path}" \
         --gce-release-key="${google_release_credentials_file}" \
         --board="${arch}-usr" \


### PR DESCRIPTION
Add the support to run the pre-release and the release jobs via managed idenities

to be merged with https://github.com/flatcar/mantle/pull/535