### PR TITLE
build_image: btrfs: minimize allocation

### DIFF
--- a/build_library/disk_util
+++ b/build_library/disk_util
@@ -661,6 +661,7 @@ def ReadWriteSubvol(options, partition, disable_rw):
     btrfs_mount = tempfile.mkdtemp()
     Sudo(['mount', '-t', 'btrfs', loop_dev, btrfs_mount])
     try:
+      Sudo(['btrfs', 'balance', 'start', '-dusage=0', '-musage=0', btrfs_mount])
       Sudo(['btrfs', 'property', 'set', '-ts', btrfs_mount, 'ro', 'true' if disable_rw else 'false'])
     finally:
       Sudo(['umount', btrfs_mount])


### PR DESCRIPTION
Rebalance the /usr btrfs allocation to the maximum possible, in order to increase the chance of having the btrfs `Free (statfs, df)` similar to `Free (estimated)`.

Note that /usr is also a zstd compressed btrfs partition, so the output of `df` free size and the actual free size after a file write for example, will be very different, because the data in that file write has a compression rate only definable after the file sync.

Unfortunately, there is no determinism in the btrfs file system case, because even if you could in theory pre-compress with zstd the file before, and have an idea about the size to be used, you still cannot really predict also the metadata size for that file write.

See: https://github.com/flatcar/Flatcar/issues/1473

# [Title: describe the change in one sentence]

[ describe the change in 1 - 3 paragraphs ]

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
