### PR TITLE
Publish stage 3 SDK tarball to use as a seed instead of stage 4

### DIFF
--- a/bootstrap_sdk
+++ b/bootstrap_sdk
@@ -89,9 +89,11 @@ cp "${BUILD_LIBRARY_DIR}/toolchain_util.sh" "${ROOT_OVERLAY}/tmp"
 
 catalyst_build
 
-if [[ "$STAGES" =~ stage4 ]]; then
+def_upload_path="${UPLOAD_ROOT}/sdk/${ARCH}/${FLAGS_version}"
+
+if [[ $STAGES =~ stage3 ]]; then
     info "Build complete! Changing output name to something more sensible."
-    build_name="stage4-${ARCH}-${FLAGS_version}.tar.bz2"
+    build_name="stage3-${ARCH}-${FLAGS_version}.tar.bz2"
     release_name="${TYPE}-${ARCH}-${FLAGS_version}.tar.bz2"
     build_image="${BUILDS}/${build_name}"
     release_image="${BUILDS}/${release_name}"
@@ -109,9 +111,11 @@ if [[ "$STAGES" =~ stage4 ]]; then
 
     info "SDK ready: ${release_image}"
 
-    def_upload_path="${UPLOAD_ROOT}/sdk/${ARCH}/${FLAGS_version}"
     sign_and_upload_files "tarball" "${def_upload_path}" "" \
         "${release_image}" "${release_contents}" "${release_digests}"
+fi
+
+if [[ $STAGES =~ stage4 ]]; then
     sign_and_upload_files "packages" "${def_upload_path}" "pkgs/" \
         "${BINPKGS}"/*
 


### PR DESCRIPTION
# Publish stage 3 SDK tarball to use as a seed instead of stage 4

We currently use a stage 4 tarball as a seed for building the SDK, but stage 3 is smaller and less likely to cause issues.

This doesn't change the name of the tarball because supporting both stage3 and stage4 at the same time just isn't feasible with the way the digest check works.

The change is almost backwards compatible except that Catalyst will fail to build older baselayout versions due to stage3 lacking git. A recent change to the baselayout package sources it from a tarball instead of git, and this has now made it into a release. This issue only affects building the SDK, and it can be resolved by simply rebasing.

## How to use

You can't really try this change specifically, but you can build the SDK up to stage 3 and then manually use that tarball as a seed to build another SDK.

## Testing done

I have tested this manually as much as I can, but the change itself cannot be tested in the usual way because it involves publishing the tarball. The change is at least relatively small.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update) -- **N/A**
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc. -- **N/A**