### PR TITLE
ci-automation: add hetzner testing

### DIFF
--- a/ci-automation/ci-config.env
+++ b/ci-automation/ci-config.env
@@ -163,3 +163,10 @@ OPENSTACK_PARALLEL="${PARALLEL_TESTS:-3}"
 : ${BRIGHTBOX_IMAGE_NAME:='flatcar_production_openstack_image.img'}
 BRIGHTBOX_PARALLEL="${PARALLEL_TESTS:-1}"
 : ${BRIGHTBOX_SERVER_TYPE:="2gb.ssd"}
+
+# -- Hetzner --
+: ${HETZNER_IMAGE_NAME:='flatcar_production_hetzner_image.bin.bz2'}
+: ${HETZNER_amd64_INSTANCE_TYPE:="cpx11"}
+: ${HETZNER_arm64_INSTANCE_TYPE:="cax11"}
+HETZNER_PARALLEL="${PARALLEL_TESTS:-1}"
+HETZNER_LOCATION="${HETZNER_LOCATION:-fsn1}"

--- a/ci-automation/vendor-testing/hetzner.sh
+++ b/ci-automation/vendor-testing/hetzner.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Copyright (c) 2023 The Flatcar Maintainers.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+set -euo pipefail
+
+# Test execution script for the Hetzner vendor.
+# This script is supposed to run in the mantle container.
+
+source ci-automation/vendor_test.sh
+
+hetzner_instance_type_var="HETZNER_${CIA_ARCH}_INSTANCE_TYPE"
+hetzner_instance_type="${!hetzner_instance_type_var}"
+
+# HETZNER_TPS_TOKEN should be provided by sdk_container/.env
+
+# We first need to create a temporary project using HETZNER_TPS_TOKEN
+# When the project is created it returns a regular HETZNER_TOKEN that can be used
+# in the next commands, it is a token similar to what you would get in your Hetzner console.
+HETZNER_TOKEN=$(curl \
+    --fail-with-body \
+    --retry 2 \
+    --silent \
+    --user-agent "flatcar-ci/unknown" \
+    --request POST \
+    --header "Authorization: Bearer ${HETZNER_TPS_TOKEN}" \
+    https://tps.hc-integrations.de
+)
+
+# Upload the image on Hetzner.
+IMAGE_ID=$(ore hetzner \
+  --hetzner-token="${HETZNER_TOKEN}" \
+  --hetzner-location="${HETZNER_LOCATION}" \
+  create-image \
+  --board="${CIA_ARCH}-usr" \
+  --name flatcar-"${CIA_VERNUM}" \
+  --file="https://${BUILDCACHE_SERVER}/images/${CIA_ARCH}/${CIA_VERNUM}/${HETZNER_IMAGE_NAME}"
+)
+
+kola_test_basename="ci-${CIA_VERNUM//[+.]/-}"
+
+set -x
+
+timeout --signal=SIGQUIT 2h kola run \
+  --board="${CIA_ARCH}-usr" \
+  --parallel="${HETZNER_PARALLEL}" \
+  --tapfile="${CIA_TAPFILE}" \
+  --channel="${CIA_CHANNEL}" \
+  --basename="${kola_test_basename}" \
+  --platform=hetzner \
+  --hetzner-token="${HETZNER_TOKEN}" \
+  --hetzner-server-type="${hetzner_instance_type}" \
+  --hetzner-location="${HETZNER_LOCATION}" \
+  --hetzner-image=${IMAGE_ID} \
+  "${@}"
+
+set +x


### PR DESCRIPTION
In this PR, we bring the "glue" between Flatcar CI and Hetzner Mantle implementation.

NOTE: For this specific cloud provider there is no need to implement garbage collection as the provider is providing us a temporary project to run our tests, the project is deleted right after

## Testing done

CI :green_circle: : http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/4600/cldsv/


---

- No changelog entry as it's not user facing. 
- To be merged with: https://github.com/flatcar/mantle/pull/536

Closes https://github.com/flatcar/Flatcar/issues/1412