### PR TITLE
Catalyst 4 upgrade follow up fixes

### DIFF
--- a/.github/workflows/portage-stable-packages-list
+++ b/.github/workflows/portage-stable-packages-list
@@ -87,6 +87,7 @@ app-arch/lzop
 app-arch/ncompress
 app-arch/pbzip2
 app-arch/pigz
+app-arch/pixz
 app-arch/rpm2targz
 app-arch/sharutils
 app-arch/tar
@@ -307,6 +308,7 @@ dev-python/setuptools
 dev-python/setuptools-scm
 dev-python/six
 dev-python/snakeoil
+dev-python/tomli
 dev-python/trove-classifiers
 dev-python/wheel
 
@@ -575,6 +577,7 @@ sys-fs/mtools
 sys-fs/multipath-tools
 sys-fs/quota
 sys-fs/squashfs-tools
+sys-fs/squashfs-tools-ng
 sys-fs/udisks
 sys-fs/xfsprogs
 sys-fs/zfs

--- a/build_library/catalyst.sh
+++ b/build_library/catalyst.sh
@@ -3,11 +3,6 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-# Before doing anything, ensure we have at least Catalyst 4.
-if catalyst --version | grep -q "Catalyst [0-3]\."; then
-    sudo emerge -v1 ">=dev-util/catalyst-4" || exit 1
-fi
-
 # common.sh should be sourced first
 [[ -n "${DEFAULT_BUILD_ROOT}" ]] || exit 1
 . "${SCRIPTS_DIR}/sdk_lib/sdk_util.sh" || exit 1
@@ -169,6 +164,11 @@ catalyst_init() {
 
     if ! command -v catalyst >/dev/null 2>&1; then
         die_notrace "catalyst not found, not installed or bad PATH?"
+    fi
+
+    # Before doing anything else, ensure we have at least Catalyst 4.
+    if catalyst --version | grep -q "Catalyst [0-3]\."; then
+        emerge --verbose "--jobs=${NUM_JOBS}" --oneshot ">=dev-util/catalyst-4" || exit 1
     fi
 
     DEBUG=()


### PR DESCRIPTION
# Changes following late feedback in #2115

This moved the Catalyst upgrade inside `catalyst_init` and adds its dependencies to the package automation list.

## How to use

```
sudo ./bootstrap_sdk
```

## Testing done

I've run bootstrap_sdk manually. Running CI over this is probably overkill.