### PR TITLE
Add overlaybd sysext

### DIFF
--- a/build_library/extra_sysexts.sh
+++ b/build_library/extra_sysexts.sh
@@ -1,4 +1,5 @@
 EXTRA_SYSEXTS=(
+  "overlaybd|sys-fs/overlaybd,app-containers/accelerated-container-image"
   "incus|app-containers/incus"
   "nvidia-drivers-535|x11-drivers/nvidia-drivers:0/535|-kernel-open persistenced|amd64"
   "nvidia-drivers-535-open|x11-drivers/nvidia-drivers:0/535|kernel-open persistenced|amd64"

--- a/changelog/changes/2025-07-25-overlaybd.md
+++ b/changelog/changes/2025-07-25-overlaybd.md
@@ -1,0 +1,3 @@
+* Added [overlaybd](https://containerd.github.io/overlaybd/) system extension to support accelerated container images.
+  The extension includes both [overlaybd](https://github.com/containerd/overlaybd/) as well as [accelerated-container-image](https://github.com/containerd/accelerated-container-image) tools.
+  Add `overlaybd` to [`/etc/flatcar/enabled-sysext.conf`](https://www.flatcar.org/docs/latest/provisioning/sysext/) to check it out.

--- a/sdk_container/src/third_party/coreos-overlay/app-containers/accelerated-container-image/accelerated-container-image-1.3.0.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/app-containers/accelerated-container-image/accelerated-container-image-1.3.0.ebuild
@@ -1,0 +1,1 @@
+accelerated-container-image-9999.ebuild

--- a/sdk_container/src/third_party/coreos-overlay/app-containers/accelerated-container-image/accelerated-container-image-9999.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/app-containers/accelerated-container-image/accelerated-container-image-9999.ebuild
@@ -1,0 +1,50 @@
+# Copyright 2025 The Flatcar Container Linux Maintainers
+# Distributed under the terms of the Apache License 2.0
+
+EAPI=8
+
+inherit git-r3 go-module systemd tmpfiles
+
+DESCRIPTION="Remote container image format (overlaybd) and snapshotter based on block-device"
+HOMEPAGE="https://github.com/containerd/accelerated-container-image"
+EGIT_REPO_URI="https://github.com/containerd/accelerated-container-image.git"
+
+if [[ ${PV} == 9999* ]]; then
+	KEYWORDS="~amd64 ~arm64"
+else
+	EGIT_COMMIT="v${PV}"
+	KEYWORDS="amd64 arm64"
+fi
+
+LICENSE="Apache-2.0"
+SLOT="0"
+
+# FIXME HACK ALERT: the build pulls go modules during src_compile.
+# This fails if network sandbox is enabled.
+RESTRICT="${RESTRICT} network-sandbox"
+
+
+RDEPEND="sys-fs/overlaybd"
+
+src_unpack() {
+	git-r3_src_unpack
+	go-module_src_unpack
+}
+
+src_install() {
+	emake install \
+		DESTDIR="${ED}" \
+		SN_DESTDIR="${ED}/usr/local/overlaybd/snapshotter" \
+		SN_CFGDIR="${ED}/usr/local/overlaybd/snapshotter/etc"
+
+	sed -i 's,/opt/overlaybd,/usr/local/overlaybd,' \
+		"${ED}/usr/local/overlaybd/snapshotter/overlaybd-snapshotter.service" || die
+
+  # tmpfiles will take care of symlinking /usr/local/overlaybd/snapshotter
+  # to /opt/overlaybd/snapshotter, where upstream expects the binaries.
+  # (we need them in /usr to be used in a sysext)
+	dotmpfiles "${FILESDIR}/10-overlaybd-snapshotter.conf"
+
+	systemd_dounit "${ED}/usr/local/overlaybd/snapshotter/overlaybd-snapshotter.service"
+	systemd_enable_service "multi-user.target" "overlaybd-snapshotter.service"
+}

--- a/sdk_container/src/third_party/coreos-overlay/app-containers/accelerated-container-image/files/10-overlaybd-snapshotter.conf
+++ b/sdk_container/src/third_party/coreos-overlay/app-containers/accelerated-container-image/files/10-overlaybd-snapshotter.conf
@@ -1,0 +1,2 @@
+C /etc/overlaybd-snapshotter/config.json - - - - /usr/local/overlaybd/snapshotter/etc/config.json
+L /opt/overlaybd/snapshotter - - - - /usr/local/overlaybd/snapshotter

--- a/sdk_container/src/third_party/coreos-overlay/app-containers/accelerated-container-image/metadata.xml
+++ b/sdk_container/src/third_party/coreos-overlay/app-containers/accelerated-container-image/metadata.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="project">
+		<email>maintainers@flatcar-linux.org</email>
+		<name>The Flatcar Container Linux Maintainers</name>
+	</maintainer>
+	<upstream>
+		<remote-id type="github">containerd/accelerated-container-image</remote-id>
+	</upstream>
+</pkgmetadata>

--- a/sdk_container/src/third_party/coreos-overlay/sys-fs/overlaybd/files/10-overlaybd.conf
+++ b/sdk_container/src/third_party/coreos-overlay/sys-fs/overlaybd/files/10-overlaybd.conf
@@ -1,0 +1,2 @@
+C /etc/overlaybd/overlaybd.json - - - - /usr/local/overlaybd/etc/overlaybd.json
+d /opt/overlaybd - - - - -

--- a/sdk_container/src/third_party/coreos-overlay/sys-fs/overlaybd/files/overlaybd-cross.patch
+++ b/sdk_container/src/third_party/coreos-overlay/sys-fs/overlaybd/files/overlaybd-cross.patch
@@ -1,0 +1,129 @@
+From de68119855229db8e457043d86bbb38bbd5d55d9 Mon Sep 17 00:00:00 2001
+From: James Le Cuirot <jlecuirot@microsoft.com>
+Date: Fri, 25 Jul 2025 17:12:03 +0100
+Subject: [PATCH 1/3] Fix cross-compiling by using CMAKE_SYSTEM_PROCESSOR
+ rather than uname -m
+
+There is no need to check the architecture twice. Also check for arm64
+(MacOS) wherever we check for aarch64 (Linux).
+
+Signed-off-by: James Le Cuirot <jlecuirot@microsoft.com>
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -9,10 +9,8 @@ enable_language(C)
+ set(CMAKE_CXX_FLAGS_RELEASE "-O2 -DNDEBUG")
+ set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -DNDEBUG -g")
+ 
+-# Get CPU arch
+-execute_process(COMMAND uname -m OUTPUT_VARIABLE ARCH OUTPUT_STRIP_TRAILING_WHITESPACE)
+-if (NOT (${ARCH} STREQUAL x86_64) AND NOT (${ARCH} STREQUAL aarch64) AND NOT (${ARCH} STREQUAL arm64))
+-    message(FATAL_ERROR "Unknown CPU architecture ${ARCH}")
++if (NOT (CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64) AND NOT (CMAKE_SYSTEM_PROCESSOR STREQUAL aarch64) AND NOT (CMAKE_SYSTEM_PROCESSOR STREQUAL arm64))
++    message(FATAL_ERROR "Unknown CPU architecture ${CMAKE_SYSTEM_PROCESSOR}")
+ endif ()
+ 
+ option(OBD_VER "Overlaybd version" "overlaybd/0.0.0-undefined")
+@@ -25,7 +23,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/CMake")
+ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fpic -Wall -Werror=sign-compare")
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpic -Wall -Werror=sign-compare -DOVERLAYBD_VER=${OBD_VER}")
+ 
+-if (${ARCH} STREQUAL aarch64)
++if ((CMAKE_SYSTEM_PROCESSOR STREQUAL aarch64) OR (CMAKE_SYSTEM_PROCESSOR STREQUAL arm64))
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=armv8-a+crc -fsigned-char -fno-stack-protector -fomit-frame-pointer")
+ endif ()
+ 
+--- a/src/overlaybd/zfile/CMakeLists.txt
++++ b/src/overlaybd/zfile/CMakeLists.txt
+@@ -2,19 +2,13 @@ file(GLOB SOURCE_ZFILE "*.cpp")
+ file(GLOB SOURCE_LZ4 "lz4/*.c")
+ file(GLOB SOURCE_CRC32 "crc32/crc32c.cpp")
+ 
+-# Get CPU arch
+-execute_process(COMMAND uname -m OUTPUT_VARIABLE ARCH OUTPUT_STRIP_TRAILING_WHITESPACE)
+-if (NOT (${ARCH} STREQUAL x86_64) AND NOT (${ARCH} STREQUAL aarch64))
+-    message(FATAL_ERROR "Unknown CPU architecture ${ARCH}")
+-endif ()
+-
+ set (CMAKE_CXX_STANDARD 17)
+ add_library(crc32_lib STATIC ${SOURCE_CRC32})
+ target_include_directories(crc32_lib PUBLIC
+     ${PHOTON_INCLUDE_DIR}
+ )
+ 
+-if (${ARCH} STREQUAL x86_64)
++if (CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64)
+     target_compile_options(crc32_lib PUBLIC -msse4.2 -mcrc32)
+ else()
+     target_compile_options(crc32_lib PRIVATE -march=native -mcpu=generic+crc)
+-- 
+2.49.0
+
+
+From ee0e074c256ea1bcbcff2ed5a3e311becaf122cc Mon Sep 17 00:00:00 2001
+From: James Le Cuirot <jlecuirot@microsoft.com>
+Date: Mon, 28 Jul 2025 12:05:19 +0100
+Subject: [PATCH 2/3] Respect aarch64 -march=|-mcpu= flag and check whether
+ -mcpu=native works
+
+Packagers may specify a target system up front, which should be
+respected. The CRC extensions are not strictly necessary as there is a
+software fallback.
+
+Otherwise, use -mcpu=native if it works (it won't when cross-compiling)
+or -mcpu=generic+crc.
+
+Signed-off-by: James Le Cuirot <jlecuirot@microsoft.com>
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -24,7 +24,16 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fpic -Wall -Werror=sign-compare")
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpic -Wall -Werror=sign-compare -DOVERLAYBD_VER=${OBD_VER}")
+ 
+ if ((CMAKE_SYSTEM_PROCESSOR STREQUAL aarch64) OR (CMAKE_SYSTEM_PROCESSOR STREQUAL arm64))
+-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=armv8-a+crc -fsigned-char -fno-stack-protector -fomit-frame-pointer")
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsigned-char -fno-stack-protector -fomit-frame-pointer")
++    if (NOT CMAKE_CXX_FLAGS MATCHES "-march=|-mcpu=")
++        include(CheckCXXCompilerFlag)
++        check_cxx_compiler_flag(-mcpu=native COMPILER_HAS_NATIVE_FLAG)
++        if (COMPILER_HAS_NATIVE_FLAG)
++            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcpu=native")
++        else ()
++            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcpu=generic+crc")
++        endif ()
++    endif ()
+ endif ()
+ 
+ set(CMAKE_CXX_STANDARD_LIBRARIES "-static-libgcc ${CMAKE_CXX_STANDARD_LIBRARIES}")
+--- a/src/overlaybd/zfile/CMakeLists.txt
++++ b/src/overlaybd/zfile/CMakeLists.txt
+@@ -10,8 +10,6 @@ target_include_directories(crc32_lib PUBLIC
+ 
+ if (CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64)
+     target_compile_options(crc32_lib PUBLIC -msse4.2 -mcrc32)
+-else()
+-    target_compile_options(crc32_lib PRIVATE -march=native -mcpu=generic+crc)
+ endif()
+ 
+ if(ENABLE_DSA OR ENABLE_ISAL)
+-- 
+2.49.0
+
+
+From 2e4edd416a42fad0e8d7ac21855a4e81f34f1e82 Mon Sep 17 00:00:00 2001
+From: James Le Cuirot <jlecuirot@microsoft.com>
+Date: Mon, 28 Jul 2025 12:16:50 +0100
+Subject: [PATCH 3/3] Patch Photon after fetching to fix cross issues
+
+Signed-off-by: James Le Cuirot <jlecuirot@microsoft.com>
+--- a/CMake/Findphoton.cmake
++++ b/CMake/Findphoton.cmake
+@@ -6,6 +6,7 @@ FetchContent_Declare(
+   photon
+   GIT_REPOSITORY https://github.com/alibaba/PhotonLibOS.git
+   GIT_TAG v0.6.17
++  PATCH_COMMAND patch -p1 -i @FILESDIR@/photon-cross.patch
+ )
+ 
+ if(BUILD_TESTING)
+-- 
+2.49.0
+

--- a/sdk_container/src/third_party/coreos-overlay/sys-fs/overlaybd/files/overlaybd-cross.patch
+++ b/sdk_container/src/third_party/coreos-overlay/sys-fs/overlaybd/files/overlaybd-cross.patch
@@ -127,3 +127,28 @@ Signed-off-by: James Le Cuirot <jlecuirot@microsoft.com>
 -- 
 2.49.0
 
+
+From 32a592ef523a14600ce658a695d827724aeb66c9 Mon Sep 17 00:00:00 2001
+From: Krzesimir Nowak <knowak@microsoft.com>
+Date: Fri, 8 Aug 2025 16:47:58 +0200
+Subject: [PATCH] Patch libtcmu after fetching to fix memory issues
+
+---
+ CMake/Findtcmu.cmake | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/CMake/Findtcmu.cmake b/CMake/Findtcmu.cmake
+index 6e8f0ef..5865a9b 100644
+--- a/CMake/Findtcmu.cmake
++++ b/CMake/Findtcmu.cmake
+@@ -5,6 +5,7 @@ FetchContent_Declare(
+   tcmu
+   GIT_REPOSITORY https://github.com/data-accelerator/photon-libtcmu.git
+   GIT_TAG main
++  PATCH_COMMAND patch -p1 -i @FILESDIR@/tcmu-fix.patch
+ )
+ 
+ if(BUILD_TESTING)
+-- 
+2.49.1
+

--- a/sdk_container/src/third_party/coreos-overlay/sys-fs/overlaybd/files/photon-cross.patch
+++ b/sdk_container/src/third_party/coreos-overlay/sys-fs/overlaybd/files/photon-cross.patch
@@ -1,0 +1,90 @@
+From a0ea7bb44f4c863519537605e8118b6ff6afd57e Mon Sep 17 00:00:00 2001
+From: James Le Cuirot <jlecuirot@microsoft.com>
+Date: Mon, 28 Jul 2025 10:23:02 +0100
+Subject: [PATCH 1/2] Fix cross-compiling by using CMAKE_SYSTEM_PROCESSOR
+ rather than uname -m
+
+There is no need to check the architecture twice. Also check for arm64
+(MacOS) wherever we check for aarch64 (Linux).
+
+Signed-off-by: James Le Cuirot <jlecuirot@microsoft.com>
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -38,10 +38,8 @@ set(PHOTON_E2FS_SOURCE "" CACHE STRING "")
+ set(PHOTON_GFLAGS_SOURCE "https://github.com/gflags/gflags/archive/refs/tags/v2.2.2.tar.gz" CACHE STRING "")
+ set(PHOTON_GOOGLETEST_SOURCE "https://github.com/google/googletest/archive/refs/tags/release-1.12.1.tar.gz" CACHE STRING "")
+ 
+-# Get CPU arch and number
+-execute_process(COMMAND uname -m OUTPUT_VARIABLE ARCH OUTPUT_STRIP_TRAILING_WHITESPACE)
+-if (NOT (${ARCH} STREQUAL x86_64) AND NOT (${ARCH} STREQUAL aarch64) AND NOT (${ARCH} STREQUAL arm64))
+-    message(FATAL_ERROR "Unknown CPU architecture ${ARCH}")
++if (NOT (CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64) AND NOT (CMAKE_SYSTEM_PROCESSOR STREQUAL aarch64) AND NOT (CMAKE_SYSTEM_PROCESSOR STREQUAL arm64))
++    message(FATAL_ERROR "Unknown CPU architecture ${CMAKE_SYSTEM_PROCESSOR}")
+ endif ()
+ ProcessorCount(NumCPU)
+ 
+@@ -65,9 +63,9 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-packed-bitfield-compat")
+ endif()
+ 
+-if (${ARCH} STREQUAL x86_64)
++if (CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64)
+     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse4.2")
+-elseif (${ARCH} STREQUAL aarch64)
++elseif ((CMAKE_SYSTEM_PROCESSOR STREQUAL aarch64) OR (CMAKE_SYSTEM_PROCESSOR STREQUAL arm64))
+     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcpu=generic+crc -fsigned-char -fno-stack-protector -fomit-frame-pointer")
+ endif ()
+ 
+--- a/net/security-context/test/CMakeLists.txt
++++ b/net/security-context/test/CMakeLists.txt
+@@ -6,9 +6,8 @@ add_executable(test-tls test.cpp)
+ target_link_libraries(test-tls PRIVATE photon_shared ${testing_libs})
+ add_test(NAME test-tls COMMAND $<TARGET_FILE:test-tls>)
+ 
+-if (ENABLE_SASL AND (NOT (APPLE AND (${ARCH} STREQUAL arm64))))
++if (ENABLE_SASL AND NOT (APPLE AND (CMAKE_SYSTEM_PROCESSOR STREQUAL arm64)))
+     add_executable(test-sasl test-sasl.cpp)
+     target_link_libraries(test-sasl PRIVATE photon_shared ${testing_libs})
+     add_test(NAME test-sasl COMMAND $<TARGET_FILE:test-sasl>)
+ endif ()
+-
+-- 
+2.49.0
+
+
+From 467ecb887c8cc9107e8f055c90f02ee04fcb895e Mon Sep 17 00:00:00 2001
+From: James Le Cuirot <jlecuirot@microsoft.com>
+Date: Mon, 28 Jul 2025 11:17:24 +0100
+Subject: [PATCH 2/2] Respect aarch64 -march=|-mcpu= flag and check whether
+ -mcpu=native works
+
+Packagers may specify a target system up front, which should be
+respected. The CRC extensions are not strictly necessary as there is a
+software fallback.
+
+Otherwise, use -mcpu=native if it works (it won't when cross-compiling)
+or -mcpu=generic+crc.
+
+Signed-off-by: James Le Cuirot <jlecuirot@microsoft.com>
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -66,7 +66,15 @@ endif()
+ if (CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64)
+     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse4.2")
+ elseif ((CMAKE_SYSTEM_PROCESSOR STREQUAL aarch64) OR (CMAKE_SYSTEM_PROCESSOR STREQUAL arm64))
+-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcpu=generic+crc -fsigned-char -fno-stack-protector -fomit-frame-pointer")
++    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsigned-char -fno-stack-protector -fomit-frame-pointer")
++    if (NOT CMAKE_CXX_FLAGS MATCHES "-march=|-mcpu=")
++        check_cxx_compiler_flag(-mcpu=native COMPILER_HAS_NATIVE_FLAG)
++        if (COMPILER_HAS_NATIVE_FLAG)
++            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcpu=native")
++        else ()
++            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mcpu=generic+crc")
++        endif ()
++    endif ()
+ endif ()
+ 
+ check_cxx_compiler_flag(-mcrc32 COMPILER_HAS_MCRC32_FLAG)
+-- 
+2.49.0
+

--- a/sdk_container/src/third_party/coreos-overlay/sys-fs/overlaybd/files/tcmu-fix.patch
+++ b/sdk_container/src/third_party/coreos-overlay/sys-fs/overlaybd/files/tcmu-fix.patch
@@ -1,0 +1,46 @@
+From 0ee2c928de51ef56376c4ab6528ca1e23c13c4a7 Mon Sep 17 00:00:00 2001
+From: Krzesimir Nowak <knowak@microsoft.com>
+Date: Fri, 8 Aug 2025 16:29:52 +0200
+Subject: [PATCH] fix
+
+---
+ scsi.cpp | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/scsi.cpp b/scsi.cpp
+index d8c27a9..4c7f480 100644
+--- a/scsi.cpp
++++ b/scsi.cpp
+@@ -183,7 +183,7 @@ int tcmu_emulate_evpd_inquiry(
+ 	{
+ 		char data[512];
+ 		char *ptr, *p, *wwn;
+-		size_t len, used = 0;
++		size_t len, used = 4;
+ 		uint16_t *tot_len = (uint16_t*) &data[2];
+ 		uint32_t padding;
+ 		bool next;
+@@ -207,7 +207,7 @@ int tcmu_emulate_evpd_inquiry(
+ 
+ 		ptr[3] = 8 + len + 1;
+ 		used += (uint8_t)ptr[3] + 4;
+-		ptr += used;
++		ptr += (uint8_t)ptr[3] + 4;
+ 
+ 		/* 2/5: NAA binary */
+ 		ptr[0] = 1; /* code set: binary */
+@@ -340,9 +340,9 @@ int tcmu_emulate_evpd_inquiry(
+ finish_page83:
+ 		/* Done with descriptor list */
+ 
+-		*tot_len = htobe16(used);
++		*tot_len = htobe16(used - 4);
+ 
+-		tcmu_memcpy_into_iovec(iovec, iov_cnt, data, used + 4);
++		tcmu_memcpy_into_iovec(iovec, iov_cnt, data, used);
+ 
+ 		free(wwn);
+ 		wwn = NULL;
+-- 
+2.49.1
+

--- a/sdk_container/src/third_party/coreos-overlay/sys-fs/overlaybd/metadata.xml
+++ b/sdk_container/src/third_party/coreos-overlay/sys-fs/overlaybd/metadata.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "https://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="project">
+		<email>maintainers@flatcar-linux.org</email>
+		<name>The Flatcar Container Linux Maintainers</name>
+	</maintainer>
+	<use>
+		<flag name="dsa">Accelerate CRC calculations with Intel Data Streaming Accelerator</flag>
+		<flag name="qat">Accelerate compression with Intel QuickAssist Technology</flag>
+	</use>
+	<upstream>
+		<remote-id type="github">containerd/overlaybd</remote-id>
+	</upstream>
+</pkgmetadata>

--- a/sdk_container/src/third_party/coreos-overlay/sys-fs/overlaybd/overlaybd-1.0.15.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/sys-fs/overlaybd/overlaybd-1.0.15.ebuild
@@ -1,0 +1,1 @@
+overlaybd-9999.ebuild

--- a/sdk_container/src/third_party/coreos-overlay/sys-fs/overlaybd/overlaybd-9999.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/sys-fs/overlaybd/overlaybd-9999.ebuild
@@ -88,14 +88,12 @@ src_install() {
 	mv "${ED}"/opt/${PN}/* "${ED}"/usr/local/${PN}/ || die
 	mv "${ED}"/etc/${PN}/* "${ED}"/usr/local/${PN}/etc/ || die
 
-  # Handle /etc (overlaybd.json), create /opt/opverlaybd and symlink
+	# Handle /etc (overlaybd.json), create /opt/overlaybd and symlink
 	# all contents of /usr/local/overlaybd to /opt/overlaybd.
-  elog "Scanning '${ED}/usr/local/${PN}/' and generating tmpfiles symlink entries..."
-	cp "${FILESDIR}"/10-${PN}.conf "${T}"
-  local entry
-  for entry in $(ls -1 "${ED}/usr/local/${PN}/") ; do
-    echo "L /opt/overlaybd/${entry} - - - - /usr/local/${PN}/${entry}" \
-      | tee -a "${T}/10-${PN}.conf"
-  done
-	dotmpfiles "${T}"/10-${PN}.conf
+	elog "Scanning '${ED}/usr/local/${PN}/' and generating tmpfiles symlink entries..."
+	cat "${FILESDIR}"/10-${PN}.conf <(
+		for entry in "${ED}"/usr/local/${PN}/*; do
+			echo "L /opt/overlaybd/${entry##*/} - - - - /usr/local/${PN}/${entry##*/}"
+		done
+	) | tee /dev/stderr | newtmpfiles - 10-${PN}.conf
 }

--- a/sdk_container/src/third_party/coreos-overlay/sys-fs/overlaybd/overlaybd-9999.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/sys-fs/overlaybd/overlaybd-9999.ebuild
@@ -1,0 +1,101 @@
+# Copyright 2025 The Flatcar Container Linux Maintainers
+# Distributed under the terms of the Apache License 2.0
+
+EAPI=8
+
+inherit cmake git-r3 systemd tmpfiles
+
+DESCRIPTION="Novel layering block-level image format for containers"
+HOMEPAGE="https://containerd.github.io/overlaybd"
+EGIT_REPO_URI="https://github.com/containerd/overlaybd.git"
+
+if [[ ${PV} == 9999* ]]; then
+	KEYWORDS="~amd64 ~arm64"
+else
+	EGIT_COMMIT="v${PV}"
+	KEYWORDS="amd64 arm64"
+fi
+
+LICENSE="Apache-2.0"
+SLOT="0"
+IUSE="cpu_flags_x86_avx2 dsa qat isal"
+REQUIRED_USE="dsa? ( cpu_flags_x86_avx2 )"
+RESTRICT="test"
+
+# FIXME HACK ALERT: overlaybd build pulls sources during src_configure.
+# (https://github.com/alibaba/PhotonLibOS.git/
+# This fails if network sandbox is enabled.
+RESTRICT="${RESTRICT} network-sandbox"
+
+DEPEND="
+	app-arch/zstd:=
+	dev-libs/libaio
+	dev-libs/libnl:3
+	dev-libs/openssl:=
+	net-misc/curl
+	sys-fs/e2fsprogs
+	sys-libs/zlib
+	dsa? ( sys-apps/pciutils )
+	qat? ( sys-apps/pciutils )
+"
+
+RDEPEND="
+	${DEPEND}
+"
+
+PATCHES=(
+	"${FILESDIR}"/${PN}-cross.patch
+)
+
+src_prepare() {
+	cmake_src_prepare
+	sed -i "s:@FILESDIR@:${FILESDIR}:g" CMake/Findphoton.cmake || die
+}
+
+src_configure() {
+	# crc32c.cpp explicitly uses special instructions but checks for them at
+	# runtime. Only DSA hard requires at least AVX2. However, the code doesn't
+	# try especially hard to avoid these instructions from being implicitly used
+	# outside these runtime checks. :(
+  # ISAL similarly leads to "illegal instruction" termination on QEMU.
+	local mycmakeargs=(
+		-DBUILD_SHARED_LIBS=no
+		-DBUILD_TESTING=no
+		-DENABLE_DSA=$(usex dsa)
+		-DENABLE_ISAL=$(usex isal)
+		-DENABLE_QAT=$(usex qat)
+		-DORIGIN_EXT2FS=yes
+	)
+
+	# Make erofs-utils configure work when cross-compiling.
+	host_alias="${CHOST}" build_alias="${CBUILD:-${CHOST}}" \
+	cmake_src_configure
+}
+
+src_install() {
+	cmake_src_install
+
+	# We want to ship our binaries in /usr/local (so we're sysext compatible)
+	# but upstream has hard-wired everything to /opt/overlaybd.
+
+	sed "s,/opt/${PN},/usr/local/${PN},g" \
+		"${ED}"/opt/${PN}/${PN}-tcmu.service |
+		systemd_newunit - ${PN}-tcmu.service
+	rm "${ED}"/opt/${PN}/${PN}-tcmu.service || die
+	systemd_enable_service multi-user.target ${PN}-tcmu.service
+
+	dodir /usr/local/${PN}/etc
+	mv "${ED}"/opt/${PN}/* "${ED}"/usr/local/${PN}/ || die
+	mv "${ED}"/etc/${PN}/* "${ED}"/usr/local/${PN}/etc/ || die
+
+  # Handle /etc (overlaybd.json), create /opt/opverlaybd and symlink
+	# all contents of /usr/local/overlaybd to /opt/overlaybd.
+  elog "Scanning '${ED}/usr/local/${PN}/' and generating tmpfiles symlink entries..."
+	cp "${FILESDIR}"/10-${PN}.conf "${T}"
+  local entry
+  for entry in $(ls -1 "${ED}/usr/local/${PN}/") ; do
+    echo "L /opt/overlaybd/${entry} - - - - /usr/local/${PN}/${entry}" \
+      | tee -a "${T}/10-${PN}.conf"
+  done
+	dotmpfiles "${T}"/10-${PN}.conf
+}

--- a/sdk_container/src/third_party/coreos-overlay/sys-fs/overlaybd/overlaybd-9999.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/sys-fs/overlaybd/overlaybd-9999.ebuild
@@ -49,7 +49,7 @@ PATCHES=(
 
 src_prepare() {
 	cmake_src_prepare
-	sed -i "s:@FILESDIR@:${FILESDIR}:g" CMake/Findphoton.cmake || die
+	sed -i "s:@FILESDIR@:${FILESDIR}:g" CMake/Findphoton.cmake CMake/Findtcmu.cmake || die
 }
 
 src_configure() {


### PR DESCRIPTION
This adds overlaybd, a user space container-optimised block device implementing a novel layering block-level image format, which is designed for containers, with security and performance in mind.

Documentation is available at https://containerd.github.io/overlaybd/.

**sys-fs/overlaybd** ships the low-level user space block device (https://github.com/containerd/overlaybd) as well as low-level tooling for operating it.

**app-containers/accelerated-container-image** (https://github.com/containerd/accelerated-container-image) ships integration with containerd.

Both are part of the Containerd CNCF project.

# BUILDING

1. Check out this branch
   ```sh
   git checkout t-lo/containerd-overlaybd
   ```
2. Start the SDK
   ```sh
   ./run_sdk_container -t
   ```
3. Build packages and image
   ```sh
    ./build_packages
    ./build_image prod sysext
    ./image_to_vm.sh --from=../build/images/amd64-usr/latest --image_compression_formats=none
   ```

## Rebuilding

After an initial build only the sysext needs to be rebuilt.
To limit the scope of system-dependent sysext builds it is useful to set
```sh
EXTRA_SYSEXTS=(                                                          
  "overlaybd|sys-fs/overlaybd,app-containers/accelerated-container-image"
)                                                                        
```
in `build_library/prod_image_util.sh`.

To pick up modifications in `overlaybd`, run
```sh
emerge-amd64-usr --buildpkg overlaybd
```

Similarly, to include `accelerated-container-image` changes, use
```sh
emerge-amd64-usr --buildpkg accelerated-container-image
```

Then rebuild the sysext(s):
```sh
./build_image sysext
```
The new `flatcar-overlaybd.raw` sysext is now available in `__build__/images/images/amd64-usr/latest`.

# TESTING

Testing is manual at this point because `kola` cannot (yet?) provision arbitrary system extensions to qemu test instances. Also, testing is limited to AMD64 as no overlaybd enabled ARM64 images are [available on dockerhub](https://hub.docker.com/search?q=overlaybd&architecture=arm64).

1. Provision `flatcar-overlaybd` extension on test instance. The [sysext bakery's ](https://github.com/flatcar/sysext-bakery)`bakery.sh boot` is particularly useful. In `__build__/images/images/amd64-usr/latest`, run
   ```sh
   ~/code/sysext-bakery/bakery.sh boot flatcar-overlaybd.raw --nutane custom.yaml
   ```
   <details><summary>Here's the "custom.yaml" butane config:</summary>
   
   ```yaml
   version: 1.0.0
   variant: flatcar
  
   storage:
     files:
       - path: /etc/config.toml
         contents:
           inline: |
             version = 2
             
             # persistent data location
             root = "/var/lib/containerd"
             # runtime state information
             state = "/run/containerd"
             # set containerd as a subreaper on linux when it is not running as PID 1
             subreaper = true
             # set containerd's OOM score
             oom_score = -999
             disabled_plugins = []
             
             # grpc configuration
             [grpc]
             address = "/run/containerd/containerd.sock"
             # socket uid
             uid = 0
             # socket gid
             gid = 0
             
             [plugins."io.containerd.runtime.v1.linux"]
             # shim binary name/path
             shim = "containerd-shim"
             # runtime binary name/path
             runtime = "runc"
             # do not use a shim when starting containers, saves on memory but
             # live restore is not supported
             no_shim = false
             
             [plugins."io.containerd.grpc.v1.cri"]
             # enable SELinux labeling
             enable_selinux = true
             
             [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
             # setting runc.options unsets parent settings
             runtime_type = "io.containerd.runc.v2"
             [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
             SystemdCgroup = true
             
             [proxy_plugins.overlaybd]
                type = "snapshot"
                address = "/run/overlaybd-snapshotter/overlaybd.sock"
       - path: /etc/extensions/flatcar-overlaybd.raw
         mode: 0644
         contents:
           # QEmu's default traffic-to-host IP
           source: http://10.0.2.2:12345/flatcar-overlaybd.raw
   
   systemd:
     units:
       - name: update-engine.service
         mask: true
       - name: locksmithd.service
         mask: true
       - name: containerd.service
         dropins:
           - name: 10-configtoml.conf
             contents: |
               [Service]
               ExecStart=
               ExecStart=/usr/bin/containerd --config /etc/config.toml
    ```

   </details>
2.  Start redis test image as per
   https://github.com/containerd/accelerated-container-image/blob/main/docs/QUICKSTART.md#run-overlaybd-images
   ```sh
    sudo /opt/overlaybd/snapshotter/ctr rpull registry.hub.docker.com/overlaybd/redis:6.2.1_obd
    sudo ctr run --net-host --snapshotter=overlaybd --rm -t registry.hub.docker.com/overlaybd/redis:6.2.1_obd demo
   ```
   and on a separate console run
   ```sh
    journalctl --no-pager -f
   ```
   and/or
   ```
   tail -f /var/log/overlaybd.log
   ```