### PR TITLE
sys-kernel/bootengine: Pull in fix for error path and warnings

### DIFF
--- a/sdk_container/src/third_party/coreos-overlay/sys-kernel/bootengine/bootengine-9999.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/sys-kernel/bootengine/bootengine-9999.ebuild
@@ -7,8 +7,7 @@ EGIT_REPO_URI="https://github.com/flatcar/bootengine.git"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	#EGIT_COMMIT="9062833e9a93602e0e8469070ece4480dae41699" # flatcar-master
-	EGIT_BRANCH="jepio/rm-add-recurse"
+	EGIT_COMMIT="1eb892c1970a158247b3709f81d03b44de7d806e" # flatcar-master
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 

--- a/sdk_container/src/third_party/coreos-overlay/sys-kernel/bootengine/bootengine-9999.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/sys-kernel/bootengine/bootengine-9999.ebuild
@@ -7,7 +7,8 @@ EGIT_REPO_URI="https://github.com/flatcar/bootengine.git"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	EGIT_COMMIT="9062833e9a93602e0e8469070ece4480dae41699" # flatcar-master
+	#EGIT_COMMIT="9062833e9a93602e0e8469070ece4480dae41699" # flatcar-master
+	EGIT_BRANCH="jepio/rm-add-recurse"
 	KEYWORDS="amd64 arm arm64 x86"
 fi
 


### PR DESCRIPTION
This pulls in https://github.com/flatcar/bootengine/pull/106 to fix bugs in sysusr-usr.mount and
initrd-setup-root-after-ignition.service

## How to use


## Testing done

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
