### PR TITLE
sdk_container/containerd: Add registry config_path

### DIFF
--- a/sdk_container/src/third_party/coreos-overlay/changelog/changes/2025-06-25-containerd-registry-config.md
+++ b/sdk_container/src/third_party/coreos-overlay/changelog/changes/2025-06-25-containerd-registry-config.md
@@ -1,0 +1,1 @@
+- set default containerd [registry config](https://github.com/containerd/containerd/blob/main/docs/hosts.md#cri)

--- a/sdk_container/src/third_party/coreos-overlay/coreos/sysext/containerd/usr/share/containerd/config-cgroupfs.toml
+++ b/sdk_container/src/third_party/coreos-overlay/coreos/sysext/containerd/usr/share/containerd/config-cgroupfs.toml
@@ -32,3 +32,6 @@ no_shim = false
 runtime_type = "io.containerd.runc.v2"
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
 SystemdCgroup = false
+
+[plugins."io.containerd.grpc.v1.cri".registry]
+config_path = "/etc/containerd/certs.d"

--- a/sdk_container/src/third_party/coreos-overlay/coreos/sysext/containerd/usr/share/containerd/config.toml
+++ b/sdk_container/src/third_party/coreos-overlay/coreos/sysext/containerd/usr/share/containerd/config.toml
@@ -36,3 +36,6 @@ enable_selinux = true
 runtime_type = "io.containerd.runc.v2"
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
 SystemdCgroup = true
+
+[plugins."io.containerd.grpc.v1.cri".registry]
+config_path = "/etc/containerd/certs.d"


### PR DESCRIPTION
# sdk_container/containerd: Add registry config_path

Update containerd config to include the crio registry plugin that defines the config_path. This allows users to add host specific configuration for containerd without having to overwrite the default containerd config.

## How to use

This config allows users to easily drop in hosts file under `etc/containerd/certs.d` as explained [here](https://github.com/containerd/containerd/blob/main/docs/hosts.md#registry-configuration---examples), in order to configure registry specific configs (mirrors, header, skip_tls, ... )

## Testing done
have to use the service override mechanism to change the default config file of containerd. Copied the containerd config of the MR into /etc/containerd/config.toml. Restarted containerd and after that:
- if the /etc/containerd/certs.d directory does not exist or is empty, containerd does *NOT* have any issues 
- I was then able to add hosts files based on the examples above and create mirrors


- [X] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->

Resolves: https://github.com/flatcar/Flatcar/issues/583