### PR TITLE
A couple of small fixes for performing Flatcar builds locally

### DIFF
--- a/build_library/grub_install.sh
+++ b/build_library/grub_install.sh
@@ -75,7 +75,9 @@ esac
 info "Updating GRUB in ${BOARD_ROOT}"
 emerge-${BOARD} \
         --nodeps --select --verbose --update --getbinpkg --usepkgonly --newuse \
-        sys-boot/grub
+        sys-boot/grub \
+        sys-boot/shim \
+        sys-boot/shim-signed
 
 GRUB_SRC="${BOARD_ROOT}/usr/lib/grub/${FLAGS_target}"
 [[ -d "${GRUB_SRC}" ]] || die "GRUB not installed at ${GRUB_SRC}"

--- a/sdk_container/src/third_party/coreos-overlay/sys-kernel/coreos-kernel/coreos-kernel-6.12.35.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/sys-kernel/coreos-kernel/coreos-kernel-6.12.35.ebuild
@@ -37,10 +37,12 @@ DEPEND="
 	sys-apps/shadow
 	sys-apps/systemd[cryptsetup]
 	sys-apps/seismograph
-	sys-apps/util-linux
+	sys-apps/util-linux[cryptsetup,udev]
 	sys-block/open-iscsi
 	sys-fs/btrfs-progs
+	sys-fs/cryptsetup[udev]
 	sys-fs/e2fsprogs
+	sys-fs/lvm2[udev]
 	sys-fs/mdadm
 	sys-fs/xfsprogs
 	>=sys-kernel/bootengine-0.0.38-r37:=


### PR DESCRIPTION
# A couple of small fixes for performing Flatcar builds locally

The shim packages must be installed when running grub_install.sh. These are not present in a fresh SDK instance.

The coreos-kernel dependencies must be tightened to ensure working initrd. In particular, sys-fs/lvm2 includes dmsetup, and systemd will fail to recognise /dev/mapper/usr if that is built without udev support.
    
This is not a problem in CI, but a fresh SDK will have board packages installed without their final USE flags in place due to cyclic dependencies.

## How to use

Perform a local build.

## Testing done

Both changes have been testing locally. The grub_install.sh change has had several runs through CI.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update) -- N/A
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc. -- N/A