### PR TITLE
SDK container: include circular dependency breaking packages in SDK container

### DIFF
--- a/sdk_lib/Dockerfile.sdk-build
+++ b/sdk_lib/Dockerfile.sdk-build
@@ -9,9 +9,11 @@ RUN echo "export COREOS_OFFICIAL=$OFFICIAL" > /mnt/host/source/.env
 
 RUN /home/sdk/sdk_entry.sh ./setup_board --board="arm64-usr" --binhost="${BINHOST}/arm64-usr"
 RUN /home/sdk/sdk_entry.sh ./setup_board --board="arm64-usr" --regen_configs
+RUN /home/sdk/sdk_entry.sh ./build_packages --board="arm64-usr" --only_resolve_circular_deps
 
 RUN /home/sdk/sdk_entry.sh ./setup_board --board="amd64-usr" --binhost="${BINHOST}/amd64-usr"
 RUN /home/sdk/sdk_entry.sh ./setup_board --board="amd64-usr" --regen_configs
+RUN /home/sdk/sdk_entry.sh ./build_packages --board="amd64-usr" --only_resolve_circular_deps
 
 RUN rm /mnt/host/source/.env
 RUN rm -rf /home/sdk/toolchain-pkgs


### PR DESCRIPTION
This change builds all packages required to break circular dependencies in the "build SDK container" stage and includes these in the SDK image. This way, emerge-<arch> can be used right away and build_packages only builds packages with production USE flags.

The change significantly reduces the build time at the cost of a larger SDK image and longer SDK container build time. Uncompressed:
|              |  Size before   |    Size after |
| ------------|--------------|------------|
| all arches    |   7.75GB    |         9.29GB |
| arm64       |     5.7GB        |      6.58GB |
| amd64     |       5.64GB       |      6.45GB |

## How to use

- Clone the repo, check out this branch
- Fetch a recent SDK tarball to build the container image from, e.g. https://bincache.flatcar-linux.net/sdk/amd64/4098.0.0+nightly-20240919-2100/flatcar-sdk-amd64-4098.0.0+nightly-20240919-2100.tar.bz2
- Build an SDK container from the tarball, e.g. `./build_sdk_container_image -k flatcar-sdk-amd64-4098.0.0+nightly-20240919-2100.tar.bz2` (NOTE: this must run outside the SDK container, on your host)
- Emerge systemd in the new container image, which should fail if the circular dependencies were not included: `./run_sdk_container -t -C ghcr.io/flatcar/flatcar-sdk-amd64:4098.0.0-nightly-20240919-2100 emerge-amd64-usr systemd`

## Testing done

Ran the above, successfully emerged systemd for both amd64 and arm64.

## Github actions

/update-sdk