### PR TITLE
workflow: update mantle branch to main

### DIFF
--- a/.github/workflows/mantle-releases-main.yml
+++ b/.github/workflows/mantle-releases-main.yml
@@ -55,7 +55,7 @@ jobs:
         id: fetch-latest-mantle
         run: |
           set -euo pipefail
-          commit=$(git ls-remote  https://github.com/flatcar/mantle refs/heads/flatcar-master | cut -f1)
+          commit=$(git ls-remote  https://github.com/flatcar/mantle refs/heads/main | cut -f1)
           echo "COMMIT=${commit}" >>"${GITHUB_OUTPUT}"
       - name: Try to apply patch
         if: ${{ steps.figure-out-branch.outputs.SKIP == 0 }}


### PR DESCRIPTION
In this PR, we update the Mantle default branch to `main`.

Follow-up from: https://github.com/flatcar/mantle/pull/605

Tested here: https://github.com/flatcar/scripts/actions/runs/15110156421