### PR TITLE
build_library: Fix extraction script and sort content listings

### DIFF
--- a/build_library/extract-initramfs-from-vmlinuz.sh
+++ b/build_library/extract-initramfs-from-vmlinuz.sh
@@ -53,7 +53,7 @@ if [[ ! -s "${image}" ]]; then
 fi
 mkdir -p "${out}"
 
-tmp=$(mktemp --directory eifv-XXXXXX)
+tmp=$(mktemp --directory -t eifv-XXXXXX)
 trap 'rm -rf -- "${tmp}"' EXIT
 ROOTFS_IDX=0
 

--- a/build_library/extract-initramfs-from-vmlinuz.sh
+++ b/build_library/extract-initramfs-from-vmlinuz.sh
@@ -29,8 +29,12 @@ try_extract() {
     # cpio can do strange things when given garbage, so do a basic check.
     [[ $(head -c6 "$1") == 070701 ]] || return 0
 
-    # There may be multiple concatenated archives so try cpio till it fails.
-    while cpio --quiet --extract --make-directories --directory="${out}/rootfs-${ROOTFS_IDX}" --nonmatching 'dev/*' 2>/dev/null; do
+    while {
+        # cpio needs the directory to exist first. Fail if it's already there.
+        { mkdir "${out}/rootfs-${ROOTFS_IDX}" || return $?; } &&
+        # There may be multiple concatenated archives so try cpio till it fails.
+        cpio --quiet --extract --make-directories --directory="${out}/rootfs-${ROOTFS_IDX}" --nonmatching 'dev/*' 2>/dev/null
+    }; do
         ROOTFS_IDX=$(( ROOTFS_IDX + 1 ))
     done < "$1"
 

--- a/build_library/reports_util.sh
+++ b/build_library/reports_util.sh
@@ -33,6 +33,7 @@ write_contents() {
     # %l - symlink target (empty if not a symlink)
     sudo TZ=UTC find -printf \
         '%M %2n %-7u %-7g %7s %TY-%Tm-%Td %TH:%TM ./%P -> %l\n' \
+        | sort --key=8 \
         | sed -e 's/ -> $//' >"${output}"
     popd >/dev/null
 }
@@ -57,7 +58,8 @@ write_contents_with_technical_details() {
     # %s - size in bytes
     # %P - file's path
     sudo find -printf \
-        '%M %D %i %n %s ./%P\n' >"${output}"
+        '%M %D %i %n %s ./%P\n' \
+        | sort --key=6 >"${output}"
     popd >/dev/null
 }
 


### PR DESCRIPTION
# build_library: Fix extraction script and sort content listings

I thought cpio was always creating the output directory automatically, but it was silently failing. It would only extract the next rootfs when run a subsequent time. I must admit that I don't know why it was apparently still working in CI, but it was definitely failing for me locally.

While fixing the above, I also decided to sort the content listings for more consistent output.

## How to use

N/A

## Testing done

Examples of the new initrd contents can be seen [here](https://bincache.flatcar-linux.net/images/arm64/9999.0.0+chewi-misc-1/flatcar_production_image_initrd_contents.txt) and [here](https://bincache.flatcar-linux.net/images/arm64/9999.0.0+chewi-misc-1/flatcar_production_image_initrd_contents_wtd.txt). The [image_changes output](http://jenkins.infra.kinvolk.io:8080/job/container/job/image_changes/10080/console) still looks good.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update) -- **N/A**
- [X] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.