### PR TITLE
sysext_prod_builder: fix build id mismatch

### DIFF
--- a/build_library/sysext_prod_builder
+++ b/build_library/sysext_prod_builder
@@ -56,7 +56,10 @@ create_prod_sysext() {
 
   info "${msg}."
   
-  sudo "${SCRIPTS_DIR}/build_sysext" \
+  # Pass the build ID extracted from root FS to build_sysext. This prevents common.sh
+  #   in build_sysext to generate a (timestamp based) build ID during a DEV build of a
+  #   release tag (which breaks its version check).
+  sudo "FLATCAR_BUILD_ID=$FLATCAR_BUILD_ID" "${SCRIPTS_DIR}/build_sysext" \
             --board="${BOARD}" \
             --image_builddir="${workdir}/sysext-build" \
             --squashfs_base="${base_sysext}" \
@@ -103,6 +106,13 @@ mkdir "${sysext_workdir}" "${sysext_output_dir}"
 
 info "creating temporary base OS squashfs"
 sudo mksquashfs "${root_fs_dir}" "${sysext_base}" -noappend -xattrs-exclude '^btrfs.'
+
+# Set build ID from root fs for later use by create_prod_sysext().
+#   This prevents common.sh in build_sysext to generate its own build ID which might cause
+#   its build ID check to fail.
+unset FLATCAR_BUILD_ID
+FLATCAR_BUILD_ID=$(source "${root_fs_dir}/usr/lib/os-release" && echo -n "$BUILD_ID")
+export FLATCAR_BUILD_ID
 
 # Build sysexts on top of root fs and mount sysexts' squashfs + pkginfo squashfs
 # for combined overlay later.


### PR DESCRIPTION
This change fixes a version mismatch of `FLATCAR_BUILD_ID` when performing a dev build of an existing release tag. The build ID is part of the version string of dev builds, separated by a `+` from the main version. If common.sh detects a dev build (`COREOS_OFFICIAL` != 1) and `FLATCAR_BUILD_ID` is empty, `common.sh` will generate a new ID based on a timestamp. This is usually desired behaviour to prevent accidentally marking a dev build non-dev (which would cause breakage much later when signature checks fail).

For official releases, `FLATCAR_BUILD_ID` is not set in version.txt. A dev build of a release tag would make `common.sh` generate a new ID each time it is sourced by different processes. build_image sources `common.sh` first, and writes the resulting version string the OS image's os-release file. `build_sysext` runs later and also sources `common.sh`, leading its version check to fail as its own VERSION now differs from the version of the OS image it's supposed to generate sysexts for. This is usually desired behaviour since `build_sysext` regularly operates on pre-built OS images; only when run from `sysext_prod_builder` _during_ an OS image build it doesn't.

This change reads `BUILD_ID` from the OS image rootfs in `sysext_prod_builder` and exports `FLATCAR_BUILD_ID` accordingly before calling build_sysext. Hence `FLATCAR_BUILD_ID` is not empty, so common.sh in build_sysext will not re-generate it.

## How to use

Try to build a dev version of a release tag, e.g.
  ```
   git checkout alpha-3975.0.0
   ./build_packages
   ./build_image
  ```
`./build_image` will fail with `build_sysext` complaining about version mismatches. Base squashfs version and SDK board packages versions will have version ID timestamps that differ by a few minutes, e.g.
  ```
...
Base squashfs version: 3975.0.0+2024-06-24-1729
SDK board packages version: 3975.0.0+2024-06-24-1736
...
  file build_sysext, line 197, called: die 'Version mismatch between board flatcar release and SDK container flatcar release.
...
   ```

Apply the patch from this branch, try again. Build now works.

## Backports and cherry-picks

Should be cherry-picked to all maintenance branches that use `build_sysext`, i.e. at least alpha, beta, and stable, and possibly LTS.
