### PR TITLE
board-packages: add hyperv hv-daemons

### DIFF
--- a/sdk_container/src/third_party/coreos-overlay/coreos-devel/board-packages/board-packages-0.0.1.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/coreos-devel/board-packages/board-packages-0.0.1.ebuild
@@ -31,6 +31,7 @@ RDEPEND="
 	app-containers/docker-cli
 	app-containers/docker-buildx
 	app-emulation/amazon-ssm-agent
+	app-emulation/hv-daemons
 	app-emulation/wa-linux-agent
 	coreos-base/coreos
 	coreos-base/coreos-dev


### PR DESCRIPTION
This change adds the Azure and HyperV OEM "hv-daemons" to board-packages so build_packages.sh will actually build these. This un-breaks a build issue with the Azure and HyperV images.

It's a one-line change to un-break the nightly build and Azure testing.

Needs to be cherry-picked to flatcar-3975, flatcar-4054, flatcar-4081.