### PR TITLE
profiles: mask libp11 0.4.13

### DIFF
--- a/sdk_container/src/third_party/coreos-overlay/profiles/coreos/base/package.mask
+++ b/sdk_container/src/third_party/coreos-overlay/profiles/coreos/base/package.mask
@@ -15,6 +15,12 @@
 # up. Update this to mask later versions when we switch to 3.11.
 >=dev-lang/python-3.12
 
+# From this version, the lib creates some issues
+# with Secure Boot signing image using Azure libpkcs11:
+#  dataFinal failed
+#  401774B96D7F0000:error:020000B3:rsa routines:rsa_ossl_private_encrypt:missing private key:../openssl-3.3.3/crypto/rsa/rsa_ossl.c:367:
+>=dev-libs/libp11-0.4.13
+
 # Update engine needs updating to use a newer version of protobuf.
 >=dev-libs/protobuf-22.0
 


### PR DESCRIPTION
This seems to make Secure Boot image signing to fail:
```
 AZURE_KEYVAULT: Getting public key for key flatcar-sb-dev-hsm-sign-2025
 AZURE_KEYVAULT: Successfully got public key for key flatcar-sb-dev-hsm-sign-2025
 AZURE_KEYVAULT: Key flatcar-sb-dev-hsm-sign-2025 is an RSA key
 dataFinal failed
 401774B96D7F0000:error:020000B3:rsa routines:rsa_ossl_private_encrypt:missing private key:../openssl-3.3.3/crypto/rsa/rsa_ossl.c:367:
```

This can be lifted once we fix the issue upstream.

## Testing done

```
sdk@flatcar-sdk-amd64-4343_0_0-nightly-20250522-2100_os-main-4343_0 ~/trunk/src/scripts $ emerge -pv libp11

These are the packages that would be merged, in order:

Calculating dependencies... done!
Dependency resolution took 1.71 s (backtrack: 0/20).

[ebuild     U  ] app-portage/elt-patches-20250306::portage-stable [20241121::portage-stable] 0 KiB
[ebuild   R    ] dev-libs/libp11-0.4.12-r7::portage-stable  USE="-doc -static-libs -test" 505 KiB

Total: 2 packages (1 upgrade, 1 reinstall), Size of downloads: 505 KiB
```

- [x] ~Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)~
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
