### PR TITLE
net-misc/openssh: Backport patch for CVE-2024-6387

### DIFF
--- a/changelog/security/2024-07-01-openssh-9.1_p1.md
+++ b/changelog/security/2024-07-01-openssh-9.1_p1.md
@@ -1,0 +1,1 @@
+- openssh ([CVE-2024-6387](https://nvd.nist.gov/vuln/detail/CVE-2024-6387))

--- a/sdk_container/src/third_party/coreos-overlay/net-misc/openssh/files/openssh-9.1_p1-CVE-2024-6387.patch
+++ b/sdk_container/src/third_party/coreos-overlay/net-misc/openssh/files/openssh-9.1_p1-CVE-2024-6387.patch
@@ -1,0 +1,34 @@
+From 200e59c2d58b27906c07a98b33420dc92ebc5920 Mon Sep 17 00:00:00 2001
+From: Sayan Chowdhury <schowdhury@microsoft.com>
+Date: Mon, 1 Jul 2024 19:14:55 +0530
+Subject: [PATCH] This applies upstream's backport suggestions from
+ https://marc.info/?l=oss-security&m=171982317624594&w=2 for both
+ CVE-2024-6387
+
+Signed-off-by: Sayan Chowdhury <schowdhury@microsoft.com>
+---
+ log.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/log.c b/log.c
+index 99bf046a7..10e41bde7 100644
+--- a/log.c
++++ b/log.c
+@@ -451,12 +451,14 @@ void
+ sshsigdie(const char *file, const char *func, int line, int showfunc,
+     LogLevel level, const char *suffix, const char *fmt, ...)
+ {
++#ifdef SYSLOG_R_SAFE_IN_SIGHAND
+ 	va_list args;
+ 
+ 	va_start(args, fmt);
+ 	sshlogv(file, func, line, showfunc, SYSLOG_LEVEL_FATAL,
+ 	    suffix, fmt, args);
+ 	va_end(args);
++#endif
+ 	_exit(1);
+ }
+ 
+-- 
+2.45.0
+

--- a/sdk_container/src/third_party/coreos-overlay/net-misc/openssh/openssh-9.1_p1.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/net-misc/openssh/openssh-9.1_p1.ebuild
@@ -124,6 +124,7 @@ PATCHES=(
 	"${FILESDIR}/${PN}-8.9_p1-allow-ppoll_time64.patch" #834019
 	"${FILESDIR}/${PN}-8.9_p1-gss-use-HOST_NAME_MAX.patch" #834044
 	"${FILESDIR}/${PN}-9.1_p1-build-tests.patch"
+	"${FILESDIR}/${PN}-9.1_p1-CVE-2024-6387.patch"
 )
 
 pkg_pretend() {


### PR DESCRIPTION
Backport patch for CVE-2024-6387

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
