### PR TITLE
pkg-auto: Some fixes made during weekly updates

### DIFF
--- a/pkg_auto/diff_pkg.sh
+++ b/pkg_auto/diff_pkg.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/impl/util.sh"
+
+##
+## Prints a diff of a package in old and new scripts
+## directories. Operates in one of two modes. First mode is an
+## "ebuild" mode where it shows a diff of two ebuilds. The other mode
+## is an "other" mode where it shows diffs of all non-ebuild files
+## (ignoring Manifest files too).
+##
+## Parameters:
+## -h: this help
+## -r <name>: New package name (useful when package got renamed)
+##
+## Positional:
+## 1: mode, "ebuild" (or "e") or "other" (or "o")
+## 2: path to old scripts repository
+## 3: path to new scripts repository
+## 4: package name (but see -r flag too)
+## 5: old version (for "ebuild" mode only)
+## 6: new version (for "ebuild" mode only)
+##
+
+renamed=
+
+while [[ ${#} -gt 0 ]]; do
+    case ${1} in
+        -h)
+            print_help
+            exit 0
+            ;;
+        -r)
+            renamed=${2}
+            shift 2
+            ;;
+        --)
+            shift
+            break
+            ;;
+        -*)
+            fail "unknown flag ${1@Q}"
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+if [[ ${#} -lt 1 ]]; then
+    fail 'Use -h to get help'
+fi
+
+mode=${1}; shift
+
+case ${mode} in
+    ebuild|ebuil|ebui|ebu|eb|e)
+        mode=e
+        if [[ ${#} -ne 5 ]]; then
+            fail 'Expected five positional parameters: a path to old and new scripts repositories, a package name, and old a new version of package'
+        fi
+        ;;
+    other|othe|oth|ot|o)
+        mode=o
+        # expect at least three parameters, if more are given, they
+        # will be ignored, to allow changing mode from ebuild to other
+        # without the need for removing versions from the command
+        # invocation
+        if [[ ${#} -lt 3 ]]; then
+            fail 'Expected three positional parameters: a path to old and new scripts repositories, and a package name'
+        fi
+        ;;
+esac
+
+old_scripts=${1}
+new_scripts=${2}
+# old and new package name
+old_package=${3}
+new_package=${renamed:-${3}}
+
+gentoo_path=sdk_container/src/third_party/portage-stable
+overlay_path=sdk_container/src/third_party/coreos-overlay
+old_gentoo_path=${old_scripts}/${gentoo_path}/${old_package}
+old_overlay_path=${old_scripts}/${overlay_path}/${old_package}
+new_gentoo_path=${new_scripts}/${gentoo_path}/${new_package}
+new_overlay_path=${new_scripts}/${overlay_path}/${new_package}
+
+if [[ -e ${old_gentoo_path} ]] && [[ -e ${old_overlay_path} ]]; then
+    fail "Package ${old_package@Q} exists in both gentoo and overlay in old scripts"
+fi
+
+if [[ -e ${new_gentoo_path} ]] && [[ -e ${new_overlay_path} ]]; then
+    fail "Package ${new_package@Q} exists in both gentoo and overlay in new scripts"
+fi
+
+if [[ ${mode} = e ]]; then
+    old_version=${4}
+    new_version=${5}
+    old_gentoo_ebuild=${old_gentoo_path}/${old_package#*/}-${old_version}.ebuild
+    old_overlay_ebuild=${old_overlay_path}/${old_package#*/}-${old_version}.ebuild
+    new_gentoo_ebuild=${new_gentoo_path}/${new_package#*/}-${new_version}.ebuild
+    new_overlay_ebuild=${new_overlay_path}/${new_package#*/}-${new_version}.ebuild
+
+    old_path=''
+    new_path=''
+
+    if [[ -e ${old_gentoo_ebuild} ]]; then
+        old_path=${old_gentoo_ebuild}
+    fi
+    if [[ -e ${old_overlay_ebuild} ]]; then
+        old_path=${old_overlay_ebuild}
+    fi
+
+    if [[ -e ${new_gentoo_ebuild} ]]; then
+        new_path=${new_gentoo_ebuild}
+    fi
+    if [[ -e ${new_overlay_ebuild} ]]; then
+        new_path=${new_overlay_ebuild}
+    fi
+
+    if [[ -z ${old_path} ]]; then
+        fail "Old version ${old_version@Q} does not exist neither in overlay nor in gentoo"
+    fi
+
+    if [[ -z ${new_path} ]]; then
+        fail "New version ${new_version@Q} does not exist neither in overlay nor in gentoo"
+    fi
+
+    diff --color --unified=3 "${old_path}" "${new_path}" || :
+else
+    old_path=${old_gentoo_path}
+    new_path=${new_gentoo_path}
+
+    if [[ -e ${old_overlay_path} ]]; then
+        old_path=${old_overlay_path}
+    fi
+
+    if [[ -e ${new_overlay_path} ]]; then
+        new_path=${new_overlay_path}
+    fi
+
+    diff --color --recursive --unified=3 --new-file --exclude='*.ebuild' --exclude='Manifest' "${old_path}" "${new_path}" || :
+fi

--- a/pkg_auto/impl/inside_sdk_container_lib.sh
+++ b/pkg_auto/impl/inside_sdk_container_lib.sh
@@ -11,11 +11,10 @@ source "$(dirname "${BASH_SOURCE[0]}")/util.sh"
 # Params:
 #
 # 1 - root filesystem with the portage config
-# 2 - metapackage to get the deps from
+# @ - packages and metapackages to get the deps from
 function emerge_pretend() {
-    local root package
+    local root
     root=${1}; shift
-    package=${1}; shift
 
     # Probably a bunch of those flags are not necessary, but I'm not
     # touching it - they seem to be working. :)
@@ -50,7 +49,7 @@ function emerge_pretend() {
     )
     local rv
     rv=0
-    emerge "${emerge_opts[@]}" "${package}" || rv=${?}
+    emerge "${emerge_opts[@]}" "${@}" || rv=${?}
     if [[ ${rv} -ne 0 ]]; then
         echo "WARNING: emerge exited with status ${rv}" >&2
     fi

--- a/pkg_auto/impl/inside_sdk_container_lib.sh
+++ b/pkg_auto/impl/inside_sdk_container_lib.sh
@@ -61,7 +61,10 @@ function package_info_for_sdk() {
     root='/'
 
     ignore_crossdev_stuff "${root}"
-    emerge_pretend "${root}" coreos-devel/sdk-depends
+    # stage4 build of SDK builds coreos-devel/sdk-depends, fsscript
+    # pulls in cross toolchains with crossdev (which we have just
+    # ignored) and dev-lang/rust
+    emerge_pretend "${root}" coreos-devel/sdk-depends dev-lang/rust
     revert_crossdev_stuff "${root}"
 }
 

--- a/pkg_auto/impl/sync_with_gentoo.sh
+++ b/pkg_auto/impl/sync_with_gentoo.sh
@@ -169,7 +169,7 @@ function commit_with_gentoo_sha() {
     if [[ -z ${SKIP_GIT_INFO} ]]; then
         local commit
 
-        commit=$(git -C "${GENTOO}/${path}" log --pretty=oneline -1 -- . | cut -f1 -d' ')
+        commit=$(git -C "${GENTOO}" log --pretty=oneline -1 -- "${path}" | cut -f1 -d' ')
         commit_extra+=( --message "It's from Gentoo commit ${commit}." )
         unset commit
     fi

--- a/pkg_auto/occurences.sh
+++ b/pkg_auto/occurences.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+##
+## Print all the places in the scripts repository where the given
+## package is mentioned. It's sort of like grep, but a bit smarter and
+## with a slightly better output.
+##
+## Parameters:
+## -h: this help
+##
+## Positional:
+## 1: scripts repo
+## 2: package name
+##
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/impl/pkg_auto_lib.sh"
+
+while [[ ${#} -gt 0 ]]; do
+    case ${1} in
+        -h)
+            print_help
+            exit 0
+            ;;
+        --)
+            shift
+            break
+            ;;
+        -*)
+            fail "unknown flag '${1}'"
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+if [[ ${#} -ne 2 ]]; then
+    fail 'Expected two positional parameters: a path to scripts repository and a package name'
+fi
+
+generate_mention_report_for_package "${1}" "${2}"


### PR DESCRIPTION
- for SDK reports, do emerge of not only coreos-devel/sdk-depends, but also dev-lang/rust directly (it's being pulled in by fsscript in stage4)
- add `diff_pkg.sh` and `occurences.sh` scripts to help with debugging report generation failures
- fix syncing eclass files
