### PR TITLE
overlay coreos: Drop obsolete subreaper key from containerd config

### DIFF
--- a/sdk_container/src/third_party/coreos-overlay/coreos/sysext/containerd/usr/share/containerd/config-cgroupfs.toml
+++ b/sdk_container/src/third_party/coreos-overlay/coreos/sysext/containerd/usr/share/containerd/config-cgroupfs.toml
@@ -4,8 +4,6 @@ version = 2
 root = "/var/lib/containerd"
 # runtime state information
 state = "/run/containerd"
-# set containerd as a subreaper on linux when it is not running as PID 1
-subreaper = true
 # set containerd's OOM score
 oom_score = -999
 disabled_plugins = []

--- a/sdk_container/src/third_party/coreos-overlay/coreos/sysext/containerd/usr/share/containerd/config.toml
+++ b/sdk_container/src/third_party/coreos-overlay/coreos/sysext/containerd/usr/share/containerd/config.toml
@@ -4,8 +4,6 @@ version = 2
 root = "/var/lib/containerd"
 # runtime state information
 state = "/run/containerd"
-# set containerd as a subreaper on linux when it is not running as PID 1
-subreaper = true
 # set containerd's OOM score
 oom_score = -999
 disabled_plugins = []


### PR DESCRIPTION
This key was first renamed to no_subreaper in 2017, then eventually dropped. Now containerd prints a warning like:

time="2025-04-08T22:59:42Z" level=warning msg="Ignoring unknown key in TOML" column=1 error="strict mode: fields in the document are missing in the target struct" file=/usr/share/containerd/config.toml key=subreaper row=8

There seem to be no replacement for it, so just drop it.