### PR TITLE
Fix non conforming partition table

### DIFF
--- a/build_library/disk_layout.json
+++ b/build_library/disk_layout.json
@@ -16,7 +16,7 @@
         "blocks":"262144",
         "fs_type":"vfat",
         "mount":"/boot",
-        "features": ["hybrid"]
+        "features": []
       },
       "2":{
         "label":"BIOS-BOOT",

--- a/changelog/bugfixes/2025-02-14-fix-efi-partition-flags.md
+++ b/changelog/bugfixes/2025-02-14-fix-efi-partition-flags.md
@@ -1,0 +1,1 @@
+- Fix non-conforming GPT partition table ([flatcar/Flatcar#1651](https://github.com/flatcar/Flatcar/issues/1651)


### PR DESCRIPTION
# Fix non conforming partition table

This change removes the legacy_boot flag from the EFI system partition. We already have a BIOS boot partition which should offer compatibility with legacy bios systems.

## How to use

Upload the image in a fresh OpenStack devstack deploy and boot. 

## Testing done

* Downloaded the already existing image
* Removed the legacy_boot flag
* booted the image and it worked.

- [x ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

