### PR TITLE
Pull in latest mantle, drop obsolete auth flags

### DIFF
--- a/ci-automation/garbage_collect_cloud.sh
+++ b/ci-automation/garbage_collect_cloud.sh
@@ -4,7 +4,7 @@ source ci-automation/ci_automation_common.sh
 timeout --signal=SIGQUIT 60m ore aws gc --access-id "${AWS_ACCESS_KEY_ID}" --secret-key "${AWS_SECRET_ACCESS_KEY}"
 timeout --signal=SIGQUIT 60m ore do gc --config-file=<(echo "${DIGITALOCEAN_TOKEN_JSON}" | base64 --decode)
 timeout --signal=SIGQUIT 60m ore gcloud gc --json-key <(echo "${GCP_JSON_KEY}" | base64 --decode)
-timeout --signal=SIGQUIT 60m ore azure gc --duration 6h --azure-identity
+timeout --signal=SIGQUIT 60m ore azure gc --duration 6h
 timeout --signal=SIGQUIT 60m ore equinixmetal gc --duration 6h \
   --project="${EQUINIXMETAL_PROJECT}" --gs-json-key=<(echo "${GCP_JSON_KEY}" | base64 --decode) --api-key="${EQUINIXMETAL_KEY}"
 timeout --signal=SIGQUIT 60m ore openstack gc --duration 6h \

--- a/ci-automation/release.sh
+++ b/ci-automation/release.sh
@@ -108,7 +108,6 @@ function _inside_mantle() {
           --debug \
           --platform="${platform}" \
           --aws-credentials="${aws_credentials_config_file}" \
-          --azure-identity \
           --gce-json-key=none \
           --board="${arch}-usr" \
           --channel="${CHANNEL}" \
@@ -137,7 +136,6 @@ function _inside_mantle() {
         --publish-marketplace \
         --access-role-arn="${AWS_MARKETPLACE_ARN}" \
         --product-ids="${pid}" \
-        --azure-identity \
         --gce-json-key="${gcp_json_key_path}" \
         --gce-release-key="${google_release_credentials_file}" \
         --board="${arch}-usr" \

--- a/ci-automation/vendor-testing/azure.sh
+++ b/ci-automation/vendor-testing/azure.sh
@@ -52,7 +52,6 @@ run_kola_tests() {
       --platform=azure \
       --azure-image-file="${AZURE_IMAGE_NAME}" \
       --azure-location="${AZURE_LOCATION}" \
-      --azure-identity \
       --tapfile="${instance_tapfile}" \
       --azure-size="${instance_type}" \
       --azure-hyper-v-generation="${hyperv_gen}" \

--- a/sdk_container/.repo/manifests/mantle-container
+++ b/sdk_container/.repo/manifests/mantle-container
@@ -1,1 +1,1 @@
-ghcr.io/flatcar/mantle:git-60de9ff9f3d070f73c2cd69bdfdc088ea0d9f0f9
+ghcr.io/flatcar/mantle:git-3321b584ff11c5cab13bde61398c30b4d205b999


### PR DESCRIPTION
These changes will be necessary after we merge https://github.com/flatcar/mantle/pull/532.

Needs to be backported to all the channels.