### PR TITLE
Simplify and improve flatcar_production_qemu*.sh script

### DIFF
--- a/build_library/qemu_template.sh
+++ b/build_library/qemu_template.sh
@@ -258,15 +258,8 @@ if [ -n "${CONFIG_IMAGE}" ]; then
 fi
 
 if [ -n "${VM_IMAGE}" ]; then
-    case "${VM_BOARD}" in
-        amd64-usr)
-            set -- -drive if=virtio,file="${VM_IMAGE}" "$@" ;;
-        arm64-usr)
-            set -- -drive if=none,id=blk,file="${VM_IMAGE}" \
-            -device virtio-blk-device,drive=blk "$@"
-            ;;
-        *) die "Unsupported arch" ;;
-    esac
+    set -- -drive if=none,id=blk,file="${VM_IMAGE}" \
+        -device virtio-blk-pci,drive=blk,bootindex=1 "$@"
 fi
 
 if [ -n "${VM_KERNEL}" ]; then

--- a/build_library/qemu_template.sh
+++ b/build_library/qemu_template.sh
@@ -291,25 +291,18 @@ fi
 
 case "${VM_BOARD}" in
     amd64-usr)
-        # Default to KVM, fall back on full emulation
-        qemu-system-x86_64 \
-            -name "$VM_NAME" \
-            -m ${VM_MEMORY} \
-            -netdev user,id=eth0${QEMU_FORWARDED_PORTS:+,}${QEMU_FORWARDED_PORTS},hostfwd=tcp::"${SSH_PORT}"-:22,hostname="${VM_NAME}" \
-            -device virtio-net-pci,netdev=eth0 \
-            -object rng-random,filename=/dev/urandom,id=rng0 -device virtio-rng-pci,rng=rng0 \
-            "$@"
-        ;;
+        QEMU_BIN=qemu-system-x86_64 ;;
     arm64-usr)
-        qemu-system-aarch64 \
-            -name "$VM_NAME" \
-            -m ${VM_MEMORY} \
-            -netdev user,id=eth0${QEMU_FORWARDED_PORTS:+,}${QEMU_FORWARDED_PORTS},hostfwd=tcp::"${SSH_PORT}"-:22,hostname="${VM_NAME}" \
-            -device virtio-net-device,netdev=eth0 \
-            -object rng-random,filename=/dev/urandom,id=rng0 -device virtio-rng-pci,rng=rng0 \
-            "$@"
-        ;;
+        QEMU_BIN=qemu-system-aarch64 ;;
     *) die "Unsupported arch" ;;
 esac
+
+"$QEMU_BIN" \
+    -name "$VM_NAME" \
+    -m ${VM_MEMORY} \
+    -netdev user,id=eth0${QEMU_FORWARDED_PORTS:+,}${QEMU_FORWARDED_PORTS},hostfwd=tcp::"${SSH_PORT}"-:22,hostname="${VM_NAME}" \
+    -device virtio-net-pci,netdev=eth0 \
+    -object rng-random,filename=/dev/urandom,id=rng0 -device virtio-rng-pci,rng=rng0 \
+    "$@"
 
 exit $?

--- a/build_library/qemu_template.sh
+++ b/build_library/qemu_template.sh
@@ -55,8 +55,8 @@ used as an explicit separator. See the qemu(1) man page for more details.
 "
 
 die(){
-	echo "${1}"
-	exit 1
+    echo "${1}"
+    exit 1
 }
 
 check_conflict() {
@@ -276,7 +276,7 @@ fi
 
 if [ -n "${VM_CDROM}" ]; then
     set -- -boot order=d \
-	-drive file="${VM_CDROM}",media=cdrom,format=raw "$@"
+        -drive file="${VM_CDROM}",media=cdrom,format=raw "$@"
 fi
 
 if [ -n "${VM_PFLASH_RO}" ] && [ -n "${VM_PFLASH_RW}" ]; then


### PR DESCRIPTION
How disk and network devices are set up for the machine need not to be arch-specific any more. We can use virtio-blk-pci and virtio-net-pci on both arches.

This PR also adds two options:
- `-D` or `-image-disk-opts` for adding options to primary disk (I used it mostly to add "serial=foo", so primary disk is available under `/dev/disk/by-id/virtio-foo` and its partitions as `/dev/disk/by-id/virtio-foo-partN`)
- `-d` or `-disk` for adding extra disks - you can do `qemu-img create -f qcow2 extradisk 1G`, and then invoke the script with `-d extradisk,serial=my-extra-disk` to have it available under `/dev/disk/by-id/virtio-my-extra-disk`

Tested locally on both amd64 and arm64.