### PR TITLE
build_sysext: override FLATCAR_VERSION only for non-official builds

### DIFF
--- a/build_sysext
+++ b/build_sysext
@@ -188,7 +188,7 @@ REPO_BUILD_ID=$(source "${REPO_MANIFESTS_DIR}/version.txt"; echo "$FLATCAR_BUILD
 REPO_FLATCAR_VERSION=$(source "${REPO_MANIFESTS_DIR}/version.txt"; echo "$FLATCAR_VERSION")
 VERSION_BOARD=$(source "${BUILD_DIR}/fs-root/usr/lib/os-release" && echo "$VERSION")
 
-if [[ -z $REPO_BUILD_ID ]] ; then
+if [[ -z $REPO_BUILD_ID ]] && [[ ${COREOS_OFFICIAL:-0} -ne 1 ]]; then
     BASE_SQUASHFS_BUILD_ID=$(source "${BUILD_DIR}/fs-root/usr/lib/os-release" && echo -n "$BUILD_ID")
     info "This is a dev rebuild of an official release tag: No BUILD ID set in '${REPO_MANIFESTS_DIR}/version.txt'.  Will use base squashfs BUILD ID for version check."
     info "Repo root FLATCAR_VERSION is '$REPO_FLATCAR_VERSION', squashfs build ID is '$BASE_SQUASHFS_BUILD_ID'"


### PR DESCRIPTION
In the current release, I noticed this error for all channels:

```
 INFO    build_sysext: This is a dev rebuild of an official release tag: No BUILD ID set in '/mnt/host/source/.repo/manifests/version.txt'.  Will use base squasfs BUILD ID for version check.
 INFO    build_sysext: Repo root FLATCAR_VERSION is '4081.0.0', squashfs build ID is '2024-09-03-2245'
 INFO    build_sysext: Setting FLATCAR_VERSION to '4081.0.0+2024-09-03-2245'
 WARNING build_sysext: Base squashfs version: 4081.0.0
 WARNING build_sysext: SDK board packages version: 4081.0.0+2024-09-03-2245
 ERROR   build_sysext: script called: build_sysext '--board=amd64-usr' '--image_builddir=/home/sdk/trunk/src/build/images/amd64-usr/alpha-4081.0.0-a1/prod-sysext-work/sysext-build' '--squashfs_base=/home/sdk/trunk/src/build/images/amd64-usr/alpha-4081.0.0-a1/prod-sysext-work/base-os.squashfs' '--generate_pkginfo' '--manglefs_script=/mnt/host/source/src/scripts/build_library/sysext_mangle_containerd-flatcar' 'containerd-flatcar' 'app-containers/containerd'
 ERROR   build_sysext: Backtrace:  (most recent call is last)
 ERROR   build_sysext:   file build_sysext, line 205, called: die 'Version mismatch between board flatcar release and SDK container flatcar release.'
```

I assume it's a side effect of this PR: https://github.com/flatcar/scripts/pull/2259.

From my understanding, the "Base squashfs version" is equals to the actual released version for release builds (e.g 4081.0.0) - in this case, if we override the FLATCAR_VERSION with "4081.0.0+2024-09-03-2245" we are creating a version mismatch.

I added an extra-check to assert that we are building an official release, we do not override the FLATCAR_VERSION for official releases -> so we shoud not get a mismatch. 

:warning: NOT TESTED 

EDIT: cc @t-lo if you can give a second look as you've worked in this area recently :pray: 