### PR TITLE
prod_image_util.sh: Temporarily nobble removing unsigned kernel and GRUB

### DIFF
--- a/build_library/prod_image_util.sh
+++ b/build_library/prod_image_util.sh
@@ -182,6 +182,8 @@ EOF
 
   # Official builds will sign and upload these files later, so remove them to
   # prevent them from being uploaded now.
+  # TODO: Un-nobble this later when we have passed the shim review.
+  false && \
   if [[ ${COREOS_OFFICIAL:-0} -eq 1 ]]; then
     rm -v \
         "${BUILD_DIR}/${image_kernel}" \


### PR DESCRIPTION
# Temporarily nobble removing unsigned kernel and GRUB

We would normally remove these for an official build so that the signed versions can be uploaded later. However, we are not doing that signing until we pass the shim review.

## How to use

Do a release!

## Testing done

I ran shellcheck. We'll do a release to see whether this works now.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update) -- **N/A**
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc. -- **N/A**