### PR TITLE
Drop python tests from GCE and Azure OEM images and python sysext

### DIFF
--- a/build_library/sysext_mangle_flatcar-python
+++ b/build_library/sysext_mangle_flatcar-python
@@ -7,4 +7,14 @@ pushd "${rootfs}"
 
 rm -rf ./usr/{lib/debug,share,include,lib64/pkgconfig}
 
+# Remove test stuff from python - it's quite large.
+for p in ./usr/lib/python*; do
+    if [[ ! -d ${p} ]]; then
+        continue
+    fi
+    # find directories named tests or test and remove them (-prune
+    # avoids searching below those directories)
+    find "${p}" \( -name tests -o -name test \) -type d -prune -exec rm -rf '{}' '+'
+done
+
 popd

--- a/sdk_container/src/third_party/coreos-overlay/coreos-base/oem-azure/files/manglefs.sh
+++ b/sdk_container/src/third_party/coreos-overlay/coreos-base/oem-azure/files/manglefs.sh
@@ -20,3 +20,13 @@ ln -sf /usr/bin/true "${rootfs}/usr/bin/eject"
 # both cases, so mangle manually.
 mkdir -p "${rootfs}"/usr/lib/systemd/system
 cp -a "${rootfs}"/{etc,usr/lib}/systemd/system/.
+
+# Remove test stuff from python - it's quite large.
+for p in "${rootfs}"/usr/lib/python*; do
+    if [[ ! -d ${p} ]]; then
+        continue
+    fi
+    # find directories named tests or test and remove them (-prune
+    # avoids searching below those directories)
+    find "${p}" \( -name tests -o -name test \) -type d -prune -exec rm -rf '{}' '+'
+done

--- a/sdk_container/src/third_party/coreos-overlay/coreos-base/oem-gce/files/manglefs.sh
+++ b/sdk_container/src/third_party/coreos-overlay/coreos-base/oem-gce/files/manglefs.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -euo pipefail
+
+rootfs=${1}
+
+# Remove test stuff from python - it's quite large.
+for p in "${rootfs}"/usr/lib/python*; do
+    if [[ ! -d ${p} ]]; then
+        continue
+    fi
+    # find directories named tests or test and remove them (-prune
+    # avoids searching below those directories)
+    find "${p}" \( -name tests -o -name test \) -type d -prune -exec rm -rf '{}' '+'
+done


### PR DESCRIPTION
CI: http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/4491/cldsv/

We used to drop them for GCE, but after converting to sysext, this change was dropped.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
