### PR TITLE
Delay generating test update payload in official builds

### DIFF
--- a/build_image
+++ b/build_image
@@ -177,7 +177,8 @@ if [[ "${PROD_IMAGE}" -eq 1 ]]; then
   if [[ ${FLAGS_extract_update} -eq ${FLAGS_TRUE} ]]; then
     extract_update "${FLATCAR_PRODUCTION_IMAGE_NAME}" "${DISK_LAYOUT}"
   fi
-  if [[ ${FLAGS_generate_update} -eq ${FLAGS_TRUE} && ${COREOS_OFFICIAL:-0} -ne 1 ]]; then
+  # TODO: Un-nobble this later when we have passed the shim review.
+  if [[ ${FLAGS_generate_update} -eq ${FLAGS_TRUE} ]]; then # && ${COREOS_OFFICIAL:-0} -ne 1 ]]; then
     generate_update "${FLATCAR_PRODUCTION_IMAGE_NAME}" "${DISK_LAYOUT}"
   fi
   if [[ "${PROD_TAR}" -eq 1 ]]; then

--- a/build_image
+++ b/build_image
@@ -177,7 +177,7 @@ if [[ "${PROD_IMAGE}" -eq 1 ]]; then
   if [[ ${FLAGS_extract_update} -eq ${FLAGS_TRUE} ]]; then
     extract_update "${FLATCAR_PRODUCTION_IMAGE_NAME}" "${DISK_LAYOUT}"
   fi
-  if [[ ${FLAGS_generate_update} -eq ${FLAGS_TRUE} ]]; then
+  if [[ ${FLAGS_generate_update} -eq ${FLAGS_TRUE} && ${COREOS_OFFICIAL:-0} -ne 1 ]]; then
     generate_update "${FLATCAR_PRODUCTION_IMAGE_NAME}" "${DISK_LAYOUT}"
   fi
   if [[ "${PROD_TAR}" -eq 1 ]]; then

--- a/build_library/build_image_util.sh
+++ b/build_library/build_image_util.sh
@@ -79,7 +79,9 @@ generate_update() {
   local devkey="/usr/share/update_engine/update-payload-key.key.pem"
 
   # Extract the partition if it isn't extracted already.
-  [[ -s ${update} ]] || extract_update "${image_name}" "${disk_layout}"
+  [[ -s ${update} ]] ||
+    "${BUILD_LIBRARY_DIR}/disk_util" --disk_layout="${disk_layout}" \
+      extract "${BUILD_DIR}/${image_name}" "USR-A" "${update}"
 
   echo "Generating update payload, signed with a dev key"
   delta_generator \

--- a/ci-automation/sbsign_image.sh
+++ b/ci-automation/sbsign_image.sh
@@ -91,7 +91,8 @@ function _sbsign_image_impl() {
                        --only_store_compressed
 
     # Delete uncompressed generic image before signing and upload
-    rm "${images_local}/flatcar_production_image.bin"
+    # Also delete update image because it will be unchanged
+    rm "${images_local}"/flatcar_production_{image,update}.bin
     create_digests "${SIGNER}" "${images_local}"/*
     sign_artifacts "${SIGNER}" "${images_local}"/*
     copy_to_buildcache "${images_remote}"/ "${images_local}"/*

--- a/ci-automation/sbsign_image.sh
+++ b/ci-automation/sbsign_image.sh
@@ -82,7 +82,9 @@ function _sbsign_image_impl() {
     local sdk_image="$(docker_image_fullname "${sdk_name}" "${docker_sdk_vernum}")"
     echo "docker image rm -f '${sdk_image}'" >> ./ci-cleanup.sh
 
-    ./run_sdk_container -x ./ci-cleanup.sh -v "${FLATCAR_VERSION}" -U -C "${sdk_image}" \
+    local docker_vernum="$(vernum_to_docker_image_version "${FLATCAR_VERSION}")"
+    local sbsign_container="flatcar-sbsign-image-${arch}-${docker_vernum}"
+    ./run_sdk_container -x ./ci-cleanup.sh -n "${sbsign_container}" -v "${FLATCAR_VERSION}" -U -C "${sdk_image}" \
         ./sbsign_image --board="${arch}-usr" \
                        --group="${channel}" --version="${FLATCAR_VERSION}" \
                        --output_root="${CONTAINER_IMAGE_ROOT}" \

--- a/sbsign_image
+++ b/sbsign_image
@@ -61,8 +61,11 @@ switch_to_strict_mode
 # Create the output directory and temporary mount points.
 mkdir -p "${BUILD_DIR}"
 
+DISK_LAYOUT="${FLAGS_disk_layout:-base}"
+
 fix_mtab
-sbsign_prod_image "${FLATCAR_PRODUCTION_IMAGE_NAME}" "${FLAGS_disk_layout:-base}"
+sbsign_prod_image "${FLATCAR_PRODUCTION_IMAGE_NAME}" "${DISK_LAYOUT}"
+generate_update "${FLATCAR_PRODUCTION_IMAGE_NAME}" "${DISK_LAYOUT}"
 
 echo "Done. ${FLATCAR_PRODUCTION_IMAGE_NAME} and associated files are now signed for Secure Boot in ${BUILD_DIR}."
 command_completed


### PR DESCRIPTION
# Delay generating test update payload in official builds

The update payload needs the kernel, which isn't signed during the image job. Secure Boot is not currently enabled for update tests, but we may as well do this properly. The production update upload is generated manually at the end after everything has already been signed.

However, we need to temporarily nobble part of the above change until we have actually passed the shim review.

This also fixes a container name clash in the sbsign_image job.

## How to use

Nothing to do.

## Testing done

I have run Jenkins for [amd64](http://jenkins.infra.kinvolk.io:8080/job/container/job/sbsign_image/15/cldsv/) and [arm64](http://jenkins.infra.kinvolk.io:8080/job/container/job/sbsign_image/16/cldsv/). The qemu_update tests passed. I also checked the timestamps of files on the bincache to ensure the right files were uploaded when expected.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update) -- **N/A**
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.**N/A**