### PR TITLE
sys-boot/grub: Adjust version string to include flatcar1 suffix

### DIFF
--- a/sdk_container/src/third_party/coreos-overlay/coreos/config/env/sys-boot/grub
+++ b/sdk_container/src/third_party/coreos-overlay/coreos/config/env/sys-boot/grub
@@ -1,10 +1,20 @@
+# Bump the flatcar version stated here every time we or Gentoo change patches
+# that modify parts of GRUB that are installed to the boot partition. Reset the
+# version back to 1 when the upstream GRUB version changes.
+FLATCAR_VERSION=flatcar1
+
+# Adjust the version string for Flatcar. This propagates throughout the source.
+cros_pre_src_prepare_adjust_version() {
+	sed -i "/AC_INIT/s/\b${PV//./\\.}\b/\0-${FLATCAR_VERSION}/g" configure.ac || die
+}
+
 # Replace Gentoo's SBAT with Flatcar's.
 cros_post_src_install_sbat() {
 	insinto /usr/share/grub
 	newins - sbat.csv <<-EOF
 		sbat,1,SBAT Version,sbat,1,https://github.com/rhboot/shim/blob/main/SBAT.md
 		grub,4,Free Software Foundation,grub,${PV},https://www.gnu.org/software/grub/
-		grub.flatcar,1,Flatcar,grub2,${PVR},https://github.com/flatcar/Flatcar
+		grub.flatcar,1,Flatcar,grub2,${PV}-${FLATCAR_VERSION},https://github.com/flatcar/Flatcar
 	EOF
 }
 


### PR DESCRIPTION
# sys-boot/grub: Adjust version to include flatcar1 suffix

We will bump this every time we or Gentoo change patches that modify parts of GRUB that are installed to the boot partition. We will reset the version back to 1 when the upstream GRUB version changes.

Without this, we are bound by Gentoo's PVR string, which we cannot change when we need to make changes to our own patches. The shim review wants to know the full version number of our GRUB build, and it would look bad to make such changes without changing the version.

This suffix is also applied to the Flatcar entry in the SBAT, which is especially important for the shim review.

The published binary package will still be labelled with the Gentoo PVR, but that seems less important given that end users cannot update individual packages on Flatcar installations.

## How to use

Boot the image from CI and see what GRUB version it shows when booting.

## Testing done

I've tested the image built in CI.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update) -- **N/A**
- [x] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.