### PR TITLE
pkg-auto: Mark in-rootfs sysexts as sysexts in reports

### DIFF
--- a/pkg_auto/impl/pkg_auto_lib.sh
+++ b/pkg_auto/impl/pkg_auto_lib.sh
@@ -562,7 +562,7 @@ EOF
                     tag=${stripped#oem-}
                     ;;
                 *'-flatcar')
-                    tag=${stripped%-flatcar}
+                    tag="sysext-${stripped%-flatcar}"
                     ;;
                 *)
                     devel_warn "Unknown listing file ${packages_file@Q}"


### PR DESCRIPTION
They were showing up as "docker" or "containerd" in the reports, which is confusing. "sysext-docker" or "sysext-containerd" makes it clear.

A follow-up to https://github.com/flatcar/scripts/pull/2860#discussion_r2068150326.