### PR TITLE
nvidia.service arm64 support & fix

### DIFF
--- a/sdk_container/src/third_party/coreos-overlay/eclass/coreos-kernel.eclass
+++ b/sdk_container/src/third_party/coreos-overlay/eclass/coreos-kernel.eclass
@@ -42,7 +42,7 @@ DEPEND="=sys-kernel/coreos-sources-${COREOS_SOURCE_VERSION}"
 RESTRICT="binchecks strip"
 
 # The build tools are OK and shouldn't trip up multilib-strict.
-QA_MULTILIB_PATHS="usr/lib/modules/.*/build/scripts/.*"
+QA_MULTILIB_PATHS="usr/lib/modules/.*/build/scripts/kconfig/.*"
 
 # Use source installed by coreos-sources
 # KERNEL_DIR must find the kernel source tree under /usr/src/linux-*-coreos,

--- a/sdk_container/src/third_party/coreos-overlay/sys-kernel/coreos-modules/coreos-modules-6.6.79.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/sys-kernel/coreos-modules/coreos-modules-6.6.79.ebuild
@@ -54,6 +54,14 @@ src_install() {
 	# Clean up the build tree
 	shred_keys
 	kmake clean
+
+	# TODO: ensure that fixdep and kbuild tools shipped inside the image
+	# are native (we previously shipped amd64 binaries on arm64).
+	# Upstream has a new script from v6.12 that we might be able to use:
+	# scripts/package/install-extmod-buil0d
+	kmake HOSTLD=$(tc-getLD) HOSTCC=$(tc-getCC) cmd_and_fixdep='$(cmd)' modules_prepare
+	kmake clean
+
 	find "build/" -type d -empty -delete || die
 	rm "build/.config.old" || die
 

--- a/sdk_container/src/third_party/coreos-overlay/x11-drivers/nvidia-drivers/files/bin/install-nvidia
+++ b/sdk_container/src/third_party/coreos-overlay/x11-drivers/nvidia-drivers/files/bin/install-nvidia
@@ -4,11 +4,35 @@
 NVIDIA_DRIVER_BASENAME="$1"
 KERNEL_NAME="$(ls /lib/modules)"
 
+option_supported() {
+  local opt="$1"
+  ./nvidia-installer -A -h | grep -qe "--$opt"
+}
+
 cd "/nvidia/${NVIDIA_DRIVER_BASENAME}"
+
+EXTRA_OPTS=()
+if option_supported no-rebuild-initramfs ; then
+  EXTRA_OPTS+=( --no-rebuild-initramfs )
+fi
+if option_supported skip-module-load ; then
+  EXTRA_OPTS+=( --skip-module-load )
+fi
+
+# TODO: open requires firmware loading.
+# Can we load the module from the nspawn container?
+if option_supported kernel-module-type ; then
+  EXTRA_OPTS+=( --kernel-module-type=proprietary )
+elif option_supported kernel-module-build-directory ; then
+  EXTRA_OPTS+=( --kernel-module-build-directory=kernel )
+fi
+
 ./nvidia-installer -s -n \
   --no-check-for-alternate-installs \
   --no-kernel-module-source \
   --kernel-name="${KERNEL_NAME}" \
+  "${EXTRA_OPTS[@]}" \
+  --no-x-check \
   --no-opengl-files \
   --no-distro-scripts \
   --no-systemd \

--- a/sdk_container/src/third_party/coreos-overlay/x11-drivers/nvidia-drivers/files/bin/install-nvidia
+++ b/sdk_container/src/third_party/coreos-overlay/x11-drivers/nvidia-drivers/files/bin/install-nvidia
@@ -40,6 +40,9 @@ fi
   --kernel-install-path="${PWD}/install-mod" \
   --log-file-name="${PWD}/nvidia-installer.log" || true
 
+echo "Last 50 lines of nvidia-installer.log:"
+tail -n50 nvidia-installer.log || true
+
 # TODO: previously we copied outputs to /lib/module and ran depmod here.
 # That didn't work right because nspawn mounts /usr readonly.
 # Removed them because the whole depmod strategy needs to be reinvented.

--- a/sdk_container/src/third_party/coreos-overlay/x11-drivers/nvidia-drivers/files/bin/install-nvidia
+++ b/sdk_container/src/third_party/coreos-overlay/x11-drivers/nvidia-drivers/files/bin/install-nvidia
@@ -40,9 +40,8 @@ fi
   --kernel-install-path="${PWD}/install-mod" \
   --log-file-name="${PWD}/nvidia-installer.log" || true
 
-mkdir -p /lib/modules/${KERNEL_NAME}/video
+# TODO: previously we copied outputs to /lib/module and ran depmod here.
+# That didn't work right because nspawn mounts /usr readonly.
+# Removed them because the whole depmod strategy needs to be reinvented.
 mkdir -p "${PWD}"/install-mod
 cp "${PWD}"/kernel/*.ko "${PWD}"/install-mod
-cp "${PWD}"/install-mod/*.ko /lib/modules/${KERNEL_NAME}/video/
-depmod -a
-cp /lib/modules/${KERNEL_NAME}/modules.* "${PWD}/install-mod/"

--- a/sdk_container/src/third_party/coreos-overlay/x11-drivers/nvidia-drivers/files/bin/setup-nvidia
+++ b/sdk_container/src/third_party/coreos-overlay/x11-drivers/nvidia-drivers/files/bin/setup-nvidia
@@ -88,7 +88,11 @@ SYSEXT_LEVEL=1.0
 EOF
 
   pushd /opt/nvidia
-  ln -sfn "${NVIDIA_FLATCAR_VERSION_PAIR}" current
+  if [[ -d "${NVIDIA_CURRENT_INSTALLATION}" ]]
+  then
+    rm -rf "${NVIDIA_CURRENT_INSTALLATION}"
+  fi
+  ln -sfn -T "${NVIDIA_FLATCAR_VERSION_PAIR}" "${NVIDIA_CURRENT_INSTALLATION}"
   popd
 }
 

--- a/sdk_container/src/third_party/coreos-overlay/x11-drivers/nvidia-drivers/files/bin/setup-nvidia
+++ b/sdk_container/src/third_party/coreos-overlay/x11-drivers/nvidia-drivers/files/bin/setup-nvidia
@@ -67,7 +67,7 @@ function extract_nvidia_installer() {
 function run_nspawn_container() {
   echo Spawn system-nspawn container to install the NVIDIA drivers
 
-  sudo systemd-nspawn --read-only --volatile=overlay --image="${FLATCAR_ROOT_WORKDIR}/${FLATCAR_DEVELOPER_CONTAINER}" --bind="${FLATCAR_ROOT_WORKDIR}/${NVIDIA_WORKDIR}":/nvidia --bind=/usr/lib/nvidia/bin:/app/bin/ /app/bin/install-nvidia "$NVIDIA_DRIVER_BASENAME"
+  sudo systemd-nspawn --keep-unit --register=no --read-only --volatile=overlay --image="${FLATCAR_ROOT_WORKDIR}/${FLATCAR_DEVELOPER_CONTAINER}" --bind="${FLATCAR_ROOT_WORKDIR}/${NVIDIA_WORKDIR}":/nvidia --bind=/usr/lib/nvidia/bin:/app/bin/ /app/bin/install-nvidia "$NVIDIA_DRIVER_BASENAME"
 }
 
 function copy_nvidia_build_artifacts() {

--- a/sdk_container/src/third_party/coreos-overlay/x11-drivers/nvidia-drivers/files/bin/setup-nvidia
+++ b/sdk_container/src/third_party/coreos-overlay/x11-drivers/nvidia-drivers/files/bin/setup-nvidia
@@ -38,8 +38,8 @@ function download_flatcar_developer_container() {
     fi
 
     curl -L --fail "${FLATCAR_DEVELOPER_CONTAINER_URL}" -o "${FLATCAR_ROOT_WORKDIR}/${FLATCAR_DEVELOPER_CONTAINER}.bz2"
-    lbzip2 -d "${FLATCAR_ROOT_WORKDIR}/${FLATCAR_DEVELOPER_CONTAINER}.bz2"
-
+    cp --sparse=always <(lbzcat "${FLATCAR_ROOT_WORKDIR}/${FLATCAR_DEVELOPER_CONTAINER}.bz2") "${FLATCAR_ROOT_WORKDIR}/${FLATCAR_DEVELOPER_CONTAINER}"
+    rm "${FLATCAR_ROOT_WORKDIR}/${FLATCAR_DEVELOPER_CONTAINER}.bz2"
   fi
 
   return 0

--- a/sdk_container/src/third_party/coreos-overlay/x11-drivers/nvidia-drivers/files/bin/setup-nvidia
+++ b/sdk_container/src/third_party/coreos-overlay/x11-drivers/nvidia-drivers/files/bin/setup-nvidia
@@ -7,7 +7,7 @@ set -euo pipefail
 [ -f /etc/flatcar/nvidia-metadata ] && . /etc/flatcar/nvidia-metadata
 
 NVIDIA_DOWNLOAD_BASEURL="https://us.download.nvidia.com/${NVIDIA_PRODUCT_TYPE}/"
-NVIDIA_DRIVER_BASENAME="NVIDIA-Linux-x86_64-${NVIDIA_DRIVER_VERSION}"
+NVIDIA_DRIVER_BASENAME="NVIDIA-Linux-$(uname -m)-${NVIDIA_DRIVER_VERSION}"
 NVIDIA_WORKDIR='nvidia-workdir'
 
 FLATCAR_DEVELOPER_CONTAINER="flatcar_developer_container-${FLATCAR_RELEASE_VERSION}.bin"

--- a/sdk_container/src/third_party/coreos-overlay/x11-drivers/nvidia-drivers/files/bin/setup-nvidia
+++ b/sdk_container/src/third_party/coreos-overlay/x11-drivers/nvidia-drivers/files/bin/setup-nvidia
@@ -79,7 +79,6 @@ function copy_nvidia_build_artifacts() {
 
   mkdir -p "/opt/nvidia/${NVIDIA_FLATCAR_VERSION_PAIR}/usr/lib/modules/$(uname -r)/video/"
   cp "$FLATCAR_ROOT_WORKDIR/$NVIDIA_WORKDIR/${NVIDIA_DRIVER_BASENAME}"/install-mod/*.ko "/opt/nvidia/${NVIDIA_FLATCAR_VERSION_PAIR}/usr/lib/modules/$(uname -r)/video/"
-  cp "$FLATCAR_ROOT_WORKDIR/$NVIDIA_WORKDIR/${NVIDIA_DRIVER_BASENAME}"/install-mod/modules.* "/opt/nvidia/${NVIDIA_FLATCAR_VERSION_PAIR}/usr/lib/modules/$(uname -r)/"
 
   mkdir -p "/opt/nvidia/${NVIDIA_FLATCAR_VERSION_PAIR}/usr/lib/extension-release.d/"
   cat <<EOF >"/opt/nvidia/${NVIDIA_FLATCAR_VERSION_PAIR}/usr/lib/extension-release.d/extension-release.nvidia-driver"


### PR DESCRIPTION
# nvidia.service arm64 support & fix

Add support for arm64 to nvidia.service and fix other related issues. Here is a brief overview of all changes:

- coreos-modules shipped kmod build tools in /lib/modules that were not properly cross-compiled for arm64. They are now.
- Fetch an architecture specific installer file from nvidia. See also: https://github.com/flatcar/Flatcar/issues/1649
- @njuettner reported that in some cases the `current` symlink may end up created as a directory, which breaks the unit silently. No idea how this can happen but handle this case.
- newer nvidia driver versions like 570.x default to kernel-open modules (maybe only on arm64?), which the service is not ready handle (and won't be able to quickly due to a dependency on firmware files). Explicitly force non-kernel-open drivers.
- Remove depmod generation. We didn't depend on this being done and this was broken because those parts of the filesystem are readonly in the nspawn container. See also: https://github.com/flatcar/Flatcar/issues/1576
- Make the devcontainer image sparse.
- Add some more verbose output from the unit.

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

Tested on g5g.xlarge instances in AWS during development, but need to script this or repeat with the final PR result.
Jenkins build (covers Azure GPU instances) running here: http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/5457/cldsv/

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
