### PR TITLE
add -nographic flag for x86_64 arch

### DIFF
--- a/build_library/qemu_template.sh
+++ b/build_library/qemu_template.sh
@@ -228,7 +228,7 @@ else
                    -global driver=cfi.pflash01,property=secure,value=on \
                    "$@"
             # Emulate the host CPU closely in both features and cores.
-            set -- -machine q35,accel=kvm:hvf:tcg,smm=on -cpu host -smp "${VM_NCPUS}" "$@"
+            set -- -machine q35,accel=kvm:hvf:tcg,smm=on -cpu host -smp "${VM_NCPUS}" -nographic "$@"
             ;;
         amd64-usr+*)
             set -- -machine q35 -cpu kvm64 -smp 1 -nographic "$@" ;;


### PR DESCRIPTION
# Add -nographic in `build_library/qemu_template.sh`

Refer https://github.com/flatcar/Flatcar/issues/1687

## Testing done

- Use the flag to boot up flatcar linux image on a headless x86_64 system and it works fine.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [x] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
