### PR TITLE
setup-nvidia: Modprobe video.ko for amd64

### DIFF
--- a/sdk_container/src/third_party/coreos-overlay/x11-drivers/nvidia-drivers/files/bin/setup-nvidia
+++ b/sdk_container/src/third_party/coreos-overlay/x11-drivers/nvidia-drivers/files/bin/setup-nvidia
@@ -99,6 +99,8 @@ function install_and_load() {
   ldconfig
 
   modprobe -a i2c_core ipmi_msghandler ipmi_devintf
+  # This is needed on amd64 due to CONFIG_ACPI_VIDEO=m
+  modprobe -q video || true
 
   pushd "/opt/nvidia/${NVIDIA_CURRENT_INSTALLATION}/usr/lib/modules/$(uname -r)/video/"
   insmod nvidia.ko


### PR DESCRIPTION
# setup-nvidia: Modprobe video.ko for amd64

Since we added CONFIG_I915 to our amd64 kernel (#2349), CONFIG_ACPI_VIDEO=m is enabled and causes the nvidia driver to compile-in some code that depends on it. Since we need to insmod the nvidia module (we don't have depmod information) - manually load the required module. The '|| true' lets this line pass on arm64.

Changelog is not required because this fixes a bug that hasn't been released yet.

## How to use

Run azure testing, which will execute GPU tests.

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [x] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
