### PR TITLE
docs: add instructions for working with forks and fetching upstream tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,17 @@ To clone the scripts repo and pick a version:
   * list releases (e.g. all Alpha releases): `git tag -l alpha-*`
   * check out the release version, e.g. `3033.0.0`: `git checkout 3033.0.0`
 
+### Working with forks
+
+If you're working with a fork of the scripts repository, you'll need to fetch the upstream tags to avoid version detection issues:
+
+```bash
+git remote add upstream https://github.com/flatcar/scripts.git
+git fetch --tags upstream
+```
+
+This is necessary because the SDK uses `git describe --tags` to determine the current version, and forks don't include the original repository's tags by default.
+
 To use the SDK container:
 * Fetch image and start the SDK container: `./run_sdk_container -t`
   This will fetch the container image of the "scripts" repo's release version you checked out.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ To clone the scripts repo and pick a version:
 When using GitHub's "fork" feature, please **make sure to fork all branches**, not just `main`. Forking only `main` is the default on GitHub,
 
 The SDK container wrapper script `run_sdk_container` requires release tags in our release branches and fails to start if no release branch is present (see e.g. https://github.com/flatcar/Flatcar/issues/1705).
-If you're working with a fork of the scripts repository, you'll need to fetch the upstream tags to avoid version detection issues:
+If you have forked manually, please make sure to include all tags. You can retrofit upstream tags to a fork by using e.g.:
 
 ```bash
 git remote add upstream https://github.com/flatcar/scripts.git

--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ To clone the scripts repo and pick a version:
 
 ### Working with forks
 
+When using GitHub's "fork" feature, please **make sure to fork all branches**, not just `main`. Forking only `main` is the default on GitHub,
+
+The SDK container wrapper script `run_sdk_container` requires release tags in our release branches and fails to start if no release branch is present (see e.g. https://github.com/flatcar/Flatcar/issues/1705).
 If you're working with a fork of the scripts repository, you'll need to fetch the upstream tags to avoid version detection issues:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ To clone the scripts repo and pick a version:
 
 ### Working with forks
 
-When using GitHub's "fork" feature, please **make sure to fork all branches**, not just `main`. Forking only `main` is the default on GitHub,
+When using GitHub's "fork" feature, please **make sure to fork all branches**, not just `main`. Forking only `main` is the default on GitHub.
 
 The SDK container wrapper script `run_sdk_container` requires release tags in our release branches and fails to start if no release branch is present (see e.g. https://github.com/flatcar/Flatcar/issues/1705).
 If you have forked manually, please make sure to include all tags. You can retrofit upstream tags to a fork by using e.g.:


### PR DESCRIPTION
This pull request updates the `README.md` to include instructions for working with forks of the scripts repository. The new section explains how to fetch upstream tags to ensure proper version detection when using the SDK. 

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R105-R115): Added a new section titled "Working with forks" to guide users on fetching upstream tags when working with a fork of the scripts repository. This ensures compatibility with the SDK's version detection mechanism using `git describe --tags`.

Fixes: https://github.com/flatcar/Flatcar/issues/1705