### PR TITLE
pkg-auto: Parallelize generating SDK reports and package updates handling.

### DIFF
--- a/pkg_auto/impl/inside_sdk_container_lib.sh
+++ b/pkg_auto/impl/inside_sdk_container_lib.sh
@@ -434,20 +434,6 @@ function clean_empty_warning_files() {
     done
 }
 
-function get_num_proc() {
-    local -n num_proc_ref=${1}; shift
-    local -i num_proc=1 rv=1
-
-    # stolen from portage
-    [[ rv -eq 0 ]] || { rv=0; num_proc=$(getconf _NPROCESSORS_ONLN 2>/dev/null) || rv=1; }
-    [[ rv -eq 0 ]] || { rv=0; num_proc=$(sysctl -n hw.ncpu 2>/dev/null) || rv=1; }
-    # stolen from common.sh
-    [[ rv -eq 0 ]] || { rv=0; num_proc=$(grep -c "^processor" /proc/cpuinfo 2>/dev/null) || rv=1; }
-    [[ rv -eq 0 ]] || { rv=0; num_proc=1; }
-
-    num_proc_ref=${num_proc}
-}
-
 function generate_cache_for() {
     local repo=${1}; shift
 

--- a/pkg_auto/impl/jobs_lib.sh
+++ b/pkg_auto/impl/jobs_lib.sh
@@ -1,0 +1,248 @@
+#!/bin/bash
+
+# This file implements a simple jobs functionality - running tasks in
+# separate processes. Communication with the job goes through standard
+# input/output/error.
+#
+# An example use of the library is as follows:
+#
+# # Echoes everything received on standard input to standard
+# # output. Will finish if receives "shutdown".
+# function echoer_job() {
+#     local REPLY
+#     while read -r; do
+#         echo "${REPLY}"
+#         if [[ ${REPLY} = 'shutdown' ]]; then
+#             return 0
+#         fi
+#     done
+# }
+#
+# job_declare echoer
+# job_run -m echoer_job
+# job_send_input echoer one two three shutdown
+# declare -a echoer_lines=()
+# declare echoer_done=''
+# while [[ -z ${echoer_done} ]]; do
+#     if ! job_is_alive echoer; then
+#         echoer_done=x
+#     fi
+#     job_get_output echoer echoer_lines
+#     printf '%s\n' ${echoer_lines[@]/#/'from echoer job: '}
+#     sleep 0.1
+# done
+# declare -i echoer_exit_status
+# job_reap echoer echoer_exit_status
+# job_unset echoer
+# echo "echoer done with exit status ${exit_status}"
+
+
+if [[ -z ${__JOBS_LIB_SH_INCLUDED__:-} ]]; then
+__JOBS_LIB_SH_INCLUDED__=x
+
+source "$(dirname "${BASH_SOURCE[0]}")/util.sh"
+
+# Fields of the job struct.
+#
+# JOB_INFD_IDX - descriptor for standard input
+#
+# JOB_OUTFD_IDX - descriptor for standard output
+#
+# JOB_ERRFD_IDX - descriptor for standard error
+#
+# JOB_PID_IDX - job PID
+declare -gri JOB_INFD_IDX=0 JOB_OUTFD_IDX=1 JOB_ERRFD_IDX=2 JOB_PID_IDX=3
+
+# Declare job variables.
+#
+# Parameters:
+#
+# @ - names of variables to be used for jobs
+function job_declare() {
+    struct_declare -ga "${@}" "('-1' '-1' '-1' '-1')"
+}
+
+# Unset job variables.
+#
+# Parameters:
+#
+# @ - names of job variables
+function job_unset() {
+    unset "${@}"
+}
+
+# Kick off the job. The passed function will be run as a separate
+# process, and following parameters will be passed to the
+# function. For this to work, the job must be just-declared or reaped.
+#
+# Flags:
+#
+# -m - merge standard output and standard error into one descriptor
+#
+# Parameters:
+#
+# 1 - job
+# @ - function to run, followed by its parameters
+function job_run() {
+    local merge_out_with_err=
+    if [[ ${1:-} = '-m' ]]; then
+        shift
+        merge_out_with_err=x
+    fi
+    local -n job_ref=${1}; shift
+    # rest are function and args to run
+
+    local -i pid=${job_ref[JOB_PID_IDX]} infd=${job_ref[JOB_INFD_IDX]} outfd=${job_ref[JOB_OUTFD_IDX]} errfd=${job_ref[JOB_ERRFD_IDX]}
+    if [[ pid -ne -1 || infd -ne -1 || outfd -ne -1 || errfd -ne -1 ]]; then
+        fail "trying to run a job (${*@Q}), while one is already running (pid: ${pid})"
+    fi
+
+    local fd_var_name path
+    local -i new_fd
+    local -a var_names=( infd outfd )
+    if [[ -z ${merge_out_with_err} ]]; then
+        var_names+=( errfd )
+    fi
+    for fd_var_name in "${var_names[@]}"; do
+        local -n fifo_fd_ref=${fd_var_name}
+        path=$(mktemp -t -u pipe-XXXXXXXXXXXXXXXXX)
+
+        mkfifo "${path}"
+        exec {new_fd}<>"${path}"
+        rm -f "${path}"
+        fifo_fd_ref=${new_fd}
+        unset -n fifo_fd_ref
+    done
+    if [[ -n ${merge_out_with_err} ]]; then
+        errfd=${outfd}
+    fi
+    __jl_job_runner__ "${@}" <&${infd} >&${outfd} 2>&${errfd} &
+    pid=${!}
+    job_ref[JOB_PID_IDX]=${pid}
+    job_ref[JOB_INFD_IDX]=${infd}
+    job_ref[JOB_OUTFD_IDX]=${outfd}
+    job_ref[JOB_ERRFD_IDX]=${errfd}
+}
+
+# Reap the dead job and get its exit status. After this call, the job
+# can be reused for another run or unset.
+#
+# Parameters:
+#
+# 1 - job
+# 2 - name of a scalar variable, where exit status will be stored
+function job_reap() {
+    local -n job_ref=${1}; shift
+    local -n exit_status_ref=${1}; shift
+
+    local -i pid=${job_ref[JOB_PID_IDX]} infd=${job_ref[JOB_INFD_IDX]} outfd=${job_ref[JOB_OUTFD_IDX]} errfd=${job_ref[JOB_ERRFD_IDX]}
+    if [[ pid -eq -1 || infd -eq -1 || outfd -eq -1 || errfd -eq -1 ]]; then
+        fail "trying to reap nonexistent job"
+    fi
+
+    local -i es=0
+    wait "${pid}" || es=${?}
+
+    local fd_var_name
+    local -i old_fd
+    local -a var_names=(infd outfd)
+    if [[ outfd -ne errfd ]]; then
+        var_names+=( errfd )
+    fi
+    for fd_var_name in "${var_names[@]}"; do
+        local -n fifo_fd_ref=${fd_var_name}
+        old_fd=${fifo_fd_ref}
+        exec {old_fd}>&-
+        unset -n fifo_fd_ref
+    done
+    job_ref[JOB_PID_IDX]=-1
+    job_ref[JOB_INFD_IDX]=-1
+    job_ref[JOB_OUTFD_IDX]=-1
+    job_ref[JOB_ERRFD_IDX]=-1
+    exit_status_ref=${es}
+}
+
+# Check if job is still alive. Returns true if so, otherwise false.
+#
+# Parameters:
+#
+# 1 - job
+function job_is_alive() {
+    local -n job_ref=${1}; shift
+
+    local -i pid=${job_ref[JOB_PID_IDX]}
+    if [[ pid -eq -1 ]]; then
+        fail "checking status of not-yet-running or already-reaped job"
+    fi
+    # dc - don't care
+    local status dc
+    local -i ppid
+    {
+        read -r dc dc status ppid dc <"/proc/${pid}/stat" || return 1
+    } >/dev/null 2>&1
+    if [[ ppid -ne ${BASHPID} && ppid -ne ${$} ]]; then
+        # parent pid mismatch, this means that our child died and the
+        # pid got reused
+        return 1
+    fi
+    case ${status} in
+        x|X|Z)
+            # I don't think I have ever reached this line.
+            return 1
+            ;;
+    esac
+    return 0
+}
+
+# Send data to the job. Every data parameter will be a separate line.
+#
+# Parameters:
+#
+# 1 - job
+# @ - data to send
+function job_send_input() {
+    local -n job_ref=${1}; shift
+    # rest are lines to send
+    local -i infd=${job_ref[JOB_INFD_IDX]}
+
+    printf '%s\n' "${@}" >&${infd}
+}
+
+# Get output from the job. Tries to read a line from standard output,
+# then a line from standard error. If any of the reads returned data,
+# it will repeat the operations. If -m was passed to job_run, then it
+# will only read from standard output.
+#
+# Parameters:
+#
+# 1 - job
+# 2 - name of an array variable where the read lines will be stored
+function job_get_output() {
+    local -n job_ref=${1}; shift
+    local -n output_lines_ref=${1}; shift
+
+    local -i outfd=${job_ref[JOB_OUTFD_IDX]} errfd=${job_ref[JOB_ERRFD_IDX]}
+    local REPLY got_output=x
+
+    output_lines_ref=()
+    while [[ -n ${got_output} ]]; do
+        got_output=
+        if read -t 0 -u ${outfd}; then
+            read -r -u ${outfd}
+            output_lines_ref+=( "${REPLY}" )
+            got_output=x
+        fi
+        if [[ errfd -ne outfd ]] && read -t 0 -u ${errfd}; then
+            read -r -u ${errfd}
+            output_lines_ref+=( "${REPLY}" )
+            got_output=x
+        fi
+    done
+}
+
+function __jl_job_runner__() {
+    set -euo pipefail
+    "${@}"
+}
+
+fi

--- a/pkg_auto/impl/pkg_auto_lib.sh
+++ b/pkg_auto/impl/pkg_auto_lib.sh
@@ -2073,6 +2073,19 @@ function handle_package_changes_job() {
     return 0
 }
 
+# Generate a report about one, possibly renamed, package. This
+# includes generating diffs between old and new ebuilds for each of
+# used slot of a package, diffs of other files the package has, some
+# automatic reports based on md5-cache entries along with summary and
+# changelog stubs.
+#
+# Parameters:
+#
+# 1 - the main output directory, the generated output will end up in
+#     some subdirectories
+# 2 - bunch of maps (generally, package information)
+# 3 - old package name
+# 4 - new package name
 function handle_one_package_change() {
     local output_dir=${1}; shift
     local -n bunch_of_maps_ref=${1}; shift
@@ -2355,10 +2368,8 @@ function handle_one_package_change() {
     pkg_debug_disable
 }
 
-# This monstrosity takes renames map and package tags information,
-# reads the reports, does consistency checks and uses the information
-# from previous steps to write out package differences between the old
-# and new state into the reports directory.
+# Reads the reports, does consistency checks, runs jobs to process all
+# the packages, and writes out reports into the reports directory.
 #
 # Params:
 #

--- a/pkg_auto/impl/pkg_auto_lib.sh
+++ b/pkg_auto/impl/pkg_auto_lib.sh
@@ -2431,7 +2431,7 @@ function handle_pkg_update() {
         lines+=( '0:release notes: TODO' )
     fi
 
-    generate_summary_stub "${new_pkg}" "${hpu_tags[@]}" -- "${lines[@]}"
+    generate_summary_stub "${top_out_dir}" "${new_pkg}" "${hpu_tags[@]}" -- "${lines[@]}"
 }
 
 # Write information to reports directory about the modified package
@@ -2512,9 +2512,11 @@ function handle_pkg_as_is() {
         lines+=( '0:TODO: review occurences-for-old-name' )
     fi
 
+    local top_out_dir=${package_output_paths_ref[POP_OUT_DIR_IDX]}
+
     local -a hpai_tags
     tags_for_pkg "${pkg_to_tags_mvm_var_name}" "${new_pkg}" hpai_tags
-    generate_summary_stub "${new_pkg}" "${hpai_tags[@]}" -- "${lines[@]}"
+    generate_summary_stub "${top_out_dir}" "${new_pkg}" "${hpai_tags[@]}" -- "${lines[@]}"
 }
 
 # Write information to reports directory about the package downgrade
@@ -2591,7 +2593,7 @@ function handle_pkg_downgrade() {
         lines+=( "0:release notes: TODO" )
     fi
 
-    generate_summary_stub "${new_pkg}" "${hpd_tags[@]}" -- "${lines[@]}"
+    generate_summary_stub "${top_out_dir}" "${new_pkg}" "${hpd_tags[@]}" -- "${lines[@]}"
 }
 
 # Retrieves tags for a package.
@@ -2663,16 +2665,15 @@ function generate_changelog_entry_stub() {
 # Adds a stub to the summary file in reports directory.
 #
 # Params:
-# 1 - package
+# 1 - output directory
+# 2 - package
 # @ - tags followed by double dash followed by lines to append to the
 #     file
 function generate_summary_stub() {
-    local pkg
+    local out_dir pkg
+    out_dir=${1}; shift
     pkg=${1}; shift
     # rest are tags separated followed by double dash followed by lines
-
-    # shellcheck source=for-shellcheck/globals
-    source "${WORKDIR}/globals"
 
     local -a tags
     tags=()
@@ -2702,7 +2703,7 @@ function generate_summary_stub() {
             printf '  - %s\n' "${line}"
         done
         printf '\n'
-    } >>"${REPORTS_DIR}/updates/summary_stubs"
+    } >>"${out_dir}/summary_stubs"
 }
 
 # Generate diffs between directories in old state and new state for a
@@ -3202,7 +3203,7 @@ function handle_eclass() {
     else
         lines+=( '0:added from Gentoo' )
     fi
-    generate_summary_stub "${eclass}" -- "${lines[@]}"
+    generate_summary_stub "${REPORTS_DIR}/updates" "${eclass}" -- "${lines[@]}"
 }
 
 # Handle profile changes. Generates three different diffs - changes in
@@ -3274,7 +3275,7 @@ function handle_profiles() {
     done <"${out_dir}/full.diff"
     lines_to_file_truncate "${out_dir}/relevant.diff" "${relevant_lines[@]}"
     lines_to_file_truncate "${out_dir}/possibly-irrelevant-files" "${possibly_irrelevant_files[@]}"
-    generate_summary_stub profiles -- '0:TODO: review the diffs'
+    generate_summary_stub "${REPORTS_DIR}/updates" profiles -- '0:TODO: review the diffs'
 }
 
 # Handles changes in license directory. Generates brief reports and
@@ -3348,7 +3349,7 @@ function handle_licenses() {
         join_by joined ', ' "${changed[@]}"
         lines+=( "0:updated ${joined}" )
     fi
-    generate_summary_stub licenses -- "${lines[@]}"
+    generate_summary_stub "${REPORTS_DIR}/updates" licenses -- "${lines[@]}"
 }
 
 # Generates reports about changes inside the scripts directory.
@@ -3361,7 +3362,7 @@ function handle_scripts() {
     mkdir -p "${out_dir}"
 
     xdiff --unified=3 --recursive "${OLD_PORTAGE_STABLE}/scripts" "${NEW_PORTAGE_STABLE}/scripts" >"${out_dir}/scripts.diff"
-    generate_summary_stub scripts -- '0:TODO: review the diffs'
+    generate_summary_stub "${REPORTS_DIR}/updates" scripts -- '0:TODO: review the diffs'
 }
 
 fi

--- a/pkg_auto/impl/pkg_auto_lib.sh
+++ b/pkg_auto/impl/pkg_auto_lib.sh
@@ -900,6 +900,20 @@ function pkg_warn() {
     pkg_warn_d "${REPORTS_DIR}" "${@}"
 }
 
+# Adds lines to "developer warnings" file in given directory. Should
+# be used to report some failed assumption in the automation, or bugs.
+#
+# Params:
+#
+# 1 - directory where the file is
+# @ - lines to add
+function devel_warn_d() {
+    local dir=${1}; shift
+
+    pkg_debug_lines 'developer warn:' "${@}"
+    lines_to_file "${dir}/developer-warnings" "${@}"
+}
+
 # Adds lines to "developer warnings" file in reports. Should be used
 # to report some failed assumption in the automation, or bugs.
 #
@@ -910,8 +924,7 @@ function devel_warn() {
     # shellcheck source=for-shellcheck/globals
     source "${WORKDIR}/globals"
 
-    pkg_debug_lines 'developer warn:' "${@}"
-    lines_to_file "${REPORTS_DIR}/developer-warnings" "${@}"
+    devel_warn_d "${REPORTS_DIR}" "${@}"
 }
 
 # Handles package names that were missing from Gentoo by either
@@ -2200,7 +2213,7 @@ function handle_package_changes() {
             new_verminmax=${new_slot_verminmax_map_ref["${s}"]:-}
             pkg_debug "slot: ${s}, vmm old: ${old_verminmax}, vmm new: ${new_verminmax}"
             if [[ -z "${old_verminmax}" ]] || [[ -z "${new_verminmax}" ]]; then
-                devel_warn \
+                devel_warn_d "${warnings_dir}" \
                     "- no minmax info available for old and/or new:" \
                     "  - old package: ${old_name}" \
                     "    - slot: ${s}" \
@@ -2245,7 +2258,7 @@ function handle_package_changes() {
             new_verminmax=${new_slot_verminmax_map_ref["${hpc_new_s}"]:-}
             pkg_debug "jumping from slot ${hpc_old_s} (vmm: ${old_verminmax}) to slot ${hpc_new_s} (vmm: ${new_verminmax})"
             if [[ -z "${old_verminmax}" ]] || [[ -z "${new_verminmax}" ]]; then
-                devel_warn \
+                devel_warn_d "${warnings_dir}" \
                     "- no verminmax info available for old and/or new:" \
                     "  - old package: ${old_name}" \
                     "    - slot: ${hpc_old_s}" \

--- a/pkg_auto/impl/pkg_auto_lib.sh
+++ b/pkg_auto/impl/pkg_auto_lib.sh
@@ -2203,7 +2203,7 @@ function handle_package_changes() {
         # POP_PKG_SLOT_OUT_DIR_IDX will be set in loops below
 
         generate_non_ebuild_diffs "${OLD_PORTAGE_STABLE}" "${NEW_PORTAGE_STABLE}" "${old_name}" "${new_name}"
-        generate_full_diffs "${OLD_PORTAGE_STABLE}" "${NEW_PORTAGE_STABLE}" "${old_name}" "${new_name}"
+        generate_full_diffs "${hpc_update_dir_non_slot}" "${OLD_PORTAGE_STABLE}" "${NEW_PORTAGE_STABLE}" "${old_name}" "${new_name}"
         generate_package_mention_reports "${NEW_STATE}" "${old_name}" "${new_name}"
 
         hpc_changed=
@@ -2711,12 +2711,14 @@ function generate_summary_stub() {
 #
 # Params:
 #
-# 1 - path to portage-stable in old state
-# 2 - path to portage-stable in new state
-# 3 - old package name
-# 4 - new package name
+# 1 - output directory
+# 2 - path to portage-stable in old state
+# 3 - path to portage-stable in new state
+# 4 - old package name
+# 5 - new package name
 function generate_full_diffs() {
-    local old_ps new_ps old_pkg new_pkg
+    local out_dir old_ps new_ps old_pkg new_pkg
+    out_dir=${1}; shift
     old_ps=${1}; shift
     new_ps=${1}; shift
     old_pkg=${1}; shift
@@ -2726,15 +2728,12 @@ function generate_full_diffs() {
     old_path="${old_ps}/${old_pkg}"
     new_path="${new_ps}/${new_pkg}"
 
-    local gfd_update_dir
-    update_dir_non_slot "${new_pkg}" gfd_update_dir
-
     local -a common_diff_opts=(
         --recursive
         --unified=3
     )
-    xdiff "${common_diff_opts[@]}" --new-file "${old_path}" "${new_path}" >"${gfd_update_dir}/full.diff"
-    xdiff "${common_diff_opts[@]}" --brief "${old_path}" "${new_path}" >"${gfd_update_dir}/brief-summary"
+    xdiff "${common_diff_opts[@]}" --new-file "${old_path}" "${new_path}" >"${out_dir}/full.diff"
+    xdiff "${common_diff_opts[@]}" --brief "${old_path}" "${new_path}" >"${out_dir}/brief-summary"
 }
 
 # Generate a diff between non-ebuild, non-Manifest files for old and

--- a/pkg_auto/impl/pkg_auto_lib.sh
+++ b/pkg_auto/impl/pkg_auto_lib.sh
@@ -847,6 +847,20 @@ function lines_to_file() {
     printf '%s\n' "${@:2}" >>"${1}"
 }
 
+# Adds lines to "manual work needed" file in given directory.
+#
+# Params:
+#
+# 1 - directory where the file is
+# @ - lines to add
+function manual_d() {
+    local dir=${1}; shift
+    # rest are lines to print
+
+    pkg_debug_lines 'manual work needed:' "${@}"
+    lines_to_file "${dir}/manual-work-needed" "${@}"
+}
+
 # Adds lines to "manual work needed" file in reports.
 #
 # Params:
@@ -856,8 +870,7 @@ function manual() {
     # shellcheck source=for-shellcheck/globals
     source "${WORKDIR}/globals"
 
-    pkg_debug_lines 'manual work needed:' "${@}"
-    lines_to_file "${REPORTS_DIR}/manual-work-needed" "${@}"
+    manual_d "${REPORTS_DIR}" "${@}"
 }
 
 # Adds lines to "warnings" file in reports. Should be used to report
@@ -2035,6 +2048,8 @@ function handle_package_changes() {
     # handled by the automation - in such cases there will be a
     # "manual action needed" report.
 
+    local warnings_dir="${REPORTS_DIR}"
+
     local pkg_idx=0
     local old_name new_name old_repo new_repo
     local hpc_old_slots_set_var_name hpc_new_slots_set_var_name
@@ -2273,7 +2288,7 @@ function handle_package_changes() {
                 new_verminmax=${new_slot_verminmax_map_ref["${s}"]:-}
                 lines+=("      - ${s}, minmax: ${new_verminmax}")
             done
-            manual "${lines[@]}"
+            manual_d "${warnings_dir}" "${lines[@]}"
         fi
         package_output_paths_unset hpc_package_output_paths
         unset -n new_slot_verminmax_map_ref old_slot_verminmax_map_ref

--- a/pkg_auto/impl/pkg_auto_lib.sh
+++ b/pkg_auto/impl/pkg_auto_lib.sh
@@ -2275,6 +2275,8 @@ function handle_package_changes() {
     mvm_declare hpc_pkg_slots_set_mvm mvm_mvc_set
     read_reports hpc_all_pkgs hpc_pkg_slots_set_mvm
 
+    info "doing package consistency checks"
+
     # map[package]map[slot]string (string being "min version:max version")
     mvm_declare hpc_old_pkg_slot_verminmax_map_mvm mvm_mvc_map
     mvm_declare hpc_new_pkg_slot_verminmax_map_mvm mvm_mvc_map
@@ -2282,6 +2284,8 @@ function handle_package_changes() {
     consistency_checks new hpc_all_pkgs hpc_pkg_slots_set_mvm hpc_new_pkg_slot_verminmax_map_mvm
 
     unset_report_mvms
+
+    info "preparing for handling package changes"
 
     # TODO: when we handle moving packages between repos, then there
     # should be two maps, for old and new state
@@ -3237,6 +3241,8 @@ function handle_eclass() {
     # shellcheck source=for-shellcheck/globals
     source "${WORKDIR}/globals"
 
+    info "handling update of ${eclass}"
+
     local -a lines
     lines=()
     if [[ -e "${OLD_PORTAGE_STABLE}/${eclass}" ]] && [[ -e "${NEW_PORTAGE_STABLE}/${eclass}" ]]; then
@@ -3258,6 +3264,8 @@ function handle_eclass() {
 function handle_profiles() {
     # shellcheck source=for-shellcheck/globals
     source "${WORKDIR}/globals"
+
+    info "handling update of profiles"
 
     local -a files=()
     local which arch
@@ -3328,6 +3336,8 @@ function handle_profiles() {
 function handle_licenses() {
     # shellcheck source=for-shellcheck/globals
     source "${WORKDIR}/globals"
+
+    info "handling update of licenses"
 
     local -a dropped=() added=() changed=()
     local line hl_stripped
@@ -3401,6 +3411,8 @@ function handle_licenses() {
 function handle_scripts() {
     # shellcheck source=for-shellcheck/globals
     source "${WORKDIR}/globals"
+
+    info "handling update of scripts"
 
     local out_dir
     out_dir="${REPORTS_DIR}/updates/scripts"

--- a/pkg_auto/impl/pkg_auto_lib.sh
+++ b/pkg_auto/impl/pkg_auto_lib.sh
@@ -2088,6 +2088,22 @@ function handle_one_package_change() {
     local new_pkg_slot_verminmax_map_mvm_var_name=${bunch_of_maps_ref[BOM_NEW_PKG_SLOT_VERMINMAX_MAP_MVM_IDX]}
     local -n pkg_sources_map_ref=${bunch_of_maps_ref[BOM_PKG_SOURCES_MAP_IDX]}
 
+    # The function goes over a pair of old and new package names. For
+    # each name there will be some checks done (like does this package
+    # even exist). Each name in the pair has a set of used slots
+    # associated with it (the most common situation is that each have
+    # just one slot, but there are some packages that we have multiple
+    # slots installed, like app-text/docbook-xml-dtd). Some of the
+    # slots will appear in both old and new package name, sometimes
+    # there will be slots available only in the old state or only in
+    # the new state. Each slot for each package name has an associated
+    # min version and max version. So for common slots we usually
+    # compare min version for old package with max version for new
+    # package. Any inconsistencies with the versions should be
+    # reported by now. There are some edge cases with the slots that
+    # are not handled by the automation - in such cases there will be
+    # a "manual action needed" report.
+
     if [[ ${old_name} = "${new_name}" ]]; then
         info "handling update of ${new_name}"
     else
@@ -2615,23 +2631,6 @@ function handle_package_changes() {
             fi
         done
     done
-
-    # The loop below goes over the pairs of old and new package
-    # names. For each name there will be some checks done (like does
-    # this package even exist). Each name in the pair has a set of
-    # used slots associated with it (the most common situation is that
-    # each have just one slot, but there are some packages that we
-    # have multiple slots installed, like
-    # app-text/docbook-xml-dtd). Some of the slots will appear in both
-    # old and new package name, sometimes there will be slots
-    # available only in the old state or only in the new state. Each
-    # slot for each package name has an associated min version and max
-    # version. So for common slots we usually compare min version for
-    # old package with max version for new package. Any
-    # inconsistencies with the versions should be reported by
-    # now. There are some edge cases with the slots that are not
-    # handled by the automation - in such cases there will be a
-    # "manual action needed" report.
 
     pkg_job_state_unset "${pkg_job_state_names[@]}"
     bunch_of_maps_unset hpc_bunch_of_maps

--- a/pkg_auto/impl/pkg_auto_lib.sh
+++ b/pkg_auto/impl/pkg_auto_lib.sh
@@ -2204,7 +2204,7 @@ function handle_package_changes() {
 
         generate_non_ebuild_diffs "${hpc_update_dir_non_slot}" "${OLD_PORTAGE_STABLE}" "${NEW_PORTAGE_STABLE}" "${old_name}" "${new_name}"
         generate_full_diffs "${hpc_update_dir_non_slot}" "${OLD_PORTAGE_STABLE}" "${NEW_PORTAGE_STABLE}" "${old_name}" "${new_name}"
-        generate_package_mention_reports "${NEW_STATE}" "${old_name}" "${new_name}"
+        generate_package_mention_reports "${hpc_update_dir_non_slot}" "${NEW_STATE}" "${old_name}" "${new_name}"
 
         hpc_changed=
         pkg_debug 'going over common slots'
@@ -2833,22 +2833,21 @@ function generate_cache_diff_report() {
 # are mentioned in entire scripts repository. May result in two
 # separate reports if the package got renamed.
 #
-# 1 - path to scripts repo
-# 2 - old package name
-# 3 - new package name
+# 1 - output directory
+# 2 - path to scripts repo
+# 3 - old package name
+# 4 - new package name
 function generate_package_mention_reports() {
-    local scripts old_pkg new_pkg
+    local out_dir scripts old_pkg new_pkg
+    out_dir=${1}; shift
     scripts=${1}; shift
     old_pkg=${1}; shift
     new_pkg=${1}; shift
 
-    local gpr_update_dir
-    update_dir_non_slot "${new_pkg}" gpr_update_dir
-
-    generate_mention_report_for_package "${scripts}" "${new_pkg}" >"${gpr_update_dir}/occurences"
+    generate_mention_report_for_package "${scripts}" "${new_pkg}" >"${out_dir}/occurences"
 
     if [[ ${old_pkg} != "${new_pkg}" ]]; then
-        generate_mention_report_for_package "${scripts}" "${old_pkg}" >"${gpr_update_dir}/occurences-for-old-name"
+        generate_mention_report_for_package "${scripts}" "${old_pkg}" >"${out_dir}/occurences-for-old-name"
     fi
 }
 

--- a/pkg_auto/impl/pkg_auto_lib.sh
+++ b/pkg_auto/impl/pkg_auto_lib.sh
@@ -873,6 +873,20 @@ function manual() {
     manual_d "${REPORTS_DIR}" "${@}"
 }
 
+# Adds lines to "warnings" file in given directory. Should be used to
+# report some issues with the processed packages.
+#
+# Params:
+#
+# 1 - directory where the file is
+# @ - lines to add
+function pkg_warn_d() {
+    local dir=${1}; shift
+
+    pkg_debug_lines 'pkg warn:' "${@}"
+    lines_to_file "${dir}/warnings" "${@}"
+}
+
 # Adds lines to "warnings" file in reports. Should be used to report
 # some issues with the processed packages.
 #
@@ -883,8 +897,7 @@ function pkg_warn() {
     # shellcheck source=for-shellcheck/globals
     source "${WORKDIR}/globals"
 
-    pkg_debug_lines 'pkg warn:' "${@}"
-    lines_to_file "${REPORTS_DIR}/warnings" "${@}"
+    pkg_warn_d "${REPORTS_DIR}" "${@}"
 }
 
 # Adds lines to "developer warnings" file in reports. Should be used
@@ -2080,7 +2093,7 @@ function handle_package_changes() {
         old_repo=${hpc_package_sources_map["${old_name}"]:-}
         new_repo=${hpc_package_sources_map["${new_name}"]:-}
         if [[ -z ${old_repo} ]]; then
-            pkg_warn \
+            pkg_warn_d "${warnings_dir}" \
                 '- package not in old state' \
                 "  - old package: ${old_name}" \
                 "  - new package: ${new_name}"
@@ -2088,7 +2101,7 @@ function handle_package_changes() {
             continue
         fi
         if [[ -z ${new_repo} ]]; then
-            pkg_warn \
+            pkg_warn_d "${warnings_dir}" \
                 '- package not in new state' \
                 "  - old package: ${old_name}" \
                 "  - new package: ${new_name}"
@@ -2098,7 +2111,7 @@ function handle_package_changes() {
         if [[ ${old_repo} != "${new_repo}" ]]; then
             # This is pretty much an arbitrary limitation and I don't
             # remember any more why we have it.
-            pkg_warn \
+            pkg_warn_d "${warnings_dir}" \
                 '- package has moved between repos? unsupported for now' \
                 "  - old package and repo: ${old_name} ${old_repo}" \
                 "  - new package and repo: ${new_name} ${new_repo}"

--- a/pkg_auto/impl/pkg_auto_lib.sh
+++ b/pkg_auto/impl/pkg_auto_lib.sh
@@ -1909,6 +1909,53 @@ function read_package_sources() {
     done
 }
 
+# Fields of the bunch of maps struct.
+#
+# BOM_PKG_TO_TAGS_MVM_IDX - mapping of a package name to an array of
+#                           tags (mostly describing where the package
+#                           is used, like SDK or azure OEM or python
+#                           sysext)
+#
+# BOM_PKG_SLOTS_SET_MVM_IDX - mapping of a package name to a set of
+#                             slots available for the package (slots
+#                             before the update and after the update
+#                             are mixed here)
+#
+# BOM_OLD_PKG_SLOT_VERMINMAX_MAP_MVM_IDX - mapping of a package name
+#                                          to used slots, each slot is
+#                                          associated with a pair of
+#                                          versions - lowest and
+#                                          greatest used version (for
+#                                          consistent packages, these
+#                                          versions are the same); the
+#                                          mapping is for packages
+#                                          before the update
+#
+# BOM_NEW_PKG_SLOT_VERMINMAX_MAP_MVM_IDX - same as above, but for
+#                                          packages after the update
+#
+# BOM_PKG_SOURCES_MAP_IDX - mapping of package name to the repository
+#                           name
+declare -gri BOM_PKG_TO_TAGS_MVM_IDX=0 BOM_PKG_SLOTS_SET_MVM_IDX=1 BOM_OLD_PKG_SLOT_VERMINMAX_MAP_MVM_IDX=2 BOM_NEW_PKG_SLOT_VERMINMAX_MAP_MVM_IDX=3 BOM_PKG_SOURCES_MAP_IDX=4
+
+# Declare bunch of maps variables.
+#
+# Parameters:
+#
+# @ - names of variables to be used for bunch of maps
+function bunch_of_maps_declare() {
+    struct_declare -ga "${@}" "( '' '' '' '' '' )"
+}
+
+# Unset bunch of maps variables.
+#
+# Parameters:
+#
+# @ - names of bunch of maps variables
+function bunch_of_maps_unset() {
+    unset "${@}"
+}
+
 # Fields of the package output paths struct.
 #
 # POP_OUT_DIR_IDX - toplevel output directory.
@@ -2056,6 +2103,13 @@ function handle_package_changes() {
         fi
     done
     unset added_pkg_to_index_map
+
+    bunch_of_maps_declare hpc_bunch_of_maps
+    hpc_bunch_of_maps[BOM_PKG_TO_TAGS_MVM_IDX]=${pkg_to_tags_mvm_var_name}
+    hpc_bunch_of_maps[BOM_PKG_SLOTS_SET_MVM_IDX]=hpc_pkg_slots_set_mvm
+    hpc_bunch_of_maps[BOM_OLD_PKG_SLOT_VERMINMAX_MAP_MVM_IDX]=hpc_old_pkg_slot_verminmax_map_mvm
+    hpc_bunch_of_maps[BOM_NEW_PKG_SLOT_VERMINMAX_MAP_MVM_IDX]=hpc_new_pkg_slot_verminmax_map_mvm
+    hpc_bunch_of_maps[BOM_PKG_SOURCES_MAP_IDX]=hpc_package_sources_map
 
     # The loop below goes over the pairs of old and new package
     # names. For each name there will be some checks done (like does
@@ -2335,6 +2389,8 @@ function handle_package_changes() {
         fi
         pkg_debug_disable
     done
+
+    bunch_of_maps_unset hpc_bunch_of_maps
 
     mvm_unset hpc_new_pkg_slot_verminmax_map_mvm
     mvm_unset hpc_old_pkg_slot_verminmax_map_mvm

--- a/pkg_auto/impl/pkg_auto_lib.sh
+++ b/pkg_auto/impl/pkg_auto_lib.sh
@@ -2688,25 +2688,21 @@ function get_first_from_set() {
 # 5 - old version
 # 6 - new version
 function handle_pkg_update() {
-    local pkg_to_tags_mvm_var_name old_pkg new_pkg old new
     local -n package_output_paths_ref=${1}; shift
-    pkg_to_tags_mvm_var_name=${1}; shift
-    old_pkg=${1}; shift
-    new_pkg=${1}; shift
-    old=${1}; shift
-    new=${1}; shift
+    local pkg_to_tags_mvm_var_name=${1}; shift
+    local old_pkg=${1}; shift
+    local new_pkg=${1}; shift
+    local old=${1}; shift
+    local new=${1}; shift
 
     # shellcheck source=for-shellcheck/globals
     source "${WORKDIR}/globals"
 
-    local old_no_r new_no_r
-    old_no_r=${old%-r+([0-9])}
-    new_no_r=${new%-r+([0-9])}
+    local old_no_r=${old%-r+([0-9])}
+    local new_no_r=${new%-r+([0-9])}
 
-    local pkg_name
-    pkg_name=${new_pkg#*/}
-    local -a lines
-    lines=( "0:from ${old} to ${new}")
+    local pkg_name=${new_pkg#*/}
+    local -a lines=( "0:from ${old} to ${new}" )
     if [[ ${old_pkg} != "${new_pkg}" ]]; then
         lines+=( "0:renamed from ${old_pkg}" )
     fi
@@ -2766,24 +2762,20 @@ function handle_pkg_update() {
 #     has changed (empty means nothing changed, non-empty means
 #     something has changed)
 function handle_pkg_as_is() {
-    local pkg_to_tags_mvm_var_name old_pkg new_pkg v
     local -n package_output_paths_ref=${1}; shift
-    pkg_to_tags_mvm_var_name=${1}; shift
-    old_pkg=${1}; shift
-    new_pkg=${1}; shift
-    v=${1}; shift
+    local pkg_to_tags_mvm_var_name=${1}; shift
+    local old_pkg=${1}; shift
+    local new_pkg=${1}; shift
+    local v=${1}; shift
     local -n changed_ref=${1}; shift
 
     # shellcheck source=for-shellcheck/globals
     source "${WORKDIR}/globals"
 
-    local pkg_name
-    pkg_name=${new_pkg#/}
-    local -a lines
-    lines=( "0:still at ${v}" )
+    local pkg_name=${new_pkg#/}
+    local -a lines=( "0:still at ${v}" )
 
-    local renamed
-    renamed=
+    local renamed=''
     if [[ ${old_pkg} != "${new_pkg}" ]]; then
         lines+=( "0:renamed from ${old_pkg}" )
         renamed=x
@@ -2792,8 +2784,7 @@ function handle_pkg_as_is() {
     local out_dir=${package_output_paths_ref[POP_PKG_SLOT_OUT_DIR_IDX]}
     generate_ebuild_diff "${out_dir}" "${OLD_PORTAGE_STABLE}" "${NEW_PORTAGE_STABLE}" "${old_pkg}" "${new_pkg}" "${v}" "${v}"
 
-    local modified
-    modified=
+    local modified=''
 
     local diff_report_name
     gen_varname diff_report_name
@@ -2849,25 +2840,21 @@ function handle_pkg_as_is() {
 # 5 - old version
 # 6 - new version
 function handle_pkg_downgrade() {
-    local pkg_to_tags_mvm_var_name old_pkg new_pkg old new
     local -n package_output_paths_ref=${1}; shift
-    pkg_to_tags_mvm_var_name=${1}; shift
-    old_pkg=${1}; shift
-    new_pkg=${1}; shift
-    old=${1}; shift
-    new=${1}; shift
+    local pkg_to_tags_mvm_var_name=${1}; shift
+    local old_pkg=${1}; shift
+    local new_pkg=${1}; shift
+    local old=${1}; shift
+    local new=${1}; shift
 
     # shellcheck source=for-shellcheck/globals
     source "${WORKDIR}/globals"
 
-    local old_no_r new_no_r
-    old_no_r=${old%-r+([0-9])}
-    new_no_r=${new%-r+([0-9])}
+    local old_no_r=${old%-r+([0-9])}
+    local new_no_r=${new%-r+([0-9])}
 
-    local pkg_name
-    pkg_name=${new_pkg#*/}
-    local -a lines
-    lines=( "0:downgraded from ${old} to ${new}" )
+    local pkg_name=${new_pkg#*/}
+    local -a lines=( "0:downgraded from ${old} to ${new}" )
     if [[ ${old_pkg} != "${new_pkg}" ]]; then
         lines+=( "0:renamed from ${old_pkg}" )
     fi
@@ -2950,10 +2937,9 @@ function tags_for_pkg() {
 # 3 - version
 # @ - package tags
 function generate_changelog_entry_stub() {
-    local out_dir pkg_name v
-    out_dir=${1}; shift
-    pkg_name=${1}; shift
-    v=${1}; shift
+    local out_dir=${1}; shift
+    local pkg_name=${1}; shift
+    local v=${1}; shift
     # rest are tags
 
     local -a applied_tags=()
@@ -2987,13 +2973,11 @@ function generate_changelog_entry_stub() {
 # @ - tags followed by double dash followed by lines to append to the
 #     file
 function generate_summary_stub() {
-    local out_dir pkg
-    out_dir=${1}; shift
-    pkg=${1}; shift
+    local out_dir=${1}; shift
+    local pkg=${1}; shift
     # rest are tags separated followed by double dash followed by lines
 
-    local -a tags
-    tags=()
+    local -a tags=()
     while [[ ${#} -gt 0 ]]; do
         if [[ ${1} = '--' ]]; then
             shift
@@ -3034,16 +3018,14 @@ function generate_summary_stub() {
 # 4 - old package name
 # 5 - new package name
 function generate_full_diffs() {
-    local out_dir old_ps new_ps old_pkg new_pkg
-    out_dir=${1}; shift
-    old_ps=${1}; shift
-    new_ps=${1}; shift
-    old_pkg=${1}; shift
-    new_pkg=${1}; shift
+    local out_dir=${1}; shift
+    local old_ps=${1}; shift
+    local new_ps=${1}; shift
+    local old_pkg=${1}; shift
+    local new_pkg=${1}; shift
 
-    local old_path new_path
-    old_path="${old_ps}/${old_pkg}"
-    new_path="${new_ps}/${new_pkg}"
+    local old_path="${old_ps}/${old_pkg}"
+    local new_path="${new_ps}/${new_pkg}"
 
     local -a common_diff_opts=(
         --recursive
@@ -3064,16 +3046,14 @@ function generate_full_diffs() {
 # 4 - old package name
 # 5 - new package name
 function generate_non_ebuild_diffs() {
-    local out_dir old_ps new_ps old_pkg new_pkg
-    out_dir=${1}; shift
-    old_ps=${1}; shift
-    new_ps=${1}; shift
-    old_pkg=${1}; shift
-    new_pkg=${1}; shift
+    local out_dir=${1}; shift
+    local old_ps=${1}; shift
+    local new_ps=${1}; shift
+    local old_pkg=${1}; shift
+    local new_pkg=${1}; shift
 
-    local old_path new_path
-    old_path="${old_ps}/${old_pkg}"
-    new_path="${new_ps}/${new_pkg}"
+    local old_path="${old_ps}/${old_pkg}"
+    local new_path="${new_ps}/${new_pkg}"
 
     local -a diff_opts=(
         --recursive
@@ -3099,22 +3079,19 @@ function generate_non_ebuild_diffs() {
 # 6 - old package version
 # 7 - new package version
 function generate_ebuild_diff() {
-    local out_dir old_ps new_ps old_pkg new_pkg old new
-    out_dir=${1}; shift
-    old_ps=${1}; shift
-    new_ps=${1}; shift
-    old_pkg=${1}; shift
-    new_pkg=${1}; shift
-    old=${1}; shift
-    new=${1}; shift
+    local out_dir=${1}; shift
+    local old_ps=${1}; shift
+    local new_ps=${1}; shift
+    local old_pkg=${1}; shift
+    local new_pkg=${1}; shift
+    local old=${1}; shift
+    local new=${1}; shift
 
-    local old_pkg_name new_pkg_name
-    old_pkg_name=${old_pkg#*/}
-    new_pkg_name=${new_pkg#*/}
+    local old_pkg_name=${old_pkg#*/}
+    local new_pkg_name=${new_pkg#*/}
 
-    local old_path new_path
-    old_path="${old_ps}/${old_pkg}/${old_pkg_name}-${old}.ebuild"
-    new_path="${new_ps}/${new_pkg}/${new_pkg_name}-${new}.ebuild"
+    local old_path="${old_ps}/${old_pkg}/${old_pkg_name}-${old}.ebuild"
+    local new_path="${new_ps}/${new_pkg}/${new_pkg_name}-${new}.ebuild"
 
     xdiff --unified=3 "${old_path}" "${new_path}" >"${out_dir}/ebuild.diff"
 }
@@ -3155,11 +3132,10 @@ function generate_cache_diff_report() {
 # 3 - old package name
 # 4 - new package name
 function generate_package_mention_reports() {
-    local out_dir scripts old_pkg new_pkg
-    out_dir=${1}; shift
-    scripts=${1}; shift
-    old_pkg=${1}; shift
-    new_pkg=${1}; shift
+    local out_dir=${1}; shift
+    local scripts=${1}; shift
+    local old_pkg=${1}; shift
+    local new_pkg=${1}; shift
 
     generate_mention_report_for_package "${scripts}" "${new_pkg}" >"${out_dir}/occurences"
 

--- a/pkg_auto/impl/pkg_auto_lib.sh
+++ b/pkg_auto/impl/pkg_auto_lib.sh
@@ -2901,53 +2901,6 @@ function generate_mention_report_for_package() {
     grep_pkg "${scripts}" "${pkg}" ":(exclude)${ps}" ":(exclude)${co}"
 }
 
-# Gets a toplevel update reports directory for a package. This is
-# where occurences and non-ebuild diffs are stored.
-#
-# Params:
-#
-# 1 - package name
-# 2 - name of a variable where the path will be stored
-function update_dir_non_slot() {
-    local pkg
-    pkg=${1}; shift
-    local -n dir_ref=${1}; shift
-
-    # shellcheck source=for-shellcheck/globals
-    source "${WORKDIR}/globals"
-
-    dir_ref="${REPORTS_DIR}/updates/${pkg}"
-}
-
-# Gets a slot specific update reports directory for a package. This is
-# where ebuild diffs are stored.
-#
-# Params:
-#
-# 1 - package name
-# 2 - old slot
-# 3 - new slot
-# 4 - name of a variable where the path will be stored
-function update_dir() {
-    local pkg old_s new_s
-    pkg=${1}; shift
-    old_s=${1}; shift
-    new_s=${1}; shift
-    local -n dir_ref=${1}; shift
-
-    # slots may have slashes in them - replace them with "-slash-"
-    local slot_dir
-    if [[ ${old_s} = "${new_s}" ]]; then
-        slot_dir=${old_s//\//-slash-}
-    else
-        slot_dir="${old_s//\//-slash-}-to-${new_s//\//-slash-}"
-    fi
-
-    local ud_non_slot_dir
-    update_dir_non_slot "${pkg}" ud_non_slot_dir
-    dir_ref="${ud_non_slot_dir}/${slot_dir}"
-}
-
 # Gets a slot-specific directory name for ebuild diffs.
 #
 # Params:

--- a/pkg_auto/impl/pkg_auto_lib.sh
+++ b/pkg_auto/impl/pkg_auto_lib.sh
@@ -53,6 +53,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/util.sh"
 source "${PKG_AUTO_IMPL_DIR}/cleanups.sh"
 source "${PKG_AUTO_IMPL_DIR}/debug.sh"
 source "${PKG_AUTO_IMPL_DIR}/gentoo_ver.sh"
+source "${PKG_AUTO_IMPL_DIR}/jobs_lib.sh"
 source "${PKG_AUTO_IMPL_DIR}/md5_cache_diff_lib.sh"
 
 # Sets up the workdir using the passed config. The config can be
@@ -1051,6 +1052,51 @@ function set_mvm_to_array_mvm_cb() {
     mvm_add "${pkg_to_tags_mvm_var_name}" "${pkg}" "${prod_item[@]}" "${sorted_items[@]}"
 }
 
+# Fields of the sdk job state struct.
+#
+# SJS_COMMAND_IDX - an array containing a command to run
+#
+# SJS_STATE_DIR_IDX - run's state directory
+#
+# SJS_KIND_IDX - run kind (either old or new, meaning reports for
+# packages before updates or after updates)
+#
+# SJS_JOB_NAME_IDX - job variable name
+declare -gri SJS_COMMAND_IDX=0 SJS_STATE_DIR_IDX=1 SJS_KIND_IDX=2 SJS_JOB_NAME_IDX=3
+
+# Declare SDK job state variables.
+#
+# Parameters:
+#
+# @ - names of variables to be used for states.
+function sdk_job_state_declare() {
+    struct_declare -ga "${@}" "( 'EMPTY_ARRAY' '' '' '' )"
+}
+
+# Unset SDK job state variables.
+#
+# Parameters:
+#
+# @ - names of state variables
+function sdk_job_state_unset() {
+    local name
+    for name; do
+        local -n sdk_job_state_ref=${name}
+        local array_name=${sdk_job_state_ref[SJS_COMMAND_IDX]}
+        if [[ ${array_name} != 'EMPTY_ARRAY' ]]; then
+            unset "${array_name}"
+        fi
+        unset array_name
+        local job_name=${sdk_job_state_ref[SJS_JOB_NAME_IDX]}
+        if [[ -n ${job_name} ]]; then
+            job_unset "${job_name}"
+        fi
+        unset job_name
+        unset -n sdk_run_state_ref
+    done
+    unset "${@}"
+}
+
 # Generate package reports inside SDKs for all arches and states. In
 # case of failure, whatever reports where generated so far will be
 # stored in salvaged-reports subdirectory of the reports directory.
@@ -1071,6 +1117,13 @@ function generate_sdk_reports() {
     local sdk_reports_dir top_dir dir entry full_path
     local -a dir_queue all_dirs all_files
 
+    local job_args_var_name sdk_job_state_name
+    local -a sdk_job_state_names=()
+
+    # First create and set up SDK job states for the "before updates"
+    # (referred as old) and "after updates" (referred as new)
+    # jobs. This means creating a separate worktrees, state
+    # directories, and preparing commands to be run as a job.
     for sdk_run_kind in "${WHICH[@]}"; do
         state_var_name="${sdk_run_kind^^}_STATE"
         sdk_run_state="${!state_var_name}_sdk_run"
@@ -1088,22 +1141,115 @@ function generate_sdk_reports() {
         pkg_auto_copy=$(mktemp --tmpdir="${WORKDIR}" --directory "pkg-auto-copy.XXXXXXXX")
         add_cleanup "rm -rf ${pkg_auto_copy@Q}"
         cp -a "${PKG_AUTO_DIR}"/* "${pkg_auto_copy}"
-        local -a run_sdk_container_args=(
-            -C "${SDK_IMAGE}"
-            -n "pkg-${sdk_run_kind}"
-            -U
-            -m "${pkg_auto_copy}:/mnt/host/source/src/scripts/pkg_auto"
-            --rm
-            ./pkg_auto/inside_sdk_container.sh pkg-reports "${ARCHES[@]}"
+        gen_varname job_args_var_name
+        declare -ga "${job_args_var_name}=()"
+        local -n job_args_ref=${job_args_var_name}
+        job_args_ref=(
+            env
+                --chdir "${sdk_run_state}"
+                ./run_sdk_container
+                    -C "${SDK_IMAGE}"
+                    -n "pkg-${sdk_run_kind}"
+                    -U
+                    -m "${pkg_auto_copy}:/mnt/host/source/src/scripts/pkg_auto"
+                    --rm
+                    ./pkg_auto/inside_sdk_container.sh
+                        pkg-reports
+                        "${ARCHES[@]}"
         )
-        rv=0
-        env --chdir "${sdk_run_state}" ./run_sdk_container "${run_sdk_container_args[@]}" || rv=${?}
-        unset run_sdk_container_args
+        unset -n job_args_ref
+
+        gen_varname sdk_job_state_name
+        sdk_job_state_declare "${sdk_job_state_name}"
+        local -n sdk_job_state_ref="${sdk_job_state_name}"
+        sdk_job_state_ref[SJS_COMMAND_IDX]=${job_args_var_name}
+        sdk_job_state_ref[SJS_STATE_DIR_IDX]=${sdk_run_state}
+        sdk_job_state_ref[SJS_KIND_IDX]=${sdk_run_kind}
+        unset -n sdk_job_state_ref
+
+        sdk_job_state_names+=( "${sdk_job_state_name}" )
+    done
+
+    # Create the jobs and kick them off.
+    local sdk_job_name
+    for sdk_job_state_name in "${sdk_job_state_names[@]}"; do
+        local -n sdk_job_state_ref=${sdk_job_state_name}
+        job_args_var_name=${sdk_job_state_ref[SJS_COMMAND_IDX]}
+
+        gen_varname sdk_job_name
+        job_declare "${sdk_job_name}"
+        all_sdk_jobs+=( "${sdk_job_name}" )
+
+        local -n job_args_ref=${job_args_var_name}
+        job_run -m "${sdk_job_name}" "${job_args_ref[@]}"
+        unset -n job_args_ref
+
+        sdk_job_state_ref[SJS_JOB_NAME_IDX]=${sdk_job_name}
+        unset -n sdk_job_state_ref
+    done
+
+    # Loop over the current running job states array to check if jobs
+    # in the array are still alive. The alive jobs will be added to
+    # the next running job states array that will be looped over (thus
+    # becoming the "current" array, whereas old "current" array
+    # becomes "next"). In the meantime gather the output from the jobs
+    # and print it to the terminal.
+    local -i current_idx=0 next_idx=1 idx state_count=${#sdk_job_state_names[@]}
+    local -a sdk_job_state_names_0=( "${sdk_job_state_names[@]}" ) sdk_job_state_names_1=() sdk_job_output_lines=()
+    local run_loop=x
+    while [[ state_count -gt 0 ]]; do
+        local -n sdk_jobs_state_names_ref=sdk_job_state_names_${current_idx}
+        local -n next_sdk_jobs_state_names_ref=sdk_job_state_names_${next_idx}
+        next_sdk_jobs_state_names_ref=()
+        for sdk_job_state_name in "${sdk_jobs_state_names_ref[@]}"; do
+            local -n sdk_job_state_ref=${sdk_job_state_name}
+            sdk_job_name=${sdk_job_state_ref[SJS_JOB_NAME_IDX]}
+            sdk_run_kind=${sdk_job_state_ref[SJS_KIND_IDX]}
+            unset -n sdk_job_state_ref
+            if job_is_alive "${sdk_job_name}"; then
+                next_sdk_jobs_state_names_ref+=( "${sdk_job_state_name}" )
+            fi
+            job_get_output "${sdk_job_name}" sdk_job_output_lines
+            if [[ ${#sdk_job_output_lines[@]} -gt 0 ]]; then
+                info_lines "${sdk_job_output_lines[@]/#/${sdk_run_kind}: }"
+            fi
+        done
+        state_count=${#next_sdk_jobs_state_names_ref[@]}
+        if [[ state_count -gt 0 ]]; then
+            sleep 0.2
+        fi
+        idx=${current_idx}
+        current_idx=${next_idx}
+        next_idx=${idx}
+        unset -n sdk_jobs_state_names_ref next_sdk_jobs_state_names_ref
+    done
+
+    # All jobs are done now, so reap them and check if the
+    # succeeded. If they failed, print the contents of the warning
+    # files and save the reports they have generated so far in a
+    # separate place.
+    local sr_dir_created='' gsr_sdk_run_state_basename
+    for sdk_job_state_name in "${sdk_job_state_names[@]}"; do
+        local -n sdk_job_state_ref=${sdk_job_state_name}
+        sdk_job_name=${sdk_job_state_ref[SJS_JOB_NAME_IDX]}
+        sdk_run_state=${sdk_job_state_ref[SJS_STATE_DIR_IDX]}
+        sdk_run_kind=${sdk_job_state_ref[SJS_KIND_IDX]}
+        unset -n sdk_job_state_ref
+        job_reap "${sdk_job_name}" rv
         if [[ ${rv} -ne 0 ]]; then
-            local salvaged_dir
+            # Report generation failed, save the generated reports in
+            # REPORTS_DIR for further examination by the developer.
+            local salvaged_dir salvaged_dir_sdk
             salvaged_dir="${REPORTS_DIR}/salvaged-reports"
+            basename_out "${sdk_run_state}" gsr_sdk_run_state_basename
+            salvaged_dir_sdk="${salvaged_dir}/${gsr_sdk_run_state_basename}"
+            if [[ -z ${sr_dir_created} ]]; then
+                rm -rf "${salvaged_dir}"
+                mkdir -p "${salvaged_dir}"
+                sr_dir_created=x
+            fi
             {
-                info "run_sdk_container finished with exit status ${rv}, printing the warnings below for a clue"
+                info "run_sdk_container for ${sdk_run_kind@Q} finished with exit status ${rv}, printing the warnings below for a clue"
                 info
                 for file in "${sdk_run_state}/pkg-reports/"*'-warnings'; do
                     info "from ${file}:"
@@ -1113,43 +1259,50 @@ function generate_sdk_reports() {
                 done
                 info
                 info 'whatever reports generated by the failed run are saved in'
-                info "${salvaged_dir@Q} directory"
+                info "${salvaged_dir_sdk@Q} directory"
                 info
             } >&2
-            rm -rf "${salvaged_dir}"
-            cp -a "${sdk_run_state}/pkg-reports" "${salvaged_dir}"
-            unset salvaged_dir
-            fail "copying done, stopping now"
-        fi
-        sdk_reports_dir="${WORKDIR}/pkg-reports/${sdk_run_kind}"
-        top_dir="${sdk_run_state}/pkg-reports"
-        dir_queue=( "${top_dir}" )
-        all_dirs=()
-        all_files=()
-        while [[ ${#dir_queue[@]} -gt 0 ]]; do
-            dir=${dir_queue[0]}
-            dir_queue=( "${dir_queue[@]:1}" )
-            entry=${dir#"${top_dir}"}
-            if [[ -z ${entry} ]]; then
-                all_dirs=( "${sdk_reports_dir}" "${all_dirs[@]}" )
-            else
-                entry=${entry#/}
-                all_dirs=( "${sdk_reports_dir}/${entry}" "${all_dirs[@]}" )
-            fi
-            for full_path in "${dir}/"*; do
-                if [[ -d ${full_path} ]]; then
-                    dir_queue+=( "${full_path}" )
+            cp -a "${sdk_run_state}/pkg-reports" "${salvaged_dir_sdk}"
+            unset salvaged_dir salvaged_dir_sdk
+        else
+            # We succeeded, so move the reports from the state dir to
+            # workdir and generate cleanups for the moved reports.
+            sdk_reports_dir="${WORKDIR}/pkg-reports/${sdk_run_kind}"
+            top_dir="${sdk_run_state}/pkg-reports"
+            dir_queue=( "${top_dir}" )
+            all_dirs=()
+            all_files=()
+            while [[ ${#dir_queue[@]} -gt 0 ]]; do
+                dir=${dir_queue[0]}
+                dir_queue=( "${dir_queue[@]:1}" )
+                entry=${dir#"${top_dir}"}
+                if [[ -z ${entry} ]]; then
+                    all_dirs=( "${sdk_reports_dir}" "${all_dirs[@]}" )
                 else
-                    entry=${full_path##"${top_dir}/"}
-                    all_files+=( "${sdk_reports_dir}/${entry}" )
+                    entry=${entry#/}
+                    all_dirs=( "${sdk_reports_dir}/${entry}" "${all_dirs[@]}" )
                 fi
+                for full_path in "${dir}/"*; do
+                    if [[ -d ${full_path} ]]; then
+                        dir_queue+=( "${full_path}" )
+                    else
+                        entry=${full_path##"${top_dir}/"}
+                        all_files+=( "${sdk_reports_dir}/${entry}" )
+                    fi
+                done
             done
-        done
-        add_cleanup \
-            "rm -f ${all_files[*]@Q}" \
-            "rmdir ${all_dirs[*]@Q}"
-        mv "${sdk_run_state}/pkg-reports" "${sdk_reports_dir}"
+            add_cleanup \
+                "rm -f ${all_files[*]@Q}" \
+                "rmdir ${all_dirs[*]@Q}"
+            mv "${sdk_run_state}/pkg-reports" "${sdk_reports_dir}"
+        fi
     done
+    sdk_job_state_unset "${sdk_job_state_names[@]}"
+    # salvaged reports directory was created, means that report
+    # generation failed
+    if [[ -n ${sr_dir_created} ]]; then
+        fail "copying done, stopping now"
+    fi
 
     cp -a "${WORKDIR}/pkg-reports" "${REPORTS_DIR}/reports-from-sdk"
 }

--- a/pkg_auto/impl/pkg_auto_lib.sh
+++ b/pkg_auto/impl/pkg_auto_lib.sh
@@ -2202,7 +2202,7 @@ function handle_package_changes() {
         hpc_package_output_paths[POP_PKG_OUT_DIR_IDX]=${hpc_update_dir_non_slot}
         # POP_PKG_SLOT_OUT_DIR_IDX will be set in loops below
 
-        generate_non_ebuild_diffs "${OLD_PORTAGE_STABLE}" "${NEW_PORTAGE_STABLE}" "${old_name}" "${new_name}"
+        generate_non_ebuild_diffs "${hpc_update_dir_non_slot}" "${OLD_PORTAGE_STABLE}" "${NEW_PORTAGE_STABLE}" "${old_name}" "${new_name}"
         generate_full_diffs "${hpc_update_dir_non_slot}" "${OLD_PORTAGE_STABLE}" "${NEW_PORTAGE_STABLE}" "${old_name}" "${new_name}"
         generate_package_mention_reports "${NEW_STATE}" "${old_name}" "${new_name}"
 
@@ -2741,12 +2741,14 @@ function generate_full_diffs() {
 #
 # Params:
 #
-# 1 - path to portage-stable in old state
-# 2 - path to portage-stable in new state
-# 3 - old package name
-# 4 - new package name
+# 1 - output directory
+# 2 - path to portage-stable in old state
+# 3 - path to portage-stable in new state
+# 4 - old package name
+# 5 - new package name
 function generate_non_ebuild_diffs() {
-    local old_ps new_ps old_pkg new_pkg
+    local out_dir old_ps new_ps old_pkg new_pkg
+    out_dir=${1}; shift
     old_ps=${1}; shift
     new_ps=${1}; shift
     old_pkg=${1}; shift
@@ -2755,9 +2757,6 @@ function generate_non_ebuild_diffs() {
     local old_path new_path
     old_path="${old_ps}/${old_pkg}"
     new_path="${new_ps}/${new_pkg}"
-
-    local gned_update_dir
-    update_dir_non_slot "${new_pkg}" gned_update_dir
 
     local -a diff_opts=(
         --recursive
@@ -2768,7 +2767,7 @@ function generate_non_ebuild_diffs() {
         --exclude='*.ebuild'
         --exclude='Manifest'
     )
-    xdiff "${diff_opts[@]}" "${old_path}" "${new_path}" >"${gned_update_dir}/other.diff"
+    xdiff "${diff_opts[@]}" "${old_path}" "${new_path}" >"${out_dir}/other.diff"
 }
 
 # Generate a diff between specific ebuilds for old and new package.

--- a/pkg_auto/impl/pkg_auto_lib.sh
+++ b/pkg_auto/impl/pkg_auto_lib.sh
@@ -2423,9 +2423,11 @@ function handle_pkg_update() {
     local -a hpu_tags
     tags_for_pkg "${pkg_to_tags_mvm_var_name}" "${new_pkg}" hpu_tags
 
+    local top_out_dir=${package_output_paths_ref[POP_OUT_DIR_IDX]}
+
     if ver_test "${new_no_r}" -gt "${old_no_r}"; then
         # version bump
-        generate_changelog_entry_stub "${pkg_name}" "${new_no_r}" "${hpu_tags[@]}"
+        generate_changelog_entry_stub "${top_out_dir}" "${pkg_name}" "${new_no_r}" "${hpu_tags[@]}"
         lines+=( '0:release notes: TODO' )
     fi
 
@@ -2581,9 +2583,11 @@ function handle_pkg_downgrade() {
     local -a hpd_tags
     tags_for_pkg "${pkg_to_tags_mvm_var_name}" "${new_pkg}" hpd_tags
 
+    local top_out_dir=${package_output_paths_ref[POP_OUT_DIR_IDX]}
+
     if ver_test "${new_no_r}" -lt "${old_no_r}"; then
         # version bump
-        generate_changelog_entry_stub "${pkg_name}" "${new_no_r}" "${hpd_tags[@]}"
+        generate_changelog_entry_stub "${top_out_dir}" "${pkg_name}" "${new_no_r}" "${hpd_tags[@]}"
         lines+=( "0:release notes: TODO" )
     fi
 
@@ -2622,11 +2626,13 @@ function tags_for_pkg() {
 # Adds a changelog stub to changelog file in reports directory.
 #
 # Params:
-# 1 - package name (shortened, without the category)
-# 2 - version
+# 1 - output directory
+# 2 - package name (shortened, without the category)
+# 3 - version
 # @ - package tags
 function generate_changelog_entry_stub() {
-    local pkg_name v
+    local out_dir pkg_name v
+    out_dir=${1}; shift
     pkg_name=${1}; shift
     v=${1}; shift
     # rest are tags
@@ -2651,10 +2657,7 @@ function generate_changelog_entry_stub() {
         gces_tags='SDK'
     fi
 
-    # shellcheck source=for-shellcheck/globals
-    source "${WORKDIR}/globals"
-
-    printf '%s %s: %s ([%s](TODO))\n' '-' "${gces_tags}" "${pkg_name}" "${v}" >>"${REPORTS_DIR}/updates/changelog_stubs"
+    printf '%s %s: %s ([%s](TODO))\n' '-' "${gces_tags}" "${pkg_name}" "${v}" >>"${out_dir}/changelog_stubs"
 }
 
 # Adds a stub to the summary file in reports directory.

--- a/pkg_auto/impl/util.sh
+++ b/pkg_auto/impl/util.sh
@@ -333,4 +333,20 @@ function struct_declare() {
     declare "${args[@]}" "${@}"
 }
 
+function get_num_proc() {
+    local -n num_proc_ref=${1}; shift
+    local -i num_proc=1 rv=1
+
+    # stolen from portage
+    [[ rv -eq 0 ]] || { rv=0; num_proc=$(getconf _NPROCESSORS_ONLN 2>/dev/null) || rv=1; }
+    [[ rv -eq 0 ]] || { rv=0; num_proc=$(sysctl -n hw.ncpu 2>/dev/null) || rv=1; }
+    # stolen from my head
+    [[ rv -eq 0 ]] || { rv=0; num_proc=$(nproc) || rv=1; }
+    # stolen from common.sh
+    [[ rv -eq 0 ]] || { rv=0; num_proc=$(grep -c "^processor" /proc/cpuinfo 2>/dev/null) || rv=1; }
+    [[ rv -eq 0 ]] || { rv=0; num_proc=1; }
+
+    num_proc_ref=${num_proc}
+}
+
 fi


### PR DESCRIPTION
The automation generates reports using emerge in two separate SDK containers - one with old packages and one with new packages. Both jobs create their reports in separate directories, so if we take care of printing messages to the terminal without producing garbled text and with being able to discern which job produced the terminal output, then there is nothing else that would prevent to run them in parallel.

Parallelizing handling of package updates was a bit more involved:

- We don't want to spawn 400+ processes, so each one processes one package. But rather spawn a small number of processes and tell them to process packages in batches.
- These jobs were writing information into the same file (like summary and changelog stubs), so we give each job its own directory to write to, and after all packages were processed, we merge the files into one.

In order to get the last point, I needed to refactor the some of the code to take an output directory path instead of hardcoding it to some subdirectory of `${REPORTS_DIR}` and to split off the code that handles the package update as this code would be running inside the job instead of the main process.

I think it's best to review the PR commit by commit.
