### PR TITLE
app-emulation/hv-daemons: use correct array syntax

### DIFF
--- a/sdk_container/src/third_party/coreos-overlay/app-emulation/hv-daemons/hv-daemons-9999.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/app-emulation/hv-daemons/hv-daemons-9999.ebuild
@@ -20,7 +20,7 @@ src_compile() {
 src_install() {
     local -a HV_DAEMONS=(hv_vss_daemon hv_kvp_daemon hv_fcopy_daemon hv_fcopy_uio_daemon)
     local HV_DAEMON
-    for HV_DAEMON in "$HV_DAEMONS[@]"
+    for HV_DAEMON in "${HV_DAEMONS[@]}"
     do
         if [ -f "${S}/build/tools/hv/${HV_DAEMON}" ]; then
             dobin "${S}/build/tools/hv/${HV_DAEMON}"


### PR DESCRIPTION
The array is not expanded without the brackets.

## Testing done

Before:
```
~/trunk/src/scripts $ equery f hv-daemons
 * Searching for hv-daemons ...
 * Contents of app-emulation/hv-daemons-6.12.30:
```

After:
```
 ~/trunk/src/scripts $ equery f hv-daemons
 * Searching for hv-daemons ...
 * Contents of app-emulation/hv-daemons-6.12.30:
/usr
/usr/bin
/usr/bin/hv_fcopy_uio_daemon
/usr/bin/hv_kvp_daemon
/usr/bin/hv_vss_daemon
/usr/lib
/usr/lib/systemd
/usr/lib/systemd/system
/usr/lib/systemd/system/hv_fcopy_uio_daemon.service
/usr/lib/systemd/system/hv_kvp_daemon.service
/usr/lib/systemd/system/hv_vss_daemon.service
/usr/lib/systemd/system/multi-user.target.wants
/usr/lib/systemd/system/multi-user.target.wants/hv_fcopy_uio_daemon.service -> ../hv_fcopy_uio_daemon.service
/usr/lib/systemd/system/multi-user.target.wants/hv_kvp_daemon.service -> ../hv_kvp_daemon.service
/usr/lib/systemd/system/multi-user.target.wants/hv_vss_daemon.service -> ../hv_vss_daemon.service
```


- [x] ~Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)~
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
