### PR TITLE
Update EGIT_COMMIT references from 'master' to 'main' in ebuild files

### DIFF
--- a/sdk_container/src/third_party/coreos-overlay/app-admin/sdnotify-proxy/sdnotify-proxy-9999.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/app-admin/sdnotify-proxy/sdnotify-proxy-9999.ebuild
@@ -10,7 +10,7 @@ inherit coreos-go git-r3
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm64"
 else
-	EGIT_COMMIT="0f8ef1aa86c59fc6d54eadaffb248feaccd1018b" # master
+	EGIT_COMMIT="0f8ef1aa86c59fc6d54eadaffb248feaccd1018b" # main
 	KEYWORDS="amd64 arm64"
 fi
 

--- a/sdk_container/src/third_party/coreos-overlay/coreos-base/coreos-cloudinit/coreos-cloudinit-9999.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/coreos-base/coreos-cloudinit/coreos-cloudinit-9999.ebuild
@@ -10,7 +10,7 @@ inherit git-r3 systemd toolchain-funcs udev coreos-go
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm64"
 else
-	EGIT_COMMIT="1c1d7f4ae6b933350d7fd36e882dda170123cccc" # flatcar-master
+	EGIT_COMMIT="1c1d7f4ae6b933350d7fd36e882dda170123cccc" # main
 	KEYWORDS="amd64 arm64"
 fi
 

--- a/sdk_container/src/third_party/coreos-overlay/sys-apps/seismograph/seismograph-9999.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/sys-apps/seismograph/seismograph-9999.ebuild
@@ -7,7 +7,7 @@ EGIT_REPO_URI="https://github.com/flatcar/seismograph.git"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	EGIT_COMMIT="e32ac4d13ca44333dc77e5872dbf23f964b6f1e2" # flatcar-master
+	EGIT_COMMIT="e32ac4d13ca44333dc77e5872dbf23f964b6f1e2" # main
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pull request updates references to branch names in several files to reflect the transition from "master" to "main." These changes ensure consistency with modern naming conventions.

Branch name updates:

* [`sdk_container/src/third_party/coreos-overlay/app-admin/sdnotify-proxy/sdnotify-proxy-9999.ebuild`](diffhunk://#diff-d55a18db8f32467a4570039534a5b94c7dbba08a4362142a1b2ba5eb7d253559L13-R13): Updated the comment next to `EGIT_COMMIT` to use "main" instead of "master."
* [`sdk_container/src/third_party/coreos-overlay/coreos-base/coreos-cloudinit/coreos-cloudinit-9999.ebuild`](diffhunk://#diff-226aa687d82eaeca2d1228ffd4dd2fcdddd57537f9d20e785d0c83d114399fe0L13-R13): Updated the comment next to `EGIT_COMMIT` to use "main" instead of "flatcar-master."
* [`sdk_container/src/third_party/coreos-overlay/sys-apps/seismograph/seismograph-9999.ebuild`](diffhunk://#diff-c0adf527a764b132b335b1ff6aa20af5ae39924fd243eeea98573bce1d2f9054L10-R10): Updated the comment next to `EGIT_COMMIT` to use "main" instead of "flatcar-master."