### PR TITLE
cpio: do not fail on ghost rootfs

### DIFF
--- a/build_library/extract-initramfs-from-vmlinuz.sh
+++ b/build_library/extract-initramfs-from-vmlinuz.sh
@@ -81,11 +81,9 @@ perform_round() {
     for rnd in "${round_prefix}"*; do
         if [[ $(file --brief "${rnd}") =~ 'cpio archive' ]]; then
             mkdir -p "${out}/rootfs-${ROOTFS_IDX}"
-            while cpio --quiet --extract --make-directories --directory="${out}/rootfs-${ROOTFS_IDX}" --nonmatching 'dev/*'; do
-                ROOTFS_IDX=$(( ROOTFS_IDX + 1 ))
-                mkdir -p "${out}/rootfs-${ROOTFS_IDX}"
-            done <${rnd}
-            rmdir "${out}/rootfs-${ROOTFS_IDX}"
+            # On Linux 6.10, the first rootfs is an extra ghost rootfs of 336K, that has a corrupted CPIO
+            cpio --quiet --extract --make-directories --directory="${out}/rootfs-${ROOTFS_IDX}" --nonmatching 'dev/*' < $rnd || true
+            ROOTFS_IDX=$(( ROOTFS_IDX + 1 ))
         fi
     done
 }


### PR DESCRIPTION
On Linux >= 6.10, the first rootfs is an extra ghost rootfs of 336K, that has a corrupted CPIO.

To overcome this issue, do not fail on `cpio --extract`.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
