### PR TITLE
eclass/coreos-kernel: add -Werror=misleading-indentation

### DIFF
--- a/sdk_container/src/third_party/coreos-overlay/eclass/coreos-kernel.eclass
+++ b/sdk_container/src/third_party/coreos-overlay/eclass/coreos-kernel.eclass
@@ -113,9 +113,9 @@ kernel_target() {
 }
 
 kmake() {
-	local kernel_arch=$(tc-arch-kernel) kernel_cflags=
+	local kernel_arch=$(tc-arch-kernel) kernel_cflags="-Werror=misleading-indentation"
 	if gcc-specs-pie; then
-		kernel_cflags="-nopie -fstack-check=no"
+		kernel_cflags="-nopie -fstack-check=no ${kernel_cflags}"
 	fi
 	emake "--directory=${S}/source" \
 		ARCH="${kernel_arch}" \


### PR DESCRIPTION
To ensure that tested patches are correctly indented.

---

In this PR, we set a C flags for Kernel build to ensure that the indentation is correctly respected when building Kernel - it's helpful when testing patches before submission to avoid this kind of issue: https://lore.kernel.org/stable/2024090532-earthworm-sincere-005e@gregkh/


## Testing done

* Tested here with a bad indented patch: http://jenkins.infra.kinvolk.io:8080/job/container/job/packages/7600/consoleFull
* Tested here with a correct kernel: http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/4635/cldsv/

No changelog as it's not user facing. 