### PR TITLE
.github: sign commits from common scripts

### DIFF
--- a/.github/workflows/common.sh
+++ b/.github/workflows/common.sh
@@ -186,7 +186,7 @@ function commit_changes() {
   for dir; do
     git add "${dir}"
   done
-  git commit -m "${pkg}: Update from ${old_version} to ${new_version}"
+  git commit --signoff -m "${pkg}: Update from ${old_version} to ${new_version}"
 
   popd
 }


### PR DESCRIPTION
It's a follow-up from https://github.com/flatcar/scripts/pull/3140, I thought the commit was created by the github-actions ("create pull request") but they are done via our automation script.

I noticed this with the current ca-certificates update that are not signed-off.