### PR TITLE
build_library/qemu_template.sh: exec qemu instead of calling it

### DIFF
--- a/build_library/qemu_template.sh
+++ b/build_library/qemu_template.sh
@@ -332,12 +332,10 @@ case "${VM_BOARD}" in
     *) die "Unsupported arch" ;;
 esac
 
-"$QEMU_BIN" \
+exec "$QEMU_BIN" \
     -name "$VM_NAME" \
     -m ${VM_MEMORY} \
     -netdev user,id=eth0${QEMU_FORWARDED_PORTS:+,}${QEMU_FORWARDED_PORTS},hostfwd=tcp::"${SSH_PORT}"-:22,hostname="${VM_NAME}" \
     -device virtio-net-pci,netdev=eth0 \
     -object rng-random,filename=/dev/urandom,id=rng0 -device virtio-rng-pci,rng=rng0 \
     "$@"
-
-exit $?


### PR DESCRIPTION
This change updates the build library's qemu template to "exec" qemu instead of calling it from the script. While serving the same purpose as calling qemu and returning "$?" (the current implementation), using exec makes it easier to manage the qemu sub-process when the qemu wrapper script is called from another script.

## How to use

- Build a qemu VM image
- Run `flatcar_production_qemu_uefi.sh`

## Testing done

- Ran `flatcar_production_qemu_uefi.sh`.