### PR TITLE
testing/openstack: clean everything before testing

### DIFF
--- a/ci-automation/vendor-testing/openstack.sh
+++ b/ci-automation/vendor-testing/openstack.sh
@@ -29,6 +29,9 @@ secret_to_file config_file "${OPENSTACK_CREDS}"
 openstack_keyfile=''
 secret_to_file openstack_keyfile "${OPENSTACK_KEYFILE}"
 
+# Make sure that everything is cleaned up before starting.
+ore --config-file "${config_file}" openstack gc --duration 1s
+
 # Upload the image on OpenStack dev instance.
 IMAGE_ID=$(ore openstack create-image \
   --name=flatcar-"${CIA_VERNUM}" \


### PR DESCRIPTION
It happens that we have some leftovers instances running in an "error" state (the error comes from the OpenStack scheduled deletion). This leads to instance creation error during the test because quota limits are hit.

Let's clean-up everything before running the new tests.

This won't impact tests from other channels as OpenStack is limited to one CI job at a time.

- [x] CI: http://localhost:8080/job/container/job/packages_all_arches/5473/cldsv/
- [x] No Changelog needed
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

