### PR TITLE
overlay wa-linux-agent: apply patch to fix ssh public key override issue (stable, beta)

### DIFF
--- a/changelog/bugfixes/2025-02-28-walinuxagent-ignition.md
+++ b/changelog/bugfixes/2025-02-28-walinuxagent-ignition.md
@@ -1,0 +1,1 @@
+- Fix issue of wa-linux-agent overriding ssh public key from ignition configuration during provisioning ([flatcar/Flatcar#1661](https://github.com/flatcar/Flatcar/issues/1661))

--- a/sdk_container/src/third_party/coreos-overlay/app-emulation/wa-linux-agent/files/0002-prevent-ssh-public-key-override.patch
+++ b/sdk_container/src/third_party/coreos-overlay/app-emulation/wa-linux-agent/files/0002-prevent-ssh-public-key-override.patch
@@ -1,0 +1,26 @@
+From 0c8db73c3567039e50ffa7447bb093ca812dedf6 Mon Sep 17 00:00:00 2001
+Message-Id: <0c8db73c3567039e50ffa7447bb093ca812dedf6.1740577844.git.dpark@linux.microsoft.com>
+From: Peyton Robertson <93797227+peytonr18@users.noreply.github.com>
+Date: Tue, 28 Jan 2025 14:17:43 -0800
+Subject: [PATCH] Applying patch to prevent ssh public key override (#3309)
+
+---
+ azurelinuxagent/common/osutil/default.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/azurelinuxagent/common/osutil/default.py b/azurelinuxagent/common/osutil/default.py
+index 584515dc..746c4363 100644
+--- a/azurelinuxagent/common/osutil/default.py
++++ b/azurelinuxagent/common/osutil/default.py
+@@ -346,7 +346,7 @@ GEN2_DEVICE_ID = 'f8b3781a-1e82-4818-a1c3-63d806ec15bb'
+                 raise OSUtilError("Bad public key: {0}".format(value))
+             if not value.endswith("\n"):
+                 value += "\n"
+-            fileutil.write_file(path, value)
++            fileutil.write_file(path, value, append=True)
+         elif thumbprint is not None:
+             lib_dir = conf.get_lib_dir()
+             crt_path = os.path.join(lib_dir, thumbprint + '.crt')
+-- 
+2.39.5
+

--- a/sdk_container/src/third_party/coreos-overlay/app-emulation/wa-linux-agent/wa-linux-agent-2.9.1.1-r3.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/app-emulation/wa-linux-agent/wa-linux-agent-2.9.1.1-r3.ebuild
@@ -30,4 +30,5 @@ S="${WORKDIR}/WALinuxAgent-${PV}"
 
 PATCHES=(
     "${FILESDIR}/0001-flatcar-changes.patch"
+    "${FILESDIR}/0002-prevent-ssh-public-key-override.patch"
 )


### PR DESCRIPTION
Apply patch to fix an issue when overriding ssh public key from ignition configuration. Since the fix is not available in releases of wa-linux-agent, we should apply a separate patch.

See also https://github.com/Azure/WALinuxAgent/pull/3309.

See also https://github.com/flatcar/Flatcar/issues/1661.

## Testing done

CI: http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/5465/cldsv/ passed

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [x] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
