### PR TITLE
Update documentation and ebuilds to reference `main` branch instead `flatcar-master`

### DIFF
--- a/PREFIX.md
+++ b/PREFIX.md
@@ -12,7 +12,7 @@ Before prefix build support are considered stable, the below must be implemented
    Prefix builds currently use the SDK cross toolchains (`/usr/<arch>-gnu/`) instead of board toolchains in `/build/<board>`.
    Prefix builds must be integrated with the board toolchains and stop using `cb-emerge` before considered stable.
 3. Add prefix wrappers for all portage tools (similar to board wrappers), not just `emerge`.
-4. Add test cases for prefix builds to [mantle/kola](https://github.com/flatcar/mantle/tree/flatcar-master/kola).
+4. Add test cases for prefix builds to [mantle/kola](https://github.com/flatcar/mantle/tree/main/kola).
 
 ## About
 

--- a/ci-automation/README.md
+++ b/ci-automation/README.md
@@ -125,7 +125,7 @@ Optionally, patterns matching a group of tests can be supplied (or simply a list
 
 Testing is implemented in two layers:
 1. `ci-automation/test.sh` is a generic test wrapper / stub to be called from CI.
-2. `ci-automation/vendor-testing/` contains low-level vendor-specific test wrappers around [`kola`](https://github.com/flatcar/mantle/tree/flatcar-master/kola/), our test scenario orchestrator.
+2. `ci-automation/vendor-testing/` contains low-level vendor-specific test wrappers around [`kola`](https://github.com/flatcar/mantle/tree/main/kola/), our test scenario orchestrator.
 
 Testing relies on the SDK container and will use tools / test suites from the SDK.
 The low-level vendor / image specific script (layer 2. in the list above) runs inside the SDK.

--- a/sdk_container/src/third_party/coreos-overlay/app-admin/toolbox/toolbox-9999.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/app-admin/toolbox/toolbox-9999.ebuild
@@ -7,7 +7,7 @@ EGIT_REPO_URI="https://github.com/flatcar/toolbox.git"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm64"
 else
-	EGIT_COMMIT="fce9ba2bbd55e1835af72952bfbb7aed6be75606" # flatcar-master
+	EGIT_COMMIT="fce9ba2bbd55e1835af72952bfbb7aed6be75606" # main
 	KEYWORDS="amd64 arm64"
 fi
 

--- a/sdk_container/src/third_party/coreos-overlay/coreos-base/update-ssh-keys/update-ssh-keys-9999.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/coreos-base/update-ssh-keys/update-ssh-keys-9999.ebuild
@@ -9,7 +9,7 @@ if [[ ${PV} == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm64"
 	CRATES=""
 else
-	EGIT_COMMIT="be3ce2acc50313a6826c578e9dbb67e17085d60d" # flatcar-master
+	EGIT_COMMIT="be3ce2acc50313a6826c578e9dbb67e17085d60d" # main
 	KEYWORDS="amd64 arm64"
 
 	CRATES="

--- a/sdk_container/src/third_party/coreos-overlay/sys-libs/nss-usrfiles/nss-usrfiles-9999.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/sys-libs/nss-usrfiles/nss-usrfiles-9999.ebuild
@@ -7,7 +7,7 @@ EGIT_REPO_URI="https://github.com/flatcar/nss-altfiles.git"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	EGIT_COMMIT="c8e05a08a2e28eb48c6c788e3007d94f8d8de5cd" # flatcar-master
+	EGIT_COMMIT="c8e05a08a2e28eb48c6c788e3007d94f8d8de5cd" # main
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pull request updates references from the `flatcar-master` branch to the `main` branch across various files and documentation. The changes ensure consistency with the updated branch naming convention.

### Documentation updates:
* Updated the link to `kola` in `PREFIX.md` to reference the `main` branch instead of `flatcar-master`.
* Updated the link to `kola` in `ci-automation/README.md` to reference the `main` branch instead of `flatcar-master`.

### Ebuild file updates:
* Changed the `EGIT_COMMIT` comment in `toolbox-9999.ebuild` to reference `main` instead of `flatcar-master`.
* Changed the `EGIT_COMMIT` comment in `update-ssh-keys-9999.ebuild` to reference `main` instead of `flatcar-master`.
* Changed the `EGIT_COMMIT` comment in `nss-usrfiles-9999.ebuild` to reference `main` instead of `flatcar-master`.

This is in reference to this issue: https://github.com/flatcar/Flatcar/issues/1714
