### PR TITLE
sdk_lib: Fix starting the SDK from a fork clone without the tags

### DIFF
--- a/sdk_lib/sdk_container_common.sh
+++ b/sdk_lib/sdk_container_common.sh
@@ -55,7 +55,9 @@ function yell() {
 function get_git_version() {
     local tag="$(git tag --points-at HEAD)"
     if [ -z "$tag" ] ; then
-        git describe --tags
+        # Clones of forks may be missing the tags, so fetch them if necessary.
+        git describe --tags 2>/dev/null ||
+            { git fetch --quiet --tags https://github.com/flatcar/scripts.git && git describe --tags; }
     else
         echo "$tag"
     fi


### PR DESCRIPTION
Closes: https://github.com/flatcar/Flatcar/issues/1705

## How to use

1. Create a fork of this repo (with just main?)
2. Clone it.
3. Try to start the SDK.

## Testing done

The above. @tormath1 has tested it too. I'll run GHA now.