### PR TITLE
ci-automation/vendor-testing/azure: Allow passing kola vnet

### DIFF
--- a/ci-automation/ci-config.env
+++ b/ci-automation/ci-config.env
@@ -149,6 +149,7 @@ AWS_PARALLEL="${PARALLEL_TESTS:-8}"
 : ${AZURE_amd64_MACHINE_SIZE:="Standard_D2s_v4"}
 : ${AZURE_arm64_MACHINE_SIZE:="Standard_D2pls_v5"}
 : ${AZURE_USE_GALLERY:=""}
+: ${AZURE_KOLA_VNET:=""}
 : ${AZURE_USE_PRIVATE_IPS:=true}
 : ${AZURE_VNET_SUBNET_NAME:="jenkins-vnet-westeurope"}
 AZURE_PARALLEL="${PARALLEL_TESTS:-20}"

--- a/ci-automation/vendor-testing/azure.sh
+++ b/ci-automation/vendor-testing/azure.sh
@@ -56,6 +56,7 @@ run_kola_tests() {
       --azure-size="${instance_type}" \
       --azure-hyper-v-generation="${hyperv_gen}" \
       ${AZURE_USE_GALLERY} \
+      ${AZURE_KOLA_VNET:+--azure-kola-vnet=${AZURE_KOLA_VNET}} \
       ${azure_vnet_subnet_name:+--azure-vnet-subnet-name=${azure_vnet_subnet_name}} \
       ${AZURE_USE_PRIVATE_IPS:+--azure-use-private-ips=${AZURE_USE_PRIVATE_IPS}} \
       "${@}"


### PR DESCRIPTION
# ci/azure: Allow passing --azure-kola-vnet

This adds support for providing a value for the newly introduced --azure-kola-vnet kola parameter through the environment. This parameter is meant to indicate that kola is running inside of a vnet in Azure and the kola created storage account will be restricted to being accessed from that vnet. This lets us disable public access to storage accounts.

Needs a corresponding change to jenkins jobs, because we have no way of determining what vnet a worker node is connected to programmatically. So it needs to be defined by the job.

## How to use

Run kola in Azure, in the same subscription that kola has access to and pass `--azure-kola-vnet`.


## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
