### PR TITLE
Drop confusing and obsolete binpkg-related code

### DIFF
--- a/build_library/dev_container_util.sh
+++ b/build_library/dev_container_util.sh
@@ -38,8 +38,7 @@ CHOST=$(get_board_chost $BOARD)
 DISTDIR="/var/lib/portage/distfiles"
 PKGDIR="/var/lib/portage/pkgs"
 PORT_LOGDIR="/var/log/portage"
-PORTAGE_BINHOST="$(get_binhost_url "${binhost}" "${update_group}" 'pkgs')
-$(get_binhost_url "${binhost}" "${update_group}" 'toolchain')"
+PORTAGE_BINHOST="$(get_binhost_url "${binhost}" "${update_group}" 'pkgs')"
 EOF
 
     sudo_clobber "${root_fs_dir}/etc/portage/repos.conf/portage-stable.conf" <<EOF

--- a/build_packages
+++ b/build_packages
@@ -24,8 +24,6 @@ DEFINE_boolean getbinpkg "${FLAGS_TRUE}" \
   "Download binary packages from remote repository."
 DEFINE_string getbinpkgver "" \
   "Use binary packages from a specific version."
-DEFINE_boolean toolchainpkgonly "${FLAGS_FALSE}" \
-  "Use binary packages only for the board toolchain."
 DEFINE_boolean workon "${FLAGS_TRUE}" \
   "Automatically rebuild updated flatcar-workon packages."
 DEFINE_boolean fetchonly "${FLAGS_FALSE}" \
@@ -99,11 +97,6 @@ if [ "${FLAGS_usepkg}" -eq "${FLAGS_TRUE}" ]; then
     UPDATE_ARGS+=( --getbinpkg )
   else
     UPDATE_ARGS+=( --nogetbinpkg )
-  fi
-  if [[ "${FLAGS_toolchainpkgonly}" -eq "${FLAGS_TRUE}" ]]; then
-    UPDATE_ARGS+=( --toolchainpkgonly )
-  else
-    UPDATE_ARGS+=( --notoolchainpkgonly )
   fi
   if [[ -n "${FLAGS_getbinpkgver}" ]]; then
     UPDATE_ARGS+=( --getbinpkgver="${FLAGS_getbinpkgver}" )

--- a/set_version
+++ b/set_version
@@ -43,8 +43,7 @@ Usage: $0 FLAGS...
   --file FILE:                                     Modify another file than ${FILE}, useful if run
                                                    outside of the SDK chroot. If /dev/stdout or
                                                    /dev/stderr is used, only new values are printed.
-  --binhost                                        Use a custom binhost (defaults to '${DEFAULT_BASE_URL}'),
-                                                   e.g., '${SETTING_BINPKG_SERVER_DEV}'.
+  --binhost                                        Use a custom binhost (defaults to '${DEFAULT_BASE_URL}').
                                                    This will update BOARD and SDK URLs accordingly.
 "
   exit 1

--- a/settings.env
+++ b/settings.env
@@ -4,5 +4,4 @@
 SETTING_BINPKG_SERVER_PROD="https://mirror.release.flatcar-linux.net"
 
 # development servers / bin caches.
-SETTING_BINPKG_SERVER_DEV="https://bucket.release.flatcar-linux.net/flatcar-jenkins"
 SETTING_BINPKG_SERVER_DEV_CONTAINERISED="https://bincache.flatcar-linux.net"

--- a/setup_board
+++ b/setup_board
@@ -31,8 +31,6 @@ DEFINE_string pkgdir "" \
   "Use binary packages from a custom directory instead of /build/[ARCH]/var/lib/portage/pkgs/."
 DEFINE_string binhost "" \
   "Use binary packages from a specific location instead of $FLATCAR_DEV_BUILDS/... "
-DEFINE_boolean toolchainpkgonly "${FLAGS_FALSE}" \
-  "Use binary packages only for the board toolchain."
 DEFINE_boolean skip_toolchain_update "${FLAGS_FALSE}" \
   "Don't update toolchain automatically."
 DEFINE_boolean skip_chroot_upgrade "${FLAGS_FALSE}" \
@@ -136,13 +134,11 @@ EOF
 }
 
 generate_binhost_list() {
-  local t
-  [[ "${FLAGS_toolchainpkgonly}" -eq "${FLAGS_TRUE}" ]] && t="-t"
   FLAGS_getbinpkgver="${FLAGS_getbinpkgver/current/${FLATCAR_VERSION_ID}}"
   FLAGS_getbinpkgver="${FLAGS_getbinpkgver/latest/${FLATCAR_VERSION_ID}}"
   FLAGS_getbinpkgver="${FLAGS_getbinpkgver/sdk/${FLATCAR_SDK_VERSION}}"
 
-  get_board_binhost $t "${BOARD}" ${FLAGS_getbinpkgver}
+  get_board_binhost "${BOARD}" ${FLAGS_getbinpkgver}
 }
 
 # Parse command line flags


### PR DESCRIPTION
# Drop confusing and obsolete binpkg-related code

I got very confused while looking into how the dev container is built. This code didn't help. I think it can be dropped.

## How to use

N/A

## Testing done

I have run [amd64 and arm64 builds](http://jenkins.infra.kinvolk.io:8080/job/container/job/packages/9267/cldsv/) with the qemu_* tests. They passed successfully.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update) -- **N/A**
- [X] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
