### PR TITLE
ci-automation: add akamai testing

### DIFF
--- a/ci-automation/ci-config.env
+++ b/ci-automation/ci-config.env
@@ -173,3 +173,9 @@ BRIGHTBOX_PARALLEL="${PARALLEL_TESTS:-1}"
 : ${HETZNER_arm64_LOCATION:="fsn1"}
 : ${HETZNER_amd64_LOCATION:="hel1"}
 HETZNER_PARALLEL="${PARALLEL_TESTS:-1}"
+
+# -- Akamai --
+: ${AKAMAI_IMAGE_NAME:='flatcar_production_akamai_image.bin.gz'}
+AKAMAI_PARALLEL="${PARALLEL_TESTS:-1}"
+AKAMAI_REGION="us-ord"
+AKAMAI_INSTANCE_TYPE="g6-standard-2"

--- a/ci-automation/garbage_collect.sh
+++ b/ci-automation/garbage_collect.sh
@@ -263,6 +263,7 @@ function _garbage_collect_impl() {
       --env VMWARE_ESX_CREDS \
       --env OPENSTACK_CREDS \
       --env BRIGHTBOX_CLIENT_ID --env BRIGHTBOX_CLIENT_SECRET \
+      --env AKAMAI_TOKEN \
       -w /work -v "$PWD":/work "${mantle_ref}" /work/ci-automation/garbage_collect_cloud.sh
 
     echo

--- a/ci-automation/garbage_collect_cloud.sh
+++ b/ci-automation/garbage_collect_cloud.sh
@@ -11,6 +11,8 @@ timeout --signal=SIGQUIT 60m ore openstack gc --duration 6h \
   --config-file=<(echo "${OPENSTACK_CREDS}" | base64 --decode)
 timeout --signal=SIGQUIT 60m ore brightbox gc --duration 6h \
   --brightbox-client-id="${BRIGHTBOX_CLIENT_ID}" --brightbox-client-secret="${BRIGHTBOX_CLIENT_SECRET}"
+timeout --signal=SIGQUIT 60m ore akamai gc --duration 6h \
+  --akamai-token="${AKAMAI_TOKEN}"
 secret_to_file aws_credentials_config_file "${AWS_CREDENTIALS}"
 for channel in alpha beta stable lts; do
   for arch in amd64 arm64; do

--- a/ci-automation/vendor-testing/akamai.sh
+++ b/ci-automation/vendor-testing/akamai.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Copyright (c) 2023 The Flatcar Maintainers.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+set -euo pipefail
+
+# Test execution script for Akamai vendor.
+# This script is supposed to run in the mantle container.
+
+source ci-automation/vendor_test.sh
+
+copy_from_buildcache "images/${CIA_ARCH}/${CIA_VERNUM}/${AKAMAI_IMAGE_NAME}" .
+
+kola_test_basename="ci-${CIA_VERNUM//[+.]/-}"
+
+# Upload the image on Akamai.
+IMAGE_ID=$(ore akamai \
+  --akamai-token="${AKAMAI_TOKEN}" \
+  --akamai-region="${AKAMAI_REGION}" \
+  create-image \
+  --name "${kola_test_basename}" \
+  --file="${AKAMAI_IMAGE_NAME}"
+)
+
+set -x
+
+timeout --signal=SIGQUIT 2h kola run \
+  --board="${CIA_ARCH}-usr" \
+  --parallel="${AKAMAI_PARALLEL}" \
+  --tapfile="${CIA_TAPFILE}" \
+  --channel="${CIA_CHANNEL}" \
+  --basename="${kola_test_basename}" \
+  --platform=akamai \
+  --akamai-token="${AKAMAI_TOKEN}" \
+  --akamai-type="${AKAMAI_INSTANCE_TYPE}" \
+  --akamai-region="${AKAMAI_REGION}" \
+  --akamai-image="${IMAGE_ID}" \
+  --image-version "${CIA_VERNUM}" \
+  "${@}"
+
+set +x


### PR DESCRIPTION
In this PR we add the "glue" to test Akamai in Flatcar's CI - Mantle implementation has been done previously. This promotes Akamai support to an "official" support (i.e it's tested in the CI in nightlies and before each release).

Needs:
- [x] https://github.com/flatcar/mantle/pull/601
- [x] https://github.com/flatcar/mantle/pull/602
- [x] https://github.com/flatcar/jenkins-os/pull/367
- [x] CI: http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/5921/cldsv/ (it failed because `cl.cloudinit.basic` was still around, this is fixed in the Mantle PR)

Closes: https://github.com/flatcar/Flatcar/issues/1404