### PR TITLE
pkg-auto: Fix occurences generation

### DIFF
--- a/pkg_auto/impl/pkg_auto_lib.sh
+++ b/pkg_auto/impl/pkg_auto_lib.sh
@@ -2742,7 +2742,7 @@ function grep_pkg() {
     pkg=${1}; shift
     # rest are directories
 
-    GIT_PAGER='' git -C "${scripts}" grep "${pkg}"'\(-[0-9]\|[^a-zA-Z0-9_-]\|$\)' -- "${@}" || :
+    GIT_PAGER='' git -C "${scripts}" grep "${pkg}"'\(-[0-9$]\|[^a-zA-Z0-9_-]\|$\)' -- "${@}" || :
 }
 
 # Prints the passed files preceding and following with BEGIN ENTRY and


### PR DESCRIPTION
Occurences file shows where the package name shows up in the repository. It tries to be smart, so that checking for sys-devel/gcc will not be showing sys-devel/gcc-config. But the smart check was flawed as it ignored the forms like sys-devel/gcc-${PV}. Noticed when trying to check occurences for sys-libs/libsepol and there were not enough occurences shown.
