### PR TITLE
ci-config: do not use OpenStack gzipped image

### DIFF
--- a/ci-automation/ci-config.env
+++ b/ci-automation/ci-config.env
@@ -158,7 +158,7 @@ AZURE_PARALLEL="${PARALLEL_TESTS:-20}"
 AZURE_LOCATION="${AZURE_LOCATION:-westeurope}"
 
 # -- Openstack --
-: ${OPENSTACK_IMAGE_NAME:='flatcar_production_openstack_image.img.gz'}
+: ${OPENSTACK_IMAGE_NAME:='flatcar_production_openstack_image.img'}
 OPENSTACK_PARALLEL="${PARALLEL_TESTS:-3}"
 
 # -- Brightbox --


### PR DESCRIPTION
In the test we should use the unzipped image, which is the one documented.

This allows us to drop some modifications to our OpenStack instance.

---

This can be backported to all channels. 