### PR TITLE
build_library/build_image_util: Fix local exporting

### DIFF
--- a/build_library/build_image_util.sh
+++ b/build_library/build_image_util.sh
@@ -95,7 +95,7 @@ zip_update_tools() {
 
   info "Generating update tools zip"
   # Make sure some vars this script needs are exported
-  local -x REPO_MANIFESTS_DIR SCRIPTS_DIR
+  local -x REPO_MANIFESTS_DIR=${REPO_MANIFESTS_DIR} SCRIPTS_DIR=${SCRIPTS_DIR}
   "${BUILD_LIBRARY_DIR}/generate_au_zip.py" \
     --arch "$(get_sdk_arch)" --output-dir "${BUILD_DIR}" --zip-name "${update_zip}"
 }


### PR DESCRIPTION
Apparently `local -x FOO` does not locally export an already existing variable, but rather does some whole weird lot of nothing - it shadows an existing variable with a new unset one, but it won't export it until it gets assigned.
