### PR TITLE
accept_keywords: pull qemu-guest-agent for arm64 arch.

### DIFF
--- a/sdk_container/src/third_party/coreos-overlay/profiles/coreos/base/package.accept_keywords
+++ b/sdk_container/src/third_party/coreos-overlay/profiles/coreos/base/package.accept_keywords
@@ -13,7 +13,7 @@
 
 # Keep the version of qemu the same on all arches.
 =app-emulation/qemu-7.2.0 ~arm64
-=app-emulation/qemu-guest-agent-6.0.0 ~arm64
+=app-emulation/qemu-guest-agent-6.0.0 **
 
 =coreos-devel/fero-client-0.1.1 **
 


### PR DESCRIPTION
For some reasons, `~arm64` or `arm64` keyword is not set for this version of qemu-guest-agent.

---

When cherry-picking this: https://github.com/flatcar/scripts/pull/2490 to LTS, I did not tested and I was not expecting the `arm64` keyword to be missing from the ebuild. Sorry about that.


## Testing done

```
emerge-arm64-usr -pv qemu-guest-agent
```
