### PR TITLE
Update EGIT_COMMIT reference from 'flatcar-master' to 'main' in mayda…

### DIFF
--- a/sdk_container/src/third_party/coreos-overlay/app-admin/mayday/mayday-9999.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/app-admin/mayday/mayday-9999.ebuild
@@ -9,7 +9,7 @@ inherit coreos-go git-r3
 if [[ "${PV}" == 9999 ]]; then
     KEYWORDS="~amd64 ~arm64"
 else
-    EGIT_COMMIT="8b9adcf261d13d395659ed839b3ba0af52bd117a" # flatcar-master
+    EGIT_COMMIT="8b9adcf261d13d395659ed839b3ba0af52bd117a" # main
     KEYWORDS="amd64 arm64"
 fi
 


### PR DESCRIPTION
This PR updates default branch references from "master" and "flatcar-master" to "main" to align with modern Git conventions and inclusive naming practices.

This pull request includes a minor update to the `mayday-9999.ebuild` file, where a comment was changed to reflect the correct branch name.

* **Branch name update:**
  - Updated the comment for `EGIT_COMMIT` to replace "flatcar-master" with "main" to align with the current branch naming convention. (`sdk_container/src/third_party/coreos-overlay/app-admin/mayday/mayday-9999.ebuild`, [sdk_container/src/third_party/coreos-overlay/app-admin/mayday/mayday-9999.ebuildL12-R12](diffhunk://#diff-81e17d7aea9e42f5de4ee6b68db45055e0297ece8fced3031acfd773582d8c26L12-R12))

In reference to https://github.com/flatcar/Flatcar/issues/1714