### PR TITLE
profiles: Prefix comment with # in package.mask

### DIFF
--- a/sdk_container/src/third_party/coreos-overlay/profiles/coreos/base/package.mask
+++ b/sdk_container/src/third_party/coreos-overlay/profiles/coreos/base/package.mask
@@ -22,6 +22,6 @@
 >=sys-block/thin-provisioning-tools-1.0.14
 
 # Too large to fit into our /boot partition - the size grew by 3MB. We
-mask a specific version in hope that the future update may be smaller,
-who knows.
+# mask a specific version in hope that the future update may be smaller,
+# who knows.
 =sys-firmware/intel-microcode-20250512_p20250513


### PR DESCRIPTION
# profiles: Prefix comment with # in package.mask

This multi-line comment accidentally only has a # prefix on the first line, which leads to this warning during the build:

    --- Invalid atom in /mnt/host/source/src/third_party/coreos-overlay/profiles/coreos/base/package.mask: mask a specific version in hope that the future update may be smaller,
    --- Invalid atom in /mnt/host/source/src/third_party/coreos-overlay/profiles/coreos/base/package.mask: who knows.

Add missing prefixes to lines 2 and 3.

## How to use

Check build log to see that those lines no longer show up.

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
