### PR TITLE
build_library: Fix depmod issues with sysext kmods

### DIFF
--- a/build_library/sysext_mangle_flatcar-nvidia-drivers-535
+++ b/build_library/sysext_mangle_flatcar-nvidia-drivers-535
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -euo pipefail
+
+SCRIPT_NAME=$(basename "$(realpath "${BASH_SOURCE[0]}")")
+SYSEXT_NAME=${SCRIPT_NAME#sysext_mangle_}
+SYSEXT_NAME=${SYSEXT_NAME%.sh}
+DIR=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
+. "$DIR/sysext_mangle_kmod"
+
+rootfs="${1}"
+
+cd "${rootfs}"
+configure_modprobe "$SYSEXT_NAME"

--- a/build_library/sysext_mangle_flatcar-nvidia-drivers-535-open
+++ b/build_library/sysext_mangle_flatcar-nvidia-drivers-535-open
@@ -1,0 +1,1 @@
+sysext_mangle_flatcar-nvidia-drivers-535

--- a/build_library/sysext_mangle_flatcar-nvidia-drivers-550
+++ b/build_library/sysext_mangle_flatcar-nvidia-drivers-550
@@ -1,0 +1,1 @@
+sysext_mangle_flatcar-nvidia-drivers-535

--- a/build_library/sysext_mangle_flatcar-nvidia-drivers-550-open
+++ b/build_library/sysext_mangle_flatcar-nvidia-drivers-550-open
@@ -1,0 +1,1 @@
+sysext_mangle_flatcar-nvidia-drivers-535

--- a/build_library/sysext_mangle_flatcar-nvidia-drivers-570
+++ b/build_library/sysext_mangle_flatcar-nvidia-drivers-570
@@ -1,0 +1,1 @@
+sysext_mangle_flatcar-nvidia-drivers-535

--- a/build_library/sysext_mangle_flatcar-nvidia-drivers-570-open
+++ b/build_library/sysext_mangle_flatcar-nvidia-drivers-570-open
@@ -1,0 +1,1 @@
+sysext_mangle_flatcar-nvidia-drivers-535

--- a/build_library/sysext_mangle_flatcar-zfs
+++ b/build_library/sysext_mangle_flatcar-zfs
@@ -3,6 +3,9 @@
 set -euo pipefail
 rootfs="${1}"
 
+DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+. "$DIR/sysext_mangle_kmod"
+
 pushd "${rootfs}"
 
 rm -rf ./usr/{lib/debug/,lib64/cmake/,include/}
@@ -40,4 +43,5 @@ cat <<EOF >./usr/lib/systemd/system/systemd-udevd.service.d/10-zfs.conf
 [Unit]
 After=systemd-sysext.service
 EOF
+configure_modprobe flatcar-zfs
 popd

--- a/build_library/sysext_mangle_kmod
+++ b/build_library/sysext_mangle_kmod
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+configure_modprobe() {
+  local sysext_name="${1}"
+  shift
+
+  local module_directories=(./usr/lib/modules/*-flatcar/)
+
+  mkdir -p ./usr/lib/modprobe.d/
+  for module_name in $(find "${module_directories[@]}" -type f \( -name "*.ko" -o -name "*.ko.*" \) -printf "%f\n" | sed -E 's/\.ko(\.\w+)?$//'); do
+    cat <<EOF >> "./usr/lib/modprobe.d/10-${sysext_name}-kmod-sysext.conf"
+install $module_name /usr/libexec/_${sysext_name}_modprobe_helper $module_name
+remove $module_name /usr/libexec/_${sysext_name}_modprobe_helper -r $module_name
+EOF
+  done
+
+  mkdir -p ./usr/libexec/
+  install -m0755 -D /dev/stdin "./usr/libexec/_${sysext_name}_modprobe_helper" <<'EOF'
+#!/bin/bash
+
+set -euo pipefail
+
+action="Loading"
+for arg in "$@"; do
+    if [[ $arg == "-r" ]]; then
+        action="Unloading"
+    fi
+done
+echo "$action kernel module from a sysext..."
+
+KMOD_PATH=/usr/lib/modules/$(uname -r)
+TMP_DIR=$(mktemp -d)
+trap "rm -rf -- '${TMP_DIR}'" EXIT
+mkdir "${TMP_DIR}"/{upper,work}
+
+unshare -m bash -s -- "${@}" <<FOE
+set -euo pipefail
+if ! mountpoint -q "${KMOD_PATH}"; then
+    mount -t overlay overlay -o lowerdir="${KMOD_PATH}",upperdir="${TMP_DIR}"/upper,workdir="${TMP_DIR}"/work "${KMOD_PATH}"
+    depmod
+fi
+modprobe --ignore-install "\${@}"
+FOE
+EOF
+
+  # prevent the sysext from masking /usr/lib/modules/*-flatcar/modules.XXX
+  find "${module_directories[@]}" -maxdepth 1 -mindepth 1 -type f -delete
+}


### PR DESCRIPTION
# build_library: Fix depmod issues with sysext kmods

OS-dependent sysexts that ship kernel modules, usually also ship the files in `/usr/lib/modules/*-flatcar/modules.XXX` When multiple such sysexts get activated, depmod files from just one sysext win and other kernel modules cannot be loaded using modprobe. We get around this by removing the depmod files from every sysext with kernel modules. Instead, we set up modprobe hook, which dynamically runs depmod in a temporary directory on every sysext kernel module activation.

Fixes: [Flatcar #1576](https://github.com/flatcar/Flatcar/issues/1576)

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
