### PR TITLE
overlay coreos/user-patches: Add a symlink for selinux-policykit

### DIFF
--- a/sdk_container/src/third_party/coreos-overlay/coreos/user-patches/sec-policy/selinux-policykit
+++ b/sdk_container/src/third_party/coreos-overlay/coreos/user-patches/sec-policy/selinux-policykit
@@ -1,0 +1,1 @@
+flatcar-selinux-patches


### PR DESCRIPTION
So the rules built for this module are consistent with rules built for other modules.