### PR TITLE
Fix the initrd option in the QEMU launcher script

### DIFF
--- a/build_library/qemu_template.sh
+++ b/build_library/qemu_template.sh
@@ -35,8 +35,8 @@ Options:
                 (see https://github.com/stefanberger/swtpm/wiki/Certificates-created-by-swtpm_setup).
     -R FILE     Set up pflash ro content, e.g., for UEFI (with -W).
     -W FILE     Set up pflash rw content, e.g., for UEFI (with -R).
-    -K FILE     Set kernel for direct boot used to simulate a PXE boot (with -R).
-    -R FILE     Set initrd for direct boot used to simulate a PXE boot (with -K).
+    -K FILE     Set kernel for direct boot used to simulate a PXE boot (with -r).
+    -r FILE     Set initrd for direct boot used to simulate a PXE boot (with -K).
     -s          Safe settings: single simple cpu and no KVM.
     -h          this ;-)
 
@@ -105,7 +105,7 @@ while [ $# -ge 1 ]; do
         -K|-kernel-file)
             VM_KERNEL="$2"
             shift 2 ;;
-        -R|-initrd-file)
+        -r|-initrd-file)
             VM_INITRD="$2"
             shift 2 ;;
         -v|-verbose)

--- a/changelog/bugfixes/2024-08-16-qemu-launcher-initrd-option.md
+++ b/changelog/bugfixes/2024-08-16-qemu-launcher-initrd-option.md
@@ -1,0 +1,1 @@
+- Fixed the initrd option in the QEMU launcher script. It was -R, but this was already taken by the read-only pflash option, so use -r instead. ([scripts#2239](https://github.com/flatcar/scripts/pull/2239))


### PR DESCRIPTION
# Fix the initrd option in the QEMU launcher script

It was `-R`, but this was already taken by the read-only pflash option, so use `-r` instead.

## How to use

Try the PXE version of the script with the `-r` option. You can pass a renamed copy of flatcar_production_pxe_image.cpio.gz and check the process listing to see what was passed to QEMU.

## Testing done

I manually applied this change to the existing PXE script and tried the `-r` option. I don't think anything in CI covers this.

- [X] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.