### PR TITLE
ci_automation_common.sh: sign commits to adhere to DCO requirements

### DIFF
--- a/ci-automation/ci_automation_common.sh
+++ b/ci-automation/ci_automation_common.sh
@@ -36,7 +36,7 @@ function update_and_push_version() {
     # Add and commit local changes
     git add "sdk_container/.repo/manifests/version.txt"
 
-    git commit --allow-empty -m "New version: ${version}"
+    git commit -s --allow-empty -m "New version: ${version}"
 
     git fetch --all --tags --force
     local -i ret=0


### PR DESCRIPTION
This change makes CI sign commits (which should work because CI uses a "regular" github user) as per our new DCO requirements.

Let's get this merged soon so we can observe the effects on nightly builds before we activate DCO.

This currently blocks https://github.com/flatcar/Flatcar/issues/1807 DCO activation for the Flatcar org.

After merge and a successful nightly build, this should be backported to all maintenance branches.