### PR TITLE
Drop --root-deps and --root-deps=rdeps emerge options

### DIFF
--- a/build_dev_binpkgs
+++ b/build_dev_binpkgs
@@ -46,7 +46,7 @@ fi
 # --
 
 function my_board_emerge() {
-	PORTAGE_CONFIGROOT="/build/${FLAGS_board}" SYSROOT="${SYSROOT:-/build/${FLAGS_board}}" ROOT="/build/${FLAGS_board}" sudo -E emerge --root-deps=rdeps "${@}"
+	PORTAGE_CONFIGROOT="/build/${FLAGS_board}" SYSROOT="${SYSROOT:-/build/${FLAGS_board}}" ROOT="/build/${FLAGS_board}" sudo -E emerge "${@}"
 }
 # --
 
@@ -56,7 +56,7 @@ trap 'rm -f "${pkg_build_list}" "${pkg_skipped_list}"' EXIT
 
 info "Collecting list of binpkgs to build"
 
-my_board_emerge --pretend --root-deps=rdeps --emptytree ${@}  \
+my_board_emerge --pretend --emptytree ${@}  \
   | grep '\[ebuild' \
   | sed 's/^\[[^]]\+\] \([^ :]\+\)*:.*/\1/' \
   | while read pkg; do

--- a/build_library/build_image_util.sh
+++ b/build_library/build_image_util.sh
@@ -184,7 +184,7 @@ emerge_to_image() {
   sudo -E ROOT="${root_fs_dir}" \
       FEATURES="-ebuild-locks" \
       PORTAGE_CONFIGROOT="${BUILD_DIR}"/configroot \
-      emerge --root-deps=rdeps --usepkgonly --jobs="${NUM_JOBS}" --verbose "$@"
+      emerge --usepkgonly --jobs="${NUM_JOBS}" --verbose "$@"
 
   # Shortcut if this was just baselayout
   [[ "$*" == *sys-apps/baselayout ]] && return
@@ -209,7 +209,7 @@ emerge_to_image_unchecked() {
 
   sudo -E ROOT="${root_fs_dir}" \
       PORTAGE_CONFIGROOT="${BUILD_DIR}"/configroot \
-      emerge --root-deps=rdeps --usepkgonly --jobs="${NUM_JOBS}" --verbose "$@"
+      emerge --usepkgonly --jobs="${NUM_JOBS}" --verbose "$@"
 
   # Shortcut if this was just baselayout
   [[ "$*" == *sys-apps/baselayout ]] && return

--- a/build_library/prefix_util.sh
+++ b/build_library/prefix_util.sh
@@ -108,7 +108,7 @@ function create_make_conf() {
     final)
       filepath="${FINALROOT}${EPREFIX}/etc/portage/make.conf"
       dir="${FINALDIR}"
-      emerge_opts="--root-deps=rdeps --usepkgonly"
+      emerge_opts="--usepkgonly"
       ;;
   esac
 

--- a/build_library/toolchain_util.sh
+++ b/build_library/toolchain_util.sh
@@ -263,7 +263,7 @@ _get_dependency_list() {
     local IFS=$'| \t\n'
 
     PORTAGE_CONFIGROOT="$ROOT" emerge "$@" --pretend \
-        --emptytree --root-deps=rdeps --onlydeps --quiet | \
+        --emptytree --onlydeps --quiet | \
         egrep "$ROOT" |
         sed -e 's/[^]]*\] \([^ :]*\).*/=\1/' |
         egrep -v "=($(echo "${pkgs[*]}"))-[0-9]"

--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -536,7 +536,7 @@ install_oem_package() {
     info "Installing ${oem_pkg} to OEM partition"
     USE="${oem_use}" emerge-${BOARD} \
         --root="${oem_tmp}" --sysroot="${oem_tmp}" \
-        --root-deps=rdeps --usepkgonly ${getbinpkg} \
+        --usepkgonly ${getbinpkg} \
         --verbose --jobs=2 "${oem_pkg}"
     sudo rsync -a "${oem_tmp}/oem/" "${VM_TMP_ROOT}/oem/"
     sudo rm -rf "${oem_tmp}"

--- a/build_sysext
+++ b/build_sysext
@@ -225,7 +225,6 @@ for package; do
     --root="${BUILD_DIR}/install-root" \
     --config-root="/build/${FLAGS_board}"  \
     --sysroot="/build/${FLAGS_board}"  \
-    --root-deps=rdeps \
     --usepkgonly \
     --getbinpkg \
     --verbose \
@@ -256,7 +255,7 @@ ROOT="${BUILD_DIR}/install-root" PORTAGE_CONFIGROOT="${BUILD_DIR}/install-root" 
 if [[ "${FLAGS_strip_binaries}" = "${FLAGS_TRUE}" ]]; then
     chost="$("portageq-${BOARD}" envvar CHOST)"
     strip="${chost}-strip"
-    
+
     info "Stripping all non-stripped binaries in sysext using '${strip}'"
 
     # Find all non-stripped binaries, remove ':' from filepath, and strip 'em

--- a/changelog/updates/2024-11-12-portage.md
+++ b/changelog/updates/2024-11-12-portage.md
@@ -1,0 +1,1 @@
+- SDK: portage ([3.0.66.1](https://github.com/gentoo/portage/blob/portage-3.0.66.1/NEWS#L9))

--- a/sdk_container/src/third_party/portage-stable/sys-apps/portage/portage-3.0.66.1-r1.ebuild
+++ b/sdk_container/src/third_party/portage-stable/sys-apps/portage/portage-3.0.66.1-r1.ebuild
@@ -20,7 +20,7 @@ if [[ ${PV} == 9999 ]] ; then
 	inherit git-r3
 else
 	SRC_URI="https://gitweb.gentoo.org/proj/portage.git/snapshot/${P}.tar.bz2"
-	KEYWORDS="~alpha ~amd64 ~arm ~arm64 ~hppa ~loong ~m68k ~mips ~ppc ~ppc64 ~riscv ~s390 ~sparc ~x86"
+	KEYWORDS="~alpha amd64 arm arm64 ~hppa ~loong ~m68k ~mips ppc ppc64 ~riscv ~s390 sparc x86"
 fi
 
 LICENSE="GPL-2"

--- a/setup_board
+++ b/setup_board
@@ -295,8 +295,7 @@ ${EMAINT_WRAPPER} --fix moveinst
 ${EMAINT_WRAPPER} --fix world
 
 if [[ ${FLAGS_regen_configs} -eq ${FLAGS_FALSE} ]]; then
-  EMERGE_FLAGS=( --select --verbose --root-deps=rdeps )
-  EMERGE_FLAGS+=( "--jobs=${NUM_JOBS}" )
+  EMERGE_FLAGS=( --select --verbose "--jobs=${NUM_JOBS}" )
   EMERGE_TOOLCHAIN_FLAGS=( "${EMERGE_FLAGS[@]}" )
 
   if [[ "${FLAGS_usepkg}" -eq "${FLAGS_TRUE}"  && \

--- a/setup_board
+++ b/setup_board
@@ -92,7 +92,7 @@ generate_all_wrappers() {
 
   info "Generating wrapper scripts"
 
-  for wrapper in 'emerge --root-deps' ebuild eclean equery portageq \
+  for wrapper in emerge ebuild eclean equery portageq \
                  qcheck qfile qlist emaint glsa-check; do
     _generate_wrapper ${wrapper}
   done


### PR DESCRIPTION
# Drop `--root-deps(=rdeps)` emerge options

`--root-deps` used to install build dependencies to ROOT instead of /. `--root-deps=rdeps` used to drop all build dependencies entirely. These never made much sense, so both options were rendered ineffective from EAPI 7. The number of ebuilds with older EAPIs has since dwindled to nothing.

Portage 3.0.66 (included in this PR) has made `--root-deps` now install build dependencies to ROOT as well as / because this can actually be useful and doesn't cause breakage.

However, it does make us more prone to cyclic dependencies when initially populating the board roots. There is no reason for us to use this option though because its main purpose is to ensure the target environment has everything it needs to rebuild itself. Given that the option didn't do anything recently, we evidently don't even require this for the developer container.

## How to use

This mostly concerns the build process covered by CI, but you can also check the developer container.

## Testing done

The [Jenkins run](http://jenkins.infra.kinvolk.io:8080/job/container/job/sdk/1830/) was successful.

- [X] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [X] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.