### PR TITLE
docker: remove legacy docker socket path

### DIFF
--- a/sdk_container/src/third_party/coreos-overlay/coreos/sysext/docker/usr/lib/systemd/system/docker.socket
+++ b/sdk_container/src/third_party/coreos-overlay/coreos/sysext/docker/usr/lib/systemd/system/docker.socket
@@ -3,7 +3,7 @@ Description=Docker Socket for the API
 PartOf=docker.service
 
 [Socket]
-ListenStream=/var/run/docker.sock
+ListenStream=/run/docker.sock
 SocketMode=0660
 SocketUser=root
 SocketGroup=docker


### PR DESCRIPTION
# Remove legacy docker socket

Per https://github.com/flatcar/Flatcar/issues/1724, systemd complains about the docker socket being stored in a legacy location /var/run/docker.sock. This updates it to use /run/docker.sock per the conversations in that issue.

Resolves https://github.com/flatcar/Flatcar/issues/1724

## How to use

Enable docker as mentioned in the [docs](https://www.flatcar.org/docs/latest/container-runtimes/getting-started-with-docker/#permanently-running-a-container) and then run systemd-analyze verify docker.service. Ensure that systemd is no longer complaining about the legacy location.

## Testing done

- [X] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [X] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
