### PR TITLE
ci-automation: Use a valid reference

### DIFF
--- a/ci-automation/image_changes.sh
+++ b/ci-automation/image_changes.sh
@@ -426,7 +426,7 @@ function prepare_env_vars_and_params_for_release() {
 
     # Nothing to prepend to show_changes_env.
     show_changes_env_ref=()
-    show_changes_params=(
+    show_changes_params_ref=(
         "NEW_CHANNEL=${new_channel}"
         "NEW_CHANNEL_PREV_VERSION=${new_channel_prev_version}"
         # Channel transition stuff
@@ -481,7 +481,7 @@ function prepare_env_vars_and_params_for_nightly() {
 
     # Nothing to prepend to show_changes_env.
     show_changes_env_ref=()
-    show_changes_params=(
+    show_changes_params_ref=(
         "NEW_CHANNEL=${ppfb_channel}"
         "NEW_CHANNEL_PREV_VERSION=${ppfb_vernum}"
         # Channel transition stuff, we set the old channel to be the


### PR DESCRIPTION
`show_changes_params` is not available in this lexical scope, we should have been using `show_changes_params_ref`. This has worked so far only because all the callers of the functions were passing `show_changes_params` to be referenced by
`show_changes_params_ref`. Just a lucky happenstance.

Spotted by Chewi.
