### PR TITLE
Free up /boot space with some GRUB module changes

### DIFF
--- a/build_library/grub_install.sh
+++ b/build_library/grub_install.sh
@@ -41,7 +41,7 @@ switch_to_strict_mode
 GRUB_DIR="flatcar/grub/${FLAGS_target}"
 
 # Modules required to boot a standard CoreOS configuration
-CORE_MODULES=( normal search test fat part_gpt search_fs_uuid gzio search_part_label terminal gptprio configfile memdisk tar echo read btrfs )
+CORE_MODULES=( normal search test fat part_gpt search_fs_uuid xzio search_part_label terminal gptprio configfile memdisk tar echo read btrfs )
 
 SBAT_ARG=()
 
@@ -137,7 +137,7 @@ case "${FLAGS_target}" in
                 [[ ${file} == ${GRUB_SRC}/${core_mod}.mod ]] && continue 2
             done
             out="${ESP_DIR}/${GRUB_DIR}/${file##*/}"
-            gzip --best --stdout "${file}" | sudo_clobber "${out}"
+            xz --stdout "${file}" | sudo_clobber "${out}"
         done
         ;;
 esac
@@ -178,7 +178,7 @@ fi
 
 info "Generating ${GRUB_IMAGE}"
 sudo grub-mkimage \
-    --compression=auto \
+    --compression=xz \
     --format "${FLAGS_target}" \
     --directory "${GRUB_SRC}" \
     --config "${ESP_DIR}/${GRUB_DIR}/load.cfg" \

--- a/build_library/grub_install.sh
+++ b/build_library/grub_install.sh
@@ -126,11 +126,21 @@ if [[ -z ${MOUNTED} ]]; then
 fi
 sudo mkdir -p "${ESP_DIR}/${GRUB_DIR}" "${ESP_DIR}/${GRUB_IMAGE%/*}"
 
-info "Compressing modules in ${GRUB_DIR}"
-for file in "${GRUB_SRC}"/*{.lst,.mod}; do
-    out="${ESP_DIR}/${GRUB_DIR}/${file##*/}"
-    gzip --best --stdout "${file}" | sudo_clobber "${out}"
-done
+# Additional GRUB modules cannot be loaded with Secure Boot enabled, so only
+# copy and compress these for target that don't support it.
+case "${FLAGS_target}" in
+    x86_64-efi|arm64-efi) : ;;
+    *)
+        info "Compressing modules in ${GRUB_DIR}"
+        for file in "${GRUB_SRC}"/*{.lst,.mod}; do
+            for core_mod in "${CORE_MODULES[@]}"; do
+                [[ ${file} == ${GRUB_SRC}/${core_mod}.mod ]] && continue 2
+            done
+            out="${ESP_DIR}/${GRUB_DIR}/${file##*/}"
+            gzip --best --stdout "${file}" | sudo_clobber "${out}"
+        done
+        ;;
+esac
 
 info "Generating ${GRUB_DIR}/load.cfg"
 # Include a small initial config in the core image to search for the ESP
@@ -176,10 +186,6 @@ sudo grub-mkimage \
     "${SBAT_ARG[@]}" \
     --output "${ESP_DIR}/${GRUB_IMAGE}" \
     "${CORE_MODULES[@]}"
-
-for mod in "${CORE_MODULES[@]}"; do
-    sudo rm "${ESP_DIR}/${GRUB_DIR}/${mod}.mod"
-done
 
 # Now target specific steps to make the system bootable
 case "${FLAGS_target}" in

--- a/changelog/changes/2024-11-18-grub-modules.md
+++ b/changelog/changes/2024-11-18-grub-modules.md
@@ -1,1 +1,2 @@
 - Additional GRUB modules are no longer installed for UEFI platforms to save space and also because they cannot be loaded with Secure Boot enabled. This does not affect existing installations.
+- The GRUB modules on non-UEFI platforms are now compressed with xz rather than gzip to save even more space. This does not affect existing installations.

--- a/changelog/changes/2024-11-18-grub-modules.md
+++ b/changelog/changes/2024-11-18-grub-modules.md
@@ -1,0 +1,1 @@
+- Additional GRUB modules are no longer installed for UEFI platforms to save space and also because they cannot be loaded with Secure Boot enabled. This does not affect existing installations.

--- a/sdk_container/src/third_party/coreos-overlay/coreos/config/env/sys-boot/grub
+++ b/sdk_container/src/third_party/coreos-overlay/coreos/config/env/sys-boot/grub
@@ -12,6 +12,32 @@ cros_pre_src_prepare_adjust_version() {
 	sed -i "/AC_INIT/s/\b${PV//./\\.}\b/\0-${FLATCAR_VERSION}/g" configure.ac || die
 }
 
+# Prevent developer test modules from being built. These are normally always
+# installed, even by grub-install, but they have no use outside of testing and
+# take up valuable space in /boot. The best way to identify these is to look for
+# references to the tests/ directory.
+cros_post_src_prepare_drop_tests() {
+	gawk -i inplace '
+		/^module = \{/ {
+			in_mod = 1
+		}
+		in_mod {
+			block = block $0 "\n"
+		}
+		/^\};/ && in_mod {
+			if (block !~ /\<tests\//) {
+				printf "%s", block
+			}
+			in_mod = 0
+			block = ""
+			next
+		}
+		!in_mod {
+			print
+		}
+	' grub-core/Makefile.core.def || die
+}
+
 # Replace Gentoo's SBAT with Flatcar's.
 cros_post_src_install_sbat() {
 	insinto /usr/share/grub


### PR DESCRIPTION
# Free up /boot space with some GRUB module changes

Secure Boot prevents you from loading additional GRUB modules so remove them from supported targets to save space. These modules could be useful for debugging with Secure Boot disabled, but manually copying the modules with debug symbols is even more useful and not that difficult.

Compress the GRUB modules with xz instead of gzip to save space. Giving the `--best` or `-9` option results in a heavier decompression cost with no gain on such small files. Note that this required [a Kola test to be dropped](https://github.com/flatcar/mantle/pull/565).

Prevent the developer test GRUB modules from being built. These are normally always installed, even by `grub-install`, but they have no use outside of testing and take up valuable space in /boot. Apologies for the use of awk here, but sed didn't cut it. Kudos to Copilot for the assistance. :smile: 

/boot usage has changed from 62MB to 60MB on amd64. arm64 remains at 62MB, despite the modules previously taking up 940KB. I suspect all these usage figures are actually quite close to 61MB. The unrounded figures would give a better picture.

We still need to be cautious about the kernel size for the time being because older systems being upgraded will not benefit from these savings. It would probably be easy to backport the changes into the updater though, so I'll look into that.

## How to use

Just test that the images boot as usual.

## Testing done

A [Jenkins run](http://jenkins.infra.kinvolk.io:8080/job/container/job/sdk/1834/) passed except for the cl.update.grubnop test, which has since been dropped as mentioned above.

- [X] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [X] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
