### PR TITLE
Fixes for flatcar-workon

### DIFF
--- a/flatcar_workon
+++ b/flatcar_workon
@@ -6,6 +6,8 @@
 
 DEFINE_string board "${DEFAULT_BOARD}" \
   "The board to set package keywords for."
+DEFINE_boolean host "${FLAGS_FALSE}" \
+  "Uses the host instead of board"
 
 FLAGS_HELP="usage: $0 <command> [flags] <atom>
 commands:
@@ -16,6 +18,13 @@ FLAGS "$@" || { [[ ${FLAGS_help} = "${FLAGS_TRUE}" ]] && exit 0; } || exit 1
 eval set -- "${FLAGS_ARGV}"
 
 set -euo pipefail
+
+# If both board and host are specified, just use host, because board
+# does not have to be specified and may come from default, in which
+# case there's no way to override.
+if [[ -n ${FLAGS_board} ]] && [[ ${FLAGS_host} = "${FLAGS_TRUE}" ]]; then
+  unset FLAGS_board # kill board
+fi
 
 # /etc/portage under either / or /build/<board>.
 ETC_PORTAGE=${FLAGS_board+/build/${FLAGS_board}}/etc/portage

--- a/flatcar_workon
+++ b/flatcar_workon
@@ -22,7 +22,7 @@ set -euo pipefail
 # If both board and host are specified, just use host, because board
 # does not have to be specified and may come from default, in which
 # case there's no way to override.
-if [[ -n ${FLAGS_board} ]] && [[ ${FLAGS_host} = "${FLAGS_TRUE}" ]]; then
+if [[ -n ${FLAGS_board} && ${FLAGS_host} = "${FLAGS_TRUE}" ]]; then
   unset FLAGS_board # kill board
 fi
 

--- a/update_chroot
+++ b/update_chroot
@@ -235,7 +235,7 @@ fi
 # Build flatcar_workon packages when they are changed.
 WORKON_PKGS=()
 if [[ ${FLAGS_workon} -eq "${FLAGS_TRUE}" ]]; then
-  mapfile -t WORKON_PKGS < <("${SRC_ROOT}"/scripts/flatcar_workon list)
+  mapfile -t WORKON_PKGS < <("${SRC_ROOT}"/scripts/flatcar_workon --host list)
 fi
 
 if [[ ${#WORKON_PKGS[@]} -gt 0 ]]; then


### PR DESCRIPTION
The `update_chroot` calls `flatcar_workon` to get a list of workon packages to rebuild on SDK. But not passing `--board` flag to `flatcar_workon` means using default board (`amd64-usr`), so it really gets a list of packages from the board. But the script failed for me during the sdk_container job, because no board was set up that point.

So this PR adds back the `--host` flag to `flatcar_workon` (which used to be here in `cros_workon`) and makes `update_chroot` pass the new flag to the script.

Changes tested as a part of [sdk-container job for merged-usr changes](http://jenkins.infra.kinvolk.io:8080/job/container/job/sdk_container/1148/consoleFull).

There are also [logs for the failing job](http://jenkins.infra.kinvolk.io:8080/job/container/job/sdk_container/1146/consoleText), search for `amd64-usr has not been setup yet` there.