### PR TITLE
build_sysext: Detect dev rebuild of release tag, fix build ID issue

### DIFF
--- a/build_library/sysext_prod_builder
+++ b/build_library/sysext_prod_builder
@@ -107,13 +107,6 @@ mkdir "${sysext_workdir}" "${sysext_output_dir}"
 info "creating temporary base OS squashfs"
 sudo mksquashfs "${root_fs_dir}" "${sysext_base}" -noappend -xattrs-exclude '^btrfs.'
 
-# Set build ID from root fs for later use by create_prod_sysext().
-#   This prevents common.sh in build_sysext to generate its own build ID which might cause
-#   its build ID check to fail.
-unset FLATCAR_BUILD_ID
-FLATCAR_BUILD_ID=$(source "${root_fs_dir}/usr/lib/os-release" && echo -n "$BUILD_ID")
-export FLATCAR_BUILD_ID
-
 # Build sysexts on top of root fs and mount sysexts' squashfs + pkginfo squashfs
 # for combined overlay later.
 prev_pkginfo=""

--- a/build_sysext
+++ b/build_sysext
@@ -7,6 +7,7 @@
 # Script to generate sysext. See systemd-sysext(8). Prerequisite is
 # that you've run build_packages and build_image.
 
+
 SCRIPT_ROOT=$(dirname "$(readlink -f "$0")")
 . "${SCRIPT_ROOT}/common.sh" || exit 1
 
@@ -183,7 +184,18 @@ mkdir "${BUILD_DIR}/install-root"
 mkdir "${BUILD_DIR}/workdir"
 mount -t overlay overlay -o lowerdir="${BUILD_DIR}/fs-root${pkginfo_lowerdirs}",upperdir="${BUILD_DIR}/install-root",workdir="${BUILD_DIR}/workdir" "${BUILD_DIR}/install-root"
 
-VERSION_BOARD=$(grep "^VERSION=" ${BUILD_DIR}/fs-root/usr/lib/os-release | cut -d = -f 2-)
+REPO_BUILD_ID="$(source "${REPO_MANIFESTS_DIR}/version.txt"; echo "$FLATCAR_BUILD_ID")"
+REPO_FLATCAR_VERSION="$(source "${REPO_MANIFESTS_DIR}/version.txt"; echo "$FLATCAR_VERSION")"
+VERSION_BOARD=$(source "${BUILD_DIR}/fs-root/usr/lib/os-release" && echo "$VERSION")
+
+if [ -z "$REPO_BUILD_ID" ] ; then
+    BASE_SQUASHFS_BUILD_ID=$(source "${BUILD_DIR}/fs-root/usr/lib/os-release" && echo -n "$BUILD_ID")
+    info "This is a dev rebuild of an official release tag: No BUILD ID set in '${REPO_MANIFESTS_DIR}/version.txt'.  Will use base squasfs BUILD ID for version check."
+    info "Repo root FLATCAR_VERSION is '$REPO_FLATCAR_VERSION', squashfs build ID is '$BASE_SQUASHFS_BUILD_ID'"
+    FLATCAR_VERSION="${REPO_FLATCAR_VERSION}+${BASE_SQUASHFS_BUILD_ID}"
+    info "Setting FLATCAR_VERSION to '$FLATCAR_VERSION'"
+fi
+
 if [ "$VERSION_BOARD" != "$FLATCAR_VERSION" ]; then
   warn "Base squashfs version: $VERSION_BOARD"
   warn "SDK board packages version: $FLATCAR_VERSION"


### PR DESCRIPTION
build_sysext uses a base squashfs (basically a full snapshot of the Flatcar OS image) to build custom sysexts on top. Before building it ensures the base image actualy matches the OS version in the repository root.

The version string includes a BUILD_ID which might be auto-generated (by including common.sh) if it is not present in the version file - e.g. when the version is an official release (tag). This build ID auto-generation causes issues with the version check when image build and sysext build scripts run independently - each will generate its own build ID, and this will cause build_sysext's version check to fail.

build_sysext will now use the build id from the base squashfs when it is not set in the source tree's version.txt to work around that issue. This is a more general solution than 361eda220b368c3c3a959357c54db10d4c2f1d1a (which this patch reverts) as it directly addresses the issue in build_sysext instead of working around it in sysext_prod_builder.

## How to use

- Check out this branch
  ```shell
  git clone https://github.com/flatcar/scripts.git
  cd scripts
  git checkout t-lo/fix-sysext-build-id-issue-in-image-to-vm
  ```
- Build it
  ```
  ./run_sdk_container -t
         ./build_packages
         ./build_image
         ./image_to_vm.sh --from ../build/images/amd64-usr/latest/ --format' 'qemu_uefi'
  ```

## Testing done

Ran the above builds.

## Cherry-pick / backport

To all active mainenance branches except LTS (which doesn't use sysext), i.e. `flatcar-3975` `flatcar-4012` `flatcar-4054`