### PR TITLE
Upgrade toolbox

### DIFF
--- a/changelog/changes/2025-06-20-toolbox-podman.md
+++ b/changelog/changes/2025-06-20-toolbox-podman.md
@@ -1,0 +1,1 @@
+- Added support for podman in `toolbox` ([toolbox#11](https://github.com/flatcar/toolbox/pull/11))

--- a/sdk_container/src/third_party/coreos-overlay/app-admin/toolbox/toolbox-9999.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/app-admin/toolbox/toolbox-9999.ebuild
@@ -7,7 +7,7 @@ EGIT_REPO_URI="https://github.com/flatcar/toolbox.git"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm64"
 else
-	EGIT_COMMIT="fce9ba2bbd55e1835af72952bfbb7aed6be75606" # main
+	EGIT_COMMIT="2fae95b467d6961a396b88d6aa20a9d6bee943c6" # main
 	KEYWORDS="amd64 arm64"
 fi
 


### PR DESCRIPTION
# Upgrade toolbox

The new version of `toolbox` adds support for podman.

Closes https://github.com/flatcar/Flatcar/issues/1778
Relates to https://github.com/flatcar/toolbox/pull/11

## How to use

- [Enable podman](https://www.flatcar.org/docs/latest/provisioning/sysext/#flatcar-release-extensions-official)
- [Disable docker and containerd](https://www.flatcar.org/docs/latest/provisioning/sysext/#remove-docker-and--or-containerd-from-flatcar)
- run toolbox

## Testing done

Ran toolbox in flatcar environment with podman and without docker/containerd

- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
