### PR TITLE
overlay sys-apps/systemd: Add patches for ldconfig.service

### DIFF
--- a/sdk_container/src/third_party/coreos-overlay/sys-apps/systemd/files/0001-wait-online-set-any-by-default.patch
+++ b/sdk_container/src/third_party/coreos-overlay/sys-apps/systemd/files/0001-wait-online-set-any-by-default.patch
@@ -1,7 +1,7 @@
-From 98cbd0a4576464478f0f9fcd2066efc08bef9491 Mon Sep 17 00:00:00 2001
+From 65839ec4c534b4a5bec568bb061a0e2960acdadd Mon Sep 17 00:00:00 2001
 From: David Michael <dm0@redhat.com>
 Date: Tue, 16 Apr 2019 02:44:51 +0000
-Subject: [PATCH 1/8] wait-online: set --any by default
+Subject: [PATCH 01/11] wait-online: set --any by default
 
 The systemd-networkd-wait-online command would normally continue
 waiting after a network interface is usable if other interfaces are

--- a/sdk_container/src/third_party/coreos-overlay/sys-apps/systemd/files/0002-networkd-default-to-kernel-IPForwarding-setting.patch
+++ b/sdk_container/src/third_party/coreos-overlay/sys-apps/systemd/files/0002-networkd-default-to-kernel-IPForwarding-setting.patch
@@ -1,7 +1,7 @@
-From e3fd50ec704b5d48e9d756c1cc5c40e72b7d1fa4 Mon Sep 17 00:00:00 2001
+From 4fe43bc57f7971d2a0eb76bdd2723e85bf381d77 Mon Sep 17 00:00:00 2001
 From: Nick Owens <nick.owens@coreos.com>
 Date: Tue, 2 Jun 2015 18:22:32 -0700
-Subject: [PATCH 2/8] networkd: default to "kernel" IPForwarding setting
+Subject: [PATCH 02/11] networkd: default to "kernel" IPForwarding setting
 
 ---
  src/network/networkd-network.c | 1 +

--- a/sdk_container/src/third_party/coreos-overlay/sys-apps/systemd/files/0003-needs-update-don-t-require-strictly-newer-usr.patch
+++ b/sdk_container/src/third_party/coreos-overlay/sys-apps/systemd/files/0003-needs-update-don-t-require-strictly-newer-usr.patch
@@ -1,7 +1,7 @@
-From 0be1b5367c24427e3285d33fb87aa4acdf3c4dce Mon Sep 17 00:00:00 2001
+From f322fd3a034a213f8a3fa70c5d3627205a874563 Mon Sep 17 00:00:00 2001
 From: Alex Crawford <alex.crawford@coreos.com>
 Date: Wed, 2 Mar 2016 10:46:33 -0800
-Subject: [PATCH 3/8] needs-update: don't require strictly newer usr
+Subject: [PATCH 03/11] needs-update: don't require strictly newer usr
 
 Updates should be triggered whenever usr changes, not only when it is newer.
 ---

--- a/sdk_container/src/third_party/coreos-overlay/sys-apps/systemd/files/0004-core-use-max-for-DefaultTasksMax.patch
+++ b/sdk_container/src/third_party/coreos-overlay/sys-apps/systemd/files/0004-core-use-max-for-DefaultTasksMax.patch
@@ -1,7 +1,7 @@
-From d21ebfcf17ffc1dba635389193f10d2b93eba730 Mon Sep 17 00:00:00 2001
+From ad84669f3ff1afd2269b506ffc3160c75a0baa2e Mon Sep 17 00:00:00 2001
 From: Adrian Vladu <avladu@cloudbasesolutions.com>
 Date: Fri, 16 Feb 2024 11:22:08 +0000
-Subject: [PATCH 4/8] core: use max for DefaultTasksMax
+Subject: [PATCH 04/11] core: use max for DefaultTasksMax
 
 Since systemd v228, systemd has a DefaultTasksMax which defaulted
 to 512, later 15% of the system's maximum number of PIDs.  This
@@ -34,7 +34,7 @@ index 3c06b65f93..71f38692b6 100644
          Kernel has a default value for <varname>kernel.pid_max=</varname> and an algorithm of counting in case of more than 32 cores.
          For example, with the default <varname>kernel.pid_max=</varname>, <varname>DefaultTasksMax=</varname> defaults to 4915,
 diff --git a/src/core/manager.c b/src/core/manager.c
-index 88eebfc626..8992c8c3e3 100644
+index 30cd8bcbea..e40076a18c 100644
 --- a/src/core/manager.c
 +++ b/src/core/manager.c
 @@ -114,7 +114,7 @@

--- a/sdk_container/src/third_party/coreos-overlay/sys-apps/systemd/files/0005-systemd-Disable-SELinux-permissions-checks.patch
+++ b/sdk_container/src/third_party/coreos-overlay/sys-apps/systemd/files/0005-systemd-Disable-SELinux-permissions-checks.patch
@@ -1,7 +1,7 @@
-From 374cca5b2f9aea1c506352cf58b09db5c216a0d3 Mon Sep 17 00:00:00 2001
+From 2e54b668efc587540cc60fc8f4ca692b618249b0 Mon Sep 17 00:00:00 2001
 From: Matthew Garrett <mjg59@coreos.com>
 Date: Tue, 20 Dec 2016 16:43:22 +0000
-Subject: [PATCH 5/8] systemd: Disable SELinux permissions checks
+Subject: [PATCH 05/11] systemd: Disable SELinux permissions checks
 
 We don't care about the interaction between systemd and SELinux policy, so
 let's just disable these checks rather than having to incorporate policy

--- a/sdk_container/src/third_party/coreos-overlay/sys-apps/systemd/files/0006-Revert-getty-Pass-tty-to-use-by-agetty-via-stdin.patch
+++ b/sdk_container/src/third_party/coreos-overlay/sys-apps/systemd/files/0006-Revert-getty-Pass-tty-to-use-by-agetty-via-stdin.patch
@@ -1,7 +1,7 @@
-From bffb2a48796a2736d7fb7328d2a88b1cbb812b12 Mon Sep 17 00:00:00 2001
+From f8d9c085ab31bda8878e5e0afa56332e36399c40 Mon Sep 17 00:00:00 2001
 From: Sayan Chowdhury <schowdhury@microsoft.com>
 Date: Fri, 16 Dec 2022 16:28:26 +0530
-Subject: [PATCH 6/8] Revert "getty: Pass tty to use by agetty via stdin"
+Subject: [PATCH 06/11] Revert "getty: Pass tty to use by agetty via stdin"
 
 This reverts commit b4bf9007cbee7dc0b1356897344ae2a7890df84c.
 

--- a/sdk_container/src/third_party/coreos-overlay/sys-apps/systemd/files/0007-units-Keep-using-old-journal-file-format.patch
+++ b/sdk_container/src/third_party/coreos-overlay/sys-apps/systemd/files/0007-units-Keep-using-old-journal-file-format.patch
@@ -1,7 +1,7 @@
-From 6a4c6f97742afc9ca5de40335b2d041095990aa2 Mon Sep 17 00:00:00 2001
+From ab3a87fd662d3f97d24edf3f57b0ae6ba05186f7 Mon Sep 17 00:00:00 2001
 From: Adrian Vladu <avladu@cloudbasesolutions.com>
 Date: Fri, 16 Feb 2024 11:29:04 +0000
-Subject: [PATCH 7/8] units: Keep using old journal file format
+Subject: [PATCH 07/11] units: Keep using old journal file format
 
 Systemd 252 made an incompatible change in journal file format. Temporarily
 force journald to use the old journal format to give logging containers more

--- a/sdk_container/src/third_party/coreos-overlay/sys-apps/systemd/files/0008-sysext-Mutable-overlays.patch
+++ b/sdk_container/src/third_party/coreos-overlay/sys-apps/systemd/files/0008-sysext-Mutable-overlays.patch
@@ -1,7 +1,7 @@
-From b3e3257bfa07ae9ff63f5a139a1f7b72353a456b Mon Sep 17 00:00:00 2001
+From 6d55ebddee9676f68d23f1187f54a339bf7a0e7b Mon Sep 17 00:00:00 2001
 From: Krzesimir Nowak <knowak@microsoft.com>
 Date: Mon, 22 Apr 2024 16:43:38 +0200
-Subject: [PATCH 8/8] sysext: Mutable overlays
+Subject: [PATCH 08/11] sysext: Mutable overlays
 
 ---
  src/basic/path-util.c   |  12 +

--- a/sdk_container/src/third_party/coreos-overlay/sys-apps/systemd/files/0009-units-Order-ldconfig.service-after-systemd-confext.s.patch
+++ b/sdk_container/src/third_party/coreos-overlay/sys-apps/systemd/files/0009-units-Order-ldconfig.service-after-systemd-confext.s.patch
@@ -1,0 +1,31 @@
+From 525a726fb25de099186257971a7d6f51584756cf Mon Sep 17 00:00:00 2001
+From: Daan De Meyer <daan.j.demeyer@gmail.com>
+Date: Wed, 11 Sep 2024 21:29:25 +0200
+Subject: [PATCH 09/11] units: Order ldconfig.service after
+ systemd-confext.service
+
+The configuration files required by ldconfig could be put into
+place by systemd-confext.service (ldconfig only looks in /etc) so
+let's order the service after systemd-confext.service to make sure
+any config files are in place before the service runs.
+---
+ units/ldconfig.service | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/units/ldconfig.service b/units/ldconfig.service
+index 53c6d4ecb1..f5fb01ee23 100644
+--- a/units/ldconfig.service
++++ b/units/ldconfig.service
+@@ -15,7 +15,8 @@ ConditionNeedsUpdate=|/etc
+ ConditionFileNotEmpty=|!/etc/ld.so.cache
+ 
+ DefaultDependencies=no
+-After=local-fs.target
++# systemd-confext.service might put the ld.so.conf configuration files in place so order this after that.
++After=local-fs.target systemd-confext.service
+ Before=sysinit.target systemd-update-done.service
+ Conflicts=shutdown.target initrd-switch-root.target
+ Before=shutdown.target initrd-switch-root.target
+-- 
+2.34.1
+

--- a/sdk_container/src/third_party/coreos-overlay/sys-apps/systemd/files/0010-units-Order-ldconfig-after-systemd-tmpfiles-setup.se.patch
+++ b/sdk_container/src/third_party/coreos-overlay/sys-apps/systemd/files/0010-units-Order-ldconfig-after-systemd-tmpfiles-setup.se.patch
@@ -1,0 +1,32 @@
+From 60865206af3e43a2a917f347c2c7bd4d46fd3702 Mon Sep 17 00:00:00 2001
+From: Daan De Meyer <daan.j.demeyer@gmail.com>
+Date: Mon, 23 Sep 2024 13:20:42 +0200
+Subject: [PATCH 10/11] units: Order ldconfig after
+ systemd-tmpfiles-setup.service
+
+tmpfiles might be linking the configuration for ldconfig into /etc
+so make sure it runs after it so that the configuration is guaranteed
+to be in place.
+---
+ units/ldconfig.service | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/units/ldconfig.service b/units/ldconfig.service
+index f5fb01ee23..404fa011d5 100644
+--- a/units/ldconfig.service
++++ b/units/ldconfig.service
+@@ -15,8 +15,9 @@ ConditionNeedsUpdate=|/etc
+ ConditionFileNotEmpty=|!/etc/ld.so.cache
+ 
+ DefaultDependencies=no
+-# systemd-confext.service might put the ld.so.conf configuration files in place so order this after that.
+-After=local-fs.target systemd-confext.service
++# systemd-confext.service or systemd-tmpfiles-setup.service might put the ld.so.conf configuration files in place so
++# order it after those.
++After=local-fs.target systemd-confext.service systemd-tmpfiles-setup.service
+ Before=sysinit.target systemd-update-done.service
+ Conflicts=shutdown.target initrd-switch-root.target
+ Before=shutdown.target initrd-switch-root.target
+-- 
+2.34.1
+

--- a/sdk_container/src/third_party/coreos-overlay/sys-apps/systemd/files/0011-Add-debug-output-to-ldconfig.patch
+++ b/sdk_container/src/third_party/coreos-overlay/sys-apps/systemd/files/0011-Add-debug-output-to-ldconfig.patch
@@ -1,0 +1,22 @@
+From feb54a32d985834d7eb1ac3d88fc02e2c3878123 Mon Sep 17 00:00:00 2001
+From: Krzesimir Nowak <knowak@microsoft.com>
+Date: Wed, 16 Oct 2024 12:52:01 +0200
+Subject: [PATCH 11/11] Add debug output to ldconfig
+
+---
+ units/ldconfig.service | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/units/ldconfig.service b/units/ldconfig.service
+index 404fa011d5..3793e111da 100644
+--- a/units/ldconfig.service
++++ b/units/ldconfig.service
+@@ -25,4 +25,4 @@ Before=shutdown.target initrd-switch-root.target
+ [Service]
+ Type=oneshot
+ RemainAfterExit=yes
+-ExecStart=/sbin/ldconfig -X
++ExecStart=/sbin/ldconfig -X -v
+-- 
+2.34.1
+

--- a/sdk_container/src/third_party/coreos-overlay/sys-apps/systemd/systemd-255.8-r1.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/sys-apps/systemd/systemd-255.8-r1.ebuild
@@ -266,6 +266,13 @@ src_prepare() {
 		"${FILESDIR}/0007-units-Keep-using-old-journal-file-format.patch"
 		# Flatcar: This can be dropped when updating to 256.
 		"${FILESDIR}/0008-sysext-Mutable-overlays.patch"
+		# Flatcar: These can be dropped when updating to 257
+		# (or earlier if they'll get backported to some patch
+		# release)
+		"${FILESDIR}/0009-units-Order-ldconfig.service-after-systemd-confext.s.patch"
+		"${FILESDIR}/0010-units-Order-ldconfig-after-systemd-tmpfiles-setup.se.patch"
+		# Flatcar: This is a debug patch, can be dropped anytime.
+		"${FILESDIR}/0011-Add-debug-output-to-ldconfig.patch"
 	)
 
 	if ! use vanilla; then


### PR DESCRIPTION
This is in hope to either fix or pinpoint the cause of https://github.com/flatcar/Flatcar/issues/1493.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
