### PR TITLE
app-misc/ca-certificates: Switch to https protocol in SRC_URI

### DIFF
--- a/sdk_container/src/third_party/coreos-overlay/app-misc/ca-certificates/ca-certificates-3.102.1.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/app-misc/ca-certificates/ca-certificates-3.102.1.ebuild
@@ -13,7 +13,7 @@ S="${WORKDIR}"
 
 DESCRIPTION="Mozilla's CA Certificate Store"
 HOMEPAGE="http://www.mozilla.org/en-US/about/governance/policies/security-group/certs/"
-SRC_URI="ftp://ftp.mozilla.org/pub/mozilla.org/security/nss/releases/${RTM_NAME}/src/${MY_P}.tar.gz"
+SRC_URI="https://archive.mozilla.org/pub/security/nss/releases/${RTM_NAME}/src/${MY_P}.tar.gz"
 
 # NSS is licensed under the MPL, files/certdata2pem.py is GPL
 LICENSE="MPL-2.0 GPL-2"


### PR DESCRIPTION
# nss: switch to https fetch
Ftp access appears to have been decommissioned (access times out) so switch to the https mirror that Mozilla provides.

See: flatcar/flatcar#1504

## How to use

Rebuild as usual always.

## Testing done

```bash
$ GENTOO_MIRRORS="" emerge --fetchonly ca-certificates
These are the packages that would be fetched, in order:

Calculating dependencies... done!
Dependency resolution took 0.96 s (backtrack: 0/20).

[ebuild     U  ] app-misc/ca-certificates-3.102.1::coreos-overlay [3.102::coreos-overlay] 74669 KiB

Total: 1 package (1 upgrade), Size of downloads: 74669 KiB


>>> Fetching (1 of 1) app-misc/ca-certificates-3.102.1::coreos-overlay
>>> Downloading 'https://archive.mozilla.org/pub/security/nss/releases/NSS_3_102_1_RTM/src/nss-3.102.1.tar.gz'
--2024-07-29 08:37:41--  https://archive.mozilla.org/pub/security/nss/releases/NSS_3_102_1_RTM/src/nss-3.102.1.tar.gz
Resolving archive.mozilla.org... 34.117.35.28, 2600:1901:0:b9fd::
Connecting to archive.mozilla.org|34.117.35.28|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 76460182 (73M) [application/x-tar]
Saving to: '/mnt/host/source/.cache/distfiles/nss-3.102.1.tar.gz.__download__'

/mnt/host/source/.cache/distfiles/nss-3.102.1.tar.gz.__do 100%[==================================================================================================================================>]  72.92M  59.9MB/s    in 1.2s

2024-07-29 08:37:42 (59.9 MB/s) - '/mnt/host/source/.cache/distfiles/nss-3.102.1.tar.gz.__download__' saved [76460182/76460182]

 * nss-3.102.1.tar.gz BLAKE2B SHA512 size ;-) ...
```

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
