### PR TITLE
Pass image version to kola

### DIFF
--- a/ci-automation/vendor-testing/aws.sh
+++ b/ci-automation/vendor-testing/aws.sh
@@ -58,6 +58,7 @@ run_kola_tests() {
          --aws-type="${instance_type}" \
          --aws-iam-profile="${AWS_IAM_PROFILE}" \
          --tapfile="${instance_tapfile}" \
+         --image-version "${CIA_VERNUM}" \
          "${@}"
 }
 

--- a/ci-automation/vendor-testing/azure.sh
+++ b/ci-automation/vendor-testing/azure.sh
@@ -59,6 +59,7 @@ run_kola_tests() {
       ${AZURE_KOLA_VNET:+--azure-kola-vnet=${AZURE_KOLA_VNET}} \
       ${azure_vnet_subnet_name:+--azure-vnet-subnet-name=${azure_vnet_subnet_name}} \
       ${AZURE_USE_PRIVATE_IPS:+--azure-use-private-ips=${AZURE_USE_PRIVATE_IPS}} \
+      --image-version "${CIA_VERNUM}" \
       "${@}"
 }
 

--- a/ci-automation/vendor-testing/brightbox.sh
+++ b/ci-automation/vendor-testing/brightbox.sh
@@ -61,6 +61,7 @@ timeout --signal=SIGQUIT 2h kola run \
   --brightbox-client-id="${BRIGHTBOX_CLIENT_ID}" \
   --brightbox-client-secret="${BRIGHTBOX_CLIENT_SECRET}" \
   --brightbox-server-type="${BRIGHTBOX_SERVER_TYPE}" \
+  --image-version "${CIA_VERNUM}" \
   "${@}"
 
 set +x

--- a/ci-automation/vendor-testing/digitalocean.sh
+++ b/ci-automation/vendor-testing/digitalocean.sh
@@ -51,6 +51,7 @@ timeout --signal=SIGQUIT 4h\
     --platform=do \
     --channel="${CIA_CHANNEL}" \
     --tapfile="${CIA_TAPFILE}" \
+    --image-version "${CIA_VERNUM}" \
     "${@}"
 
 set +x

--- a/ci-automation/vendor-testing/equinix_metal.sh
+++ b/ci-automation/vendor-testing/equinix_metal.sh
@@ -45,6 +45,7 @@ run_kola_tests() {
           --equinixmetal-storage-url="${EQUINIXMETAL_STORAGE_URL}" \
           --gce-json-key=<(set +x; echo "${GCP_JSON_KEY}" | base64 --decode) \
           --equinixmetal-api-key="${EQUINIXMETAL_KEY}" \
+          --image-version "${CIA_VERNUM}" \
           "${@}"
 }
 

--- a/ci-automation/vendor-testing/gce.sh
+++ b/ci-automation/vendor-testing/gce.sh
@@ -62,6 +62,7 @@ run_kola_tests() {
         --platform=gce \
         --channel="${CIA_CHANNEL}" \
         --tapfile="${instance_tapfile}" \
+        --image-version "${CIA_VERNUM}" \
         "${@}"
 }
 

--- a/ci-automation/vendor-testing/hetzner.sh
+++ b/ci-automation/vendor-testing/hetzner.sh
@@ -56,6 +56,7 @@ timeout --signal=SIGQUIT 2h kola run \
   --hetzner-server-type="${hetzner_instance_type}" \
   --hetzner-location="${hetzner_location}" \
   --hetzner-image=${IMAGE_ID} \
+  --image-version "${CIA_VERNUM}" \
   "${@}"
 
 set +x

--- a/ci-automation/vendor-testing/openstack.sh
+++ b/ci-automation/vendor-testing/openstack.sh
@@ -62,6 +62,7 @@ timeout --signal=SIGQUIT 2h kola run \
   --openstack-keyfile="${openstack_keyfile}" \
   --openstack-image="${IMAGE_ID}" \
   --openstack-config-file="${config_file}" \
+  --image-version "${CIA_VERNUM}" \
   "${@}"
 
 set +x

--- a/ci-automation/vendor-testing/qemu.sh
+++ b/ci-automation/vendor-testing/qemu.sh
@@ -73,6 +73,7 @@ kola run \
     --tapfile="${CIA_TAPFILE}" \
     ${QEMU_KOLA_SKIP_MANGLE:+--qemu-skip-mangle} \
     "${devcontainer_opts[@]}" \
+    --image-version "${CIA_VERNUM}" \
     "${@}"
 
 set +x

--- a/ci-automation/vendor-testing/qemu_update.sh
+++ b/ci-automation/vendor-testing/qemu_update.sh
@@ -119,6 +119,7 @@ run_kola_tests() {
       --tapfile="${instance_tapfile}" \
       --update-payload="${QEMU_UPDATE_PAYLOAD}" \
       ${QEMU_KOLA_SKIP_MANGLE:+--qemu-skip-mangle} \
+      --image-version "${CIA_VERNUM}" \
       "${tests[@]}"
 }
 

--- a/ci-automation/vendor-testing/vmware.sh
+++ b/ci-automation/vendor-testing/vmware.sh
@@ -62,6 +62,7 @@ sudo timeout --signal=SIGQUIT 2h kola run \
     --parallel="${VMWARE_ESX_PARALLEL}" \
     --esx-config-file "${config_file}" \
     --esx-ova-path "${VMWARE_ESX_IMAGE_NAME}" \
+    --image-version "${CIA_VERNUM}" \
     "${@}"
 
 set +x

--- a/sdk_container/.repo/manifests/mantle-container
+++ b/sdk_container/.repo/manifests/mantle-container
@@ -1,1 +1,1 @@
-ghcr.io/flatcar/mantle:git-06e6ea5b493e73946f67766ebba75d1b6983f57e
+ghcr.io/flatcar/mantle:git-8004043d568dcfce45c0389d50e56c982e388157


### PR DESCRIPTION
The SELinux denial checking in kola is conditionally disabled - if the Flatcar image version is too old, then it's disabled for all the tests. For kola to decide whether to disable or enable the checking, it needs to know the version of the image. It can be done in two ways - either we pass the version to kola through a flag, or kola itself spins a temporary cluster with one machine and figures out the version from os-release file. The latter is obviously very slow, to a point that kola was skipping this step if the tests didn't need the version information. Now the version information is needed always, and our ci-automation already knows the version of the image, so we can pass it to kola to skip creating the temporary cluster.

Requires https://github.com/flatcar/mantle/pull/572. Will update this PR later, when mantle PR is merged.