### PR TITLE
sysext: Append to `/etc/subuid` and `/etc/subgid` for podman

### DIFF
--- a/build_library/sysext_mangle_flatcar-podman
+++ b/build_library/sysext_mangle_flatcar-podman
@@ -10,11 +10,11 @@ rm -rf ./usr/{lib/debug/,lib64/cmake/,lib64/pkgconfig,include/,share/fish,share/
 mkdir -p ./usr/share/podman/etc
 cp -a ./etc/{fuse.conf,containers} ./usr/share/podman/etc/
 
-cat <<EOF >>./usr/lib/tmpfiles.d/podman.conf
+cat <<EOF >./usr/lib/tmpfiles.d/podman.conf
 C /etc/containers - - - - /usr/share/podman/etc/containers
 C /etc/fuse.conf - - - - /usr/share/podman/etc/fuse.conf
-w /etc/subuid - - - - core:1065536:65536
-w /etc/subgid - - - - core:1065536:65536
+w+ /etc/subuid - - - - core:1065536:65536
+w+ /etc/subgid - - - - core:1065536:65536
 EOF
 
 popd


### PR DESCRIPTION
# Append to `/etc/subuid` and `/etc/subgid` for podman
Append instead of overwrite `/etc/subuid` and `/etc/subgid`

I copied this behaviour from [sysext_mangle_flatcar-incus](https://github.com/flatcar/scripts/blob/efb5c5d1ffaa39296f273af5ac29b85af71fa935/build_library/sysext_mangle_flatcar-incus#L17-L18)

## How to use
Follow https://github.com/flatcar/Flatcar/issues/1733#issue-3019402596

## Testing done

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
