### PR TITLE
.github: Handle missing app-emulation/hv-daemons

### DIFF
--- a/.github/workflows/kernel-apply-patch.sh
+++ b/.github/workflows/kernel-apply-patch.sh
@@ -32,10 +32,12 @@ for pkg in sources modules kernel; do
     popd
 done
 
-# Update hyperv daemons ebuild soft-link to reflect new kernel version
-find -D exec app-emulation/hv-daemons/ -type l -exec rm '{}' \;
-ln -s app-emulation/hv-daemons/hv-daemons-9999.ebuild \
-      app-emulation/hv-daemons/hv-daemons-${VERSION_NEW}.ebuild
+if [[ -d app-emulation/hv-daemons ]]; then
+    # Update hyperv daemons ebuild soft-link to reflect new kernel version
+    find -D exec app-emulation/hv-daemons/ -type l -exec rm '{}' \;
+    ln -s app-emulation/hv-daemons/hv-daemons-9999.ebuild \
+          app-emulation/hv-daemons/hv-daemons-${VERSION_NEW}.ebuild
+fi
 
 # Leave ebuild repo section of SDK
 popd

--- a/.github/workflows/kernel-apply-patch.sh
+++ b/.github/workflows/kernel-apply-patch.sh
@@ -35,7 +35,7 @@ done
 if [[ -d app-emulation/hv-daemons ]]; then
     # Update hyperv daemons ebuild soft-link to reflect new kernel version
     find -D exec app-emulation/hv-daemons/ -type l -exec rm '{}' \;
-    ln -s app-emulation/hv-daemons/hv-daemons-9999.ebuild \
+    ln --relative -s app-emulation/hv-daemons/hv-daemons-9999.ebuild \
           app-emulation/hv-daemons/hv-daemons-${VERSION_NEW}.ebuild
 fi
 


### PR DESCRIPTION
LTS channel has no such package, so the action for finding the kernel update was failing. Fix it by updating the package only if it exists.
