### PR TITLE
Add a more detailed way of determining the package target

### DIFF
--- a/build_library/build_image_util.sh
+++ b/build_library/build_image_util.sh
@@ -852,7 +852,7 @@ EOF
 
     info "Generating $pcr_policy"
     pushd "${BUILD_DIR}" >/dev/null
-    zip --quiet -r -9 "${BUILD_DIR}/${pcr_policy}" pcrs
+    zip --quiet -r -9 "${pcr_policy}" pcrs
     popd >/dev/null
     rm -rf "${BUILD_DIR}/pcrs"
   fi

--- a/build_library/dev_container_util.sh
+++ b/build_library/dev_container_util.sh
@@ -81,7 +81,9 @@ create_dev_container() {
   fi
 
   info "Building developer image ${image_name}"
-  local root_fs_dir="${BUILD_DIR}/rootfs"
+  # The "dev-image-rootfs" directory name is important - it is used to
+  # determine the package target in coreos/base/profile.bashrc
+  local root_fs_dir="${BUILD_DIR}/dev-image-rootfs"
   local image_contents="${image_name%.bin}_contents.txt"
   local image_contents_wtd="${image_name%.bin}_contents_wtd.txt"
   local image_packages="${image_name%.bin}_packages.txt"

--- a/build_library/prod_image_util.sh
+++ b/build_library/prod_image_util.sh
@@ -66,7 +66,9 @@ create_prod_image() {
   local base_sysexts="$5"
 
   info "Building production image ${image_name}"
-  local root_fs_dir="${BUILD_DIR}/rootfs"
+  # The "prod-image-rootfs" directory name is important - it is used
+  # to determine the package target in coreos/base/profile.bashrc
+  local root_fs_dir="${BUILD_DIR}/prod-image-rootfs"
   local root_fs_sysexts_output_dir="${BUILD_DIR}/rootfs-included-sysexts"
   local image_contents="${image_name%.bin}_contents.txt"
   local image_contents_wtd="${image_name%.bin}_contents_wtd.txt"
@@ -241,11 +243,17 @@ create_prod_sysexts() {
 	"${BUILD_DIR}/flatcar-test-update-${name}.gz" \
 	"${BUILD_DIR}/${name}_*"
     # we use -E to pass the USE flags, but also MODULES_SIGN variables
+    #
+    # The --install_root_basename="${name}-extra-sysext-rootfs" flag
+    # is important - it sets the name of a rootfs directory, which is
+    # used to determine the package target in
+    # coreos/base/profile.bashrc
     USE="${useflags_array[*]}" sudo -E "${SCRIPT_ROOT}/build_sysext" --board="${BOARD}" \
-	--squashfs_base="${BUILD_DIR}/${image_sysext_base}" \
-	--image_builddir="${BUILD_DIR}" \
-	${mangle_script:+--manglefs_script=${mangle_script}} \
-	"${name}" "${pkg_array[@]}"
+        --squashfs_base="${BUILD_DIR}/${image_sysext_base}" \
+        --image_builddir="${BUILD_DIR}" \
+        --install_root_basename="${name}-extra-sysext-rootfs" \
+        ${mangle_script:+--manglefs_script=${mangle_script}} \
+        "${name}" "${pkg_array[@]}"
     delta_generator \
       -private_key "/usr/share/update_engine/update-payload-key.key.pem" \
       -new_image "${BUILD_DIR}/${name}.raw" \

--- a/build_library/sysext_prod_builder
+++ b/build_library/sysext_prod_builder
@@ -55,15 +55,20 @@ create_prod_sysext() {
   fi
 
   info "${msg}."
-  
+
   # Pass the build ID extracted from root FS to build_sysext. This prevents common.sh
   #   in build_sysext to generate a (timestamp based) build ID during a DEV build of a
   #   release tag (which breaks its version check).
+  #
+  # The --install_root_basename="${name}-base-sysext-rootfs" flag is
+  # important - it sets the name of a rootfs directory, which is used
+  # to determine the package target in coreos/base/profile.bashrc
   sudo "FLATCAR_BUILD_ID=$FLATCAR_BUILD_ID" "${SCRIPTS_DIR}/build_sysext" \
             --board="${BOARD}" \
             --image_builddir="${workdir}/sysext-build" \
             --squashfs_base="${base_sysext}" \
             --generate_pkginfo \
+            --install_root_basename="${name}-base-sysext-rootfs" \
             "${build_sysext_opts[@]}" \
             "${name}" "${grp_pkg[@]}"
 

--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -522,7 +522,10 @@ setup_disk_image() {
 install_oem_package() {
     local oem_pkg=$(_get_vm_opt OEM_PACKAGE)
     local oem_use=$(_get_vm_opt OEM_USE)
-    local oem_tmp="${VM_TMP_DIR}/oem"
+    # The "${VM_IMG_TYPE}-oem-image-rootfs" directory name is
+    # important - it is used to determine the package target in
+    # coreos/base/profile.bashrc
+    local oem_tmp="${VM_TMP_DIR}/${VM_IMG_TYPE}-oem-image-rootfs"
 
     if [[ -z "${oem_pkg}" ]]; then
         return 0
@@ -564,11 +567,16 @@ install_oem_sysext() {
     local built_sysext_path="${built_sysext_dir}/${built_sysext_filename}"
     local version="${FLATCAR_VERSION}"
     local metapkg="coreos-base/${oem_sysext}"
+    # The --install_root_basename="${name}-oem-sysext-rootfs" flag is
+    # important - it sets the name of a rootfs directory, which is
+    # used to determine the package target in
+    # coreos/base/profile.bashrc
     local build_sysext_flags=(
         --board="${BOARD}"
         --squashfs_base="${VM_SRC_SYSEXT_IMG}"
         --image_builddir="${built_sysext_dir}"
         --metapkgs="${metapkg}"
+        --install_root_basename="${VM_IMG_TYPE}-oem-sysext-rootfs"
     )
     local overlay_path mangle_fs
     overlay_path=$(portageq get_repo_path / coreos-overlay)

--- a/build_sysext
+++ b/build_sysext
@@ -16,6 +16,7 @@ assert_inside_chroot
 assert_root_user
 
 default_imagedir="$(readlink -f "${SCRIPT_ROOT}/../build/images")/<BOARD>/latest/"
+default_install_root_basename='install-root'
 
 # All these are used to set up the 'BUILD_DIR' variable
 DEFINE_string board "${DEFAULT_BOARD}" \
@@ -40,6 +41,8 @@ DEFINE_string mksquashfs_opts "" \
   "Additional command line options to pass to mksquashfs. See 'man 1 mksquashfs'. If <compression> is 'zstd' (the default), this option defaults to '-Xcompression-level 22 -b 512K'. Otherwise the default is empty."
 DEFINE_boolean ignore_version_mismatch "${FLAGS_FALSE}" \
   "Ignore version mismatch between SDK board packages and base squashfs. DANGEROUS."
+DEFINE_string install_root_basename "${default_install_root_basename}" \
+  "Name of a root directory where packages will be installed. ${default_install_root_basename@Q} by default."
 
 FLAGS_HELP="USAGE: build_sysext [flags] <sysext_name> <binary_package> [<binary_package> ...]
 
@@ -137,7 +140,7 @@ _get_sysext_arch() {
 cleanup() {
   local dirs=(
     "${BUILD_DIR}/fs-root"
-    "${BUILD_DIR}/install-root"
+    "${BUILD_DIR}/${FLAGS_install_root_basename}"
     "${BUILD_DIR}/workdir"
     "${BUILD_DIR}/img-rootfs"
   )
@@ -180,9 +183,9 @@ fi
 
 mkdir "${BUILD_DIR}/fs-root"
 mount -rt squashfs -o loop,nodev "${FLAGS_squashfs_base}" "${BUILD_DIR}/fs-root"
-mkdir "${BUILD_DIR}/install-root"
+mkdir "${BUILD_DIR}/${FLAGS_install_root_basename}"
 mkdir "${BUILD_DIR}/workdir"
-mount -t overlay overlay -o lowerdir="${BUILD_DIR}/fs-root${pkginfo_lowerdirs}",upperdir="${BUILD_DIR}/install-root",workdir="${BUILD_DIR}/workdir" "${BUILD_DIR}/install-root"
+mount -t overlay overlay -o lowerdir="${BUILD_DIR}/fs-root${pkginfo_lowerdirs}",upperdir="${BUILD_DIR}/${FLAGS_install_root_basename}",workdir="${BUILD_DIR}/workdir" "${BUILD_DIR}/${FLAGS_install_root_basename}"
 
 REPO_BUILD_ID=$(source "${REPO_MANIFESTS_DIR}/version.txt"; echo "$FLATCAR_BUILD_ID")
 REPO_FLATCAR_VERSION=$(source "${REPO_MANIFESTS_DIR}/version.txt"; echo "$FLATCAR_VERSION")
@@ -222,7 +225,7 @@ info "Building '${SYSEXTNAME}' squashfs with (meta-)packages '${@}' in '${BUILD_
 for package; do
   echo "Installing package into sysext image: $package"
   FEATURES="-ebuild-locks binpkg-multi-instance" emerge \
-    --root="${BUILD_DIR}/install-root" \
+    --root="${BUILD_DIR}/${FLAGS_install_root_basename}" \
     --config-root="/build/${FLAGS_board}"  \
     --sysroot="/build/${FLAGS_board}"  \
     --usepkgonly \
@@ -237,19 +240,19 @@ done
 export SOURCE_DATE_EPOCH=$(stat -c '%Y' "${BUILD_DIR}/fs-root/usr/lib/os-release")
 
 # Unmount in order to get rid of the overlay
-umount "${BUILD_DIR}/install-root"
+umount "${BUILD_DIR}/${FLAGS_install_root_basename}"
 umount "${BUILD_DIR}/fs-root"
 
 if [[ "$FLAGS_generate_pkginfo" = "${FLAGS_TRUE}" ]] ; then
   info "  Creating pkginfo squashfs '${BUILD_DIR}/${SYSEXTNAME}_pkginfo.raw'"
   mkdir -p "${BUILD_DIR}/img-pkginfo/var/db"
-  cp -R "${BUILD_DIR}/install-root/var/db/pkg" "${BUILD_DIR}/img-pkginfo/var/db/"
+  cp -R "${BUILD_DIR}/${FLAGS_install_root_basename}/var/db/pkg" "${BUILD_DIR}/img-pkginfo/var/db/"
   mksquashfs "${BUILD_DIR}/img-pkginfo" "${BUILD_DIR}/${SYSEXTNAME}_pkginfo.raw" \
               -noappend -xattrs-exclude '^btrfs.' -comp "${FLAGS_compression}" ${FLAGS_mksquashfs_opts}
 fi
 
 info "Writing ${SYSEXTNAME}_packages.txt"
-ROOT="${BUILD_DIR}/install-root" PORTAGE_CONFIGROOT="${BUILD_DIR}/install-root" \
+ROOT="${BUILD_DIR}/${FLAGS_install_root_basename}" PORTAGE_CONFIGROOT="${BUILD_DIR}/${FLAGS_install_root_basename}" \
       equery --no-color list --format '$cpv::$repo' '*' > "${BUILD_DIR}/${SYSEXTNAME}_packages.txt"
 
 
@@ -260,7 +263,7 @@ if [[ "${FLAGS_strip_binaries}" = "${FLAGS_TRUE}" ]]; then
     info "Stripping all non-stripped binaries in sysext using '${strip}'"
 
     # Find all non-stripped binaries, remove ':' from filepath, and strip 'em
-    find "${BUILD_DIR}/install-root" -exec file \{\} \; \
+    find "${BUILD_DIR}/${FLAGS_install_root_basename}" -exec file \{\} \; \
          | awk '/not stripped/ {print substr($1, 1, length($1)-1)}' \
          | while read bin; do
                 info "     ${strip} ${bin}"
@@ -272,38 +275,38 @@ if [[ -n "${FLAGS_manglefs_script}" ]]; then
   if [[ ! -x "${FLAGS_manglefs_script}" ]]; then
     die "${FLAGS_manglefs_script} is not executable"
   fi
-  "${FLAGS_manglefs_script}" "${BUILD_DIR}/install-root"
+  "${FLAGS_manglefs_script}" "${BUILD_DIR}/${FLAGS_install_root_basename}"
 fi
 
 info "Removing non-/usr directories from sysext image"
-for entry in "${BUILD_DIR}/install-root"/*; do
+for entry in "${BUILD_DIR}/${FLAGS_install_root_basename}"/*; do
   if [[ "${entry}" = */usr ]]; then
     continue
   fi
   info "  Removing ${entry##*/}"
   rm -rf "${entry}"
 done
-mkdir -p "${BUILD_DIR}/install-root/usr/lib/extension-release.d"
+mkdir -p "${BUILD_DIR}/${FLAGS_install_root_basename}/usr/lib/extension-release.d"
 version_field="${VERSION_FIELD_OVERRIDE:-VERSION_ID=${FLATCAR_VERSION_ID}}"
 all_fields=(
   'ID=flatcar'
   "${version_field}"
   "ARCHITECTURE=${ARCH}"
 )
-printf '%s\n' "${all_fields[@]}" >"${BUILD_DIR}/install-root/usr/lib/extension-release.d/extension-release.${SYSEXTNAME}"
+printf '%s\n' "${all_fields[@]}" >"${BUILD_DIR}/${FLAGS_install_root_basename}/usr/lib/extension-release.d/extension-release.${SYSEXTNAME}"
 
 info "Removing opaque directory markers to always merge all contents"
-find "${BUILD_DIR}/install-root" -xdev -type d -exec sh -c 'if [ "$(attr -R -q -g overlay.opaque {} 2>/dev/null)" = y ]; then attr -R -r overlay.opaque {}; fi' \;
+find "${BUILD_DIR}/${FLAGS_install_root_basename}" -xdev -type d -exec sh -c 'if [ "$(attr -R -q -g overlay.opaque {} 2>/dev/null)" = y ]; then attr -R -r overlay.opaque {}; fi' \;
 
 info "Checking for invalid file ownership"
-invalid_files=$(find "${BUILD_DIR}/install-root" -user sdk -or -group sdk)
+invalid_files=$(find "${BUILD_DIR}/${FLAGS_install_root_basename}" -user sdk -or -group sdk)
 if [[ -n "${invalid_files}" ]]; then
   die "Invalid file ownership: ${invalid_files}"
 fi
 
-mksquashfs "${BUILD_DIR}/install-root" "${BUILD_DIR}/${SYSEXTNAME}.raw" \
+mksquashfs "${BUILD_DIR}/${FLAGS_install_root_basename}" "${BUILD_DIR}/${SYSEXTNAME}.raw" \
                -noappend -xattrs-exclude '^btrfs.' -comp "${FLAGS_compression}" ${FLAGS_mksquashfs_opts}
-rm -rf "${BUILD_DIR}"/{fs-root,install-root,workdir}
+rm -rf "${BUILD_DIR}"/{fs-root,"${FLAGS_install_root_basename}",workdir}
 
 # Generate reports
 mkdir "${BUILD_DIR}/img-rootfs"

--- a/sdk_container/src/third_party/coreos-overlay/coreos/config/env/dev-libs/glib
+++ b/sdk_container/src/third_party/coreos-overlay/coreos/config/env/dev-libs/glib
@@ -1,5 +1,5 @@
 # Do not install gobject-introspection binaries in production images.
-if [[ $(cros_target) != "cros_host" ]] ; then
+if [[ $(flatcar_target) != 'sdk' ]] ; then
 	glib_mask="/usr/bin/gi-* /usr/lib*/libgirepository-2.0*"
 	PKG_INSTALL_MASK+=" ${glib_mask}"
 	INSTALL_MASK+=" ${glib_mask}"

--- a/sdk_container/src/third_party/coreos-overlay/coreos/config/env/net-misc/openssh
+++ b/sdk_container/src/third_party/coreos-overlay/coreos/config/env/net-misc/openssh
@@ -2,7 +2,7 @@
 #
 # Do not install the config snippet that defines a subsystem. We have
 # our own definition in coreos-init.
-if [[ $(cros_target) != "cros_host" ]] ; then
+if [[ $(flatcar_target) != 'sdk' ]] ; then
 	openssh_mask=" /usr/lib*/misc/ssh-keysign /etc/ssh/sshd_config.d/*gentoo-subsystem.conf "
 	PKG_INSTALL_MASK+="${openssh_mask}"
 	INSTALL_MASK+="${openssh_mask}"

--- a/sdk_container/src/third_party/coreos-overlay/profiles/coreos/base/profile.bashrc
+++ b/sdk_container/src/third_party/coreos-overlay/profiles/coreos/base/profile.bashrc
@@ -5,23 +5,6 @@ CROS_BUILD_BOARD_BIN="${CROS_BUILD_BOARD_TREE}/bin"
 
 CROS_ADDONS_TREE="/mnt/host/source/src/third_party/coreos-overlay/coreos"
 
-# Are we merging for the board sysroot, or for the cros sdk, or for
-# the target hardware?  Returns a string:
-#  - cros_host (the sdk)
-#  - board_sysroot
-#  - target_image
-# We can't rely on "use cros_host" as USE gets filtred based on IUSE,
-# and not all packages have IUSE=cros_host.
-cros_target() {
-	if [[ ${CROS_SDK_HOST} == "cros-sdk-host" ]] ; then
-		echo "cros_host"
-	elif [[ ${ROOT%/} == ${SYSROOT%/} ]] ; then
-		echo "board_sysroot"
-	else
-		echo "target_image"
-	fi
-}
-
 # Are we merging for the board sysroot, or for the SDK, or for
 # the images? Returns a string in a passed variable:
 #

--- a/sdk_container/src/third_party/coreos-overlay/profiles/coreos/base/profile.bashrc
+++ b/sdk_container/src/third_party/coreos-overlay/profiles/coreos/base/profile.bashrc
@@ -22,6 +22,70 @@ cros_target() {
 	fi
 }
 
+# Are we merging for the board sysroot, or for the SDK, or for
+# the images? Returns a string in a passed variable:
+#
+#  - sdk (the SDK)
+#  - generic-board (board sysroot)
+#  - generic-prod (production image)
+#  - generic-dev (developer container image)
+#  - generic-oem-${name} (image for OEM ${name}, like azure, qemu_uefi)
+#  - generic-sysext-base-${name} (sysext image ${name} built-in into
+#    production image, usually docker or containerd)
+#  - generic-sysext-extra-${name} (extra sysext image ${name}, like
+#    podman, python, zfs)
+#  - generic-sysext-oem-${name} (OEM sysext image ${name}, like
+#    azure, qemu_uefi)
+#  - generic-unknown (something using generic profile, but otherwise
+#    unknown, probably something is messed up)
+#  - unknown (unknown type of image, neither generic, nor sdk,
+#    probably something is messed up)
+flatcar_target_ref() {
+    local -n type_ref=${1}; shift
+
+    local name
+    case ${FLATCAR_TYPE} in
+        sdk) type_ref='sdk';;
+        generic)
+            case ${ROOT} in
+                */prod-image-rootfs) type_ref='generic-prod';;
+                */dev-image-rootfs) type_ref='generic-dev';;
+                */*-base-sysext-rootfs)
+                    name=${ROOT##*/}
+                    name=${name%-base-sysext-rootfs}
+                    type_ref="generic-sysext-base-${name}"
+                    ;;
+                */*-extra-sysext-rootfs)
+                    name=${ROOT##*/}
+                    name=${name%-extra-sysext-rootfs}
+                    type_ref="generic-sysext-extra-${name}"
+                    ;;
+                */*-oem-image-rootfs)
+                    name=${ROOT##*/}
+                    name=${name%-oem-image-rootfs}
+                    type_ref="generic-oem-${name}"
+                    ;;
+                */*-oem-sysext-rootfs)
+                    name=${ROOT##*/}
+                    name=${name%-oem-sysext-rootfs}
+                    type_ref="generic-sysext-oem-${name}"
+                    ;;
+                "${SYSROOT}") type_ref='generic-board';;
+                *) type_ref='generic-unknown'
+            esac
+            ;;
+        *) type_ref='unknown';;
+    esac
+}
+
+# Prints the type of image we are merging the package for, see
+# flatcar_target_ref for details.
+flatcar_target() {
+    local target_type
+    flatcar_target_ref target_type
+    echo "${target_type}"
+}
+
 # Load all additional bashrc files we have for this package.
 cros_stack_bashrc() {
 	local cfg cfgd

--- a/sdk_container/src/third_party/coreos-overlay/profiles/coreos/targets/generic/make.defaults
+++ b/sdk_container/src/third_party/coreos-overlay/profiles/coreos/targets/generic/make.defaults
@@ -1,6 +1,8 @@
 # Copyright (c) 2012 The Chromium OS Authors. All rights reserved.
 # Distributed under the terms of the GNU General Public License v2
 
+FLATCAR_TYPE=generic
+
 USE="acpi usb cryptsetup policykit"
 USE="${USE} -cros_host -expat -cairo -X -man"
 USE="${USE} -acl -gpm -python"

--- a/sdk_container/src/third_party/coreos-overlay/profiles/coreos/targets/sdk/make.defaults
+++ b/sdk_container/src/third_party/coreos-overlay/profiles/coreos/targets/sdk/make.defaults
@@ -2,10 +2,6 @@ FLATCAR_TYPE=sdk
 
 USE="cros_host expat man -pam"
 
-# Used by some old goo in profiles/coreos/base/profile.bashrc
-# TODO: clean up that old goo
-CROS_SDK_HOST="cros-sdk-host"
-
 # Enable CPU architectures needed by Rust builds
 LLVM_TARGETS="X86 AArch64"
 

--- a/sdk_container/src/third_party/coreos-overlay/profiles/coreos/targets/sdk/make.defaults
+++ b/sdk_container/src/third_party/coreos-overlay/profiles/coreos/targets/sdk/make.defaults
@@ -1,3 +1,5 @@
+FLATCAR_TYPE=sdk
+
 USE="cros_host expat man -pam"
 
 # Used by some old goo in profiles/coreos/base/profile.bashrc


### PR DESCRIPTION
CI: http://localhost:8080/job/container/job/sdk/2210/cldsv/

This adds a function `flatcar_target` that replaces the earlier `cros_target`. The function returns a string that tells where the package will end up (prod image, dev container, sysexts, sdk, etc.) This is something I wanted to use for the selinux work, where I need to enable some python stuff for the production image. But since we don't want neither python interpreter nor selinux tools written in python in the production image, I need to mask them during installation. But these things may be still useful for other images we build (some sysext or dev container).

One thing to note is that the way we build packages, normally the target will be `generic-board` during source-based installation (from ebuild) - this step also produces a binary package. When installing the binary package into some filesystem, this is when the target will be e.g. a `generic-prod` or `generic-sysext-oem-azure`.

## Testing done

Tested locally, if the targets are correct. CI passed. No image changes, as expected.

Along the way, while testing locally, did a small fix for packing pcr policies with zip, when build directory is a relative path (our CI uses absolute paths, so this went by unnoticed).