### PR TITLE
build_library: Fix path handling in QEMU launcher script

### DIFF
--- a/build_library/qemu_template.sh
+++ b/build_library/qemu_template.sh
@@ -260,9 +260,9 @@ fi
 if [ -n "${VM_IMAGE}" ]; then
     case "${VM_BOARD}" in
         amd64-usr)
-            set -- -drive if=virtio,file="${SCRIPT_DIR}/${VM_IMAGE}" "$@" ;;
+            set -- -drive if=virtio,file="${VM_IMAGE}" "$@" ;;
         arm64-usr)
-            set -- -drive if=none,id=blk,file="${SCRIPT_DIR}/${VM_IMAGE}" \
+            set -- -drive if=none,id=blk,file="${VM_IMAGE}" \
             -device virtio-blk-device,drive=blk "$@"
             ;;
         *) die "Unsupported arch" ;;
@@ -270,11 +270,11 @@ if [ -n "${VM_IMAGE}" ]; then
 fi
 
 if [ -n "${VM_KERNEL}" ]; then
-    set -- -kernel "${SCRIPT_DIR}/${VM_KERNEL}" "$@"
+    set -- -kernel "${VM_KERNEL}" "$@"
 fi
 
 if [ -n "${VM_INITRD}" ]; then
-    set -- -initrd "${SCRIPT_DIR}/${VM_INITRD}" "$@"
+    set -- -initrd "${VM_INITRD}" "$@"
 fi
 
 if [ -n "${VM_UUID}" ]; then
@@ -283,13 +283,13 @@ fi
 
 if [ -n "${VM_CDROM}" ]; then
     set -- -boot order=d \
-	-drive file="${SCRIPT_DIR}/${VM_CDROM}",media=cdrom,format=raw "$@"
+	-drive file="${VM_CDROM}",media=cdrom,format=raw "$@"
 fi
 
 if [ -n "${VM_PFLASH_RO}" ] && [ -n "${VM_PFLASH_RW}" ]; then
     set -- \
-        -drive if=pflash,unit=0,file="${SCRIPT_DIR}/${VM_PFLASH_RO}",format=qcow2,readonly=on \
-        -drive if=pflash,unit=1,file="${SCRIPT_DIR}/${VM_PFLASH_RW}",format=qcow2 "$@"
+        -drive if=pflash,unit=0,file="${VM_PFLASH_RO}",format=qcow2,readonly=on \
+        -drive if=pflash,unit=1,file="${VM_PFLASH_RW}",format=qcow2 "$@"
 fi
 
 if [ -n "${IGNITION_CONFIG_FILE}" ]; then

--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -821,7 +821,7 @@ _write_qemu_conf() {
     local dst_name=$(basename "$VM_DST_IMG")
 
     _write_qemu_common "${script}"
-    sed -e "s%^VM_IMAGE=.*%VM_IMAGE='${dst_name}'%" -i "${script}"
+    sed -e "s%^VM_IMAGE=.*%VM_IMAGE=\"\${SCRIPT_DIR}/${dst_name}\"%" -i "${script}"
 }
 
 _write_qemu_uefi_conf() {
@@ -842,8 +842,8 @@ _write_qemu_uefi_conf() {
             ;;
     esac
 
-    sed -e "s%^VM_PFLASH_RO=.*%VM_PFLASH_RO='${flash_ro}'%" \
-        -e "s%^VM_PFLASH_RW=.*%VM_PFLASH_RW='${flash_rw}'%" -i "${script}"
+    sed -e "s%^VM_PFLASH_RO=.*%VM_PFLASH_RO=\"\${SCRIPT_DIR}/${flash_ro}\"%" \
+        -e "s%^VM_PFLASH_RW=.*%VM_PFLASH_RW=\"\${SCRIPT_DIR}/${flash_rw}\"%" -i "${script}"
     VM_GENERATED_FILES+=( "$(_dst_dir)/${flash_ro}" "$(_dst_dir)/${flash_rw}" )
 
     # We now only support building qemu_uefi and generate the
@@ -899,8 +899,8 @@ _write_pxe_conf() {
     local dst_name=$(basename "$VM_DST_IMG")
 
     _write_qemu_common "${script}"
-    sed -e "s%^VM_KERNEL=.*%VM_KERNEL='${vmlinuz_name}'%" \
-        -e "s%^VM_INITRD=.*%VM_INITRD='${dst_name}'%" -i "${script}"
+    sed -e "s%^VM_KERNEL=.*%VM_KERNEL=\"\${SCRIPT_DIR}/${vmlinuz_name}\"%" \
+        -e "s%^VM_INITRD=.*%VM_INITRD=\"\${SCRIPT_DIR}/${dst_name}\"%" -i "${script}"
 
     cat >>"${VM_README}" <<EOF
 
@@ -925,7 +925,7 @@ _write_iso_conf() {
     local script="$(_dst_dir)/$(_dst_name ".sh")"
     local dst_name=$(basename "$VM_DST_IMG")
     _write_qemu_common "${script}"
-    sed -e "s%^VM_CDROM=.*%VM_CDROM='${dst_name}'%" -i "${script}"
+    sed -e "s%^VM_CDROM=.*%VM_CDROM=\"\${SCRIPT_DIR}/${dst_name}\"%" -i "${script}"
 }
 
 # Generate the vmware config file

--- a/changelog/bugfixes/2025-04-07-qemu-script-paths.md
+++ b/changelog/bugfixes/2025-04-07-qemu-script-paths.md
@@ -1,0 +1,1 @@
+- Fixed path handling in the QEMU .sh launcher scripts. Given paths now are relative to the current directory and absolute paths work as you would expect.


### PR DESCRIPTION
# build_library: Fix path handling in QEMU launcher script

I couldn't take it anymore! The launcher script could not handle paths outside the script's own directory, and it was driving me crazy. Now only the default values are relative to the script's directory. Given paths are relative to the current directory and absolute paths work as you would expect.

## How to use

You don't need to grab any new images, just the .sh files from [bincache](https://bincache.flatcar-linux.net/images/amd64/9999.0.0+qemu-script-paths-2/).

## Testing done

I ran [CI](http://jenkins.infra.kinvolk.io:8080/job/container/job/packages/9100/cldsv/) but without the tests because they don't use this script. I grabbed the new .sh files, compared them against the old ones, and tried them out with different paths.

- [X] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [X] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.