### PR TITLE
config/env/sys-fs/zfs-kmod: un-break zfs-kmod binpkg install

### DIFF
--- a/sdk_container/src/third_party/coreos-overlay/coreos/config/env/sys-fs/zfs-kmod
+++ b/sdk_container/src/third_party/coreos-overlay/coreos/config/env/sys-fs/zfs-kmod
@@ -1,6 +1,11 @@
 : ${MODULES_ROOT:=$(echo ${SYSROOT}/lib/modules/*)}
 KERNEL_DIR="${MODULES_ROOT}/build"
 
+# This addresses an issue with the kernel version compatibility check
+#  when installing zfs-kmod to /build/<arch> (e.g. via build_packages)
+#  from its binpkg (i.e. not recompiling it).
+SKIP_KERNEL_BINPKG_ENV_RESET=1
+
 # Necessary to prevent KV_FULL & KV_OUT_DIR from being unset
 # when building Kernel modules for sysext. See also eclass/linux-info.eclass.
 cros_pre_pkg_setup_kernel_version() {


### PR DESCRIPTION
This change sets `SKIP_KERNEL_BINPKG_ENV_RESET` in the zfs-kmod env so linux-info.eclass keeps kernel env variables. This resolves an issue with installing zfs-kmod as a binpkg when the kernel was not yet installed. In a pure binpkg install the zfs-kmod package might be installed before the kernel, leading to the kmod's kernel version detection to fail.

The original issue may be reproduced by running a rebuild of a release tag (which will use binpkgs from our mirrors). Note that the reproduction is flaky because the issue is caused by a race condition between installing the kernel binpkg and zfs-kmod.

## How to use

- Reproduce by rebuilding a recent release tag
  ```
   git clone https://github.com/flatcar/scripts.git
   cd scripts
   git checkout alpha-4054.0.0
   ./run_sdk_container -t
         ./build_packages
   ```
   As noted above it might be necessary to run the package build multiple times to reproduce the issue. Make sure to `docker container prune` between runs so the build starts from scratch.
- Apply patch from this branch, try to repro. The issue should not repro anymore.

## Testing done

Ran the above builds.

# Cherry-pick / backport

Should be cherry-picked to all maintenance branches that ship the zfs sysext (i.e. all except LTS):  `flatcar-3975` `flatcar-4012` `flatcar-4054`