### PR TITLE
test: initrd in /usr

### DIFF
--- a/sdk_container/src/third_party/coreos-overlay/sys-kernel/coreos-kernel/coreos-kernel-6.12.44.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/sys-kernel/coreos-kernel/coreos-kernel-6.12.44.ebuild
@@ -89,6 +89,14 @@ src_compile() {
 
 	tc-export PKG_CONFIG
 	"${ESYSROOT}"/usr/bin/update-bootengine -k "${KV_FULL}" -o "${S}"/build/bootengine.cpio "${BE_ARGS[@]}" || die
+	mkdir "${S}"/build/bootengine
+	cat "${S}"/build/bootengine.cpio | while cpio --no-absolute-filenames -d -m -D "${S}"/build/bootengine -i ; do :; done
+	# Lacking read permissions even for user
+	chmod u+r "${S}"/build/bootengine/etc/gshadow
+	# CPU microcode should stay in the minimal initrd
+	rm -rf "${S}"/build/bootengine/kernel "${S}"/build/bootengine/early_cpio
+	# TODO: rework /usr verity mount to reuse the one from the minimal initrd
+	mksquashfs "${S}"/build/bootengine "${S}"/build/bootengine.img -all-root -noappend -xattrs-exclude ^btrfs.
 	kmake "$(kernel_target)"
 
 	# sanity check :)
@@ -111,4 +119,7 @@ src_install() {
 	# For easy access to vdso debug symbols in gdb:
 	#   set debug-file-directory /usr/lib/debug/usr/lib/modules/${KV_FULL}/vdso/
 	kmake INSTALL_MOD_PATH="${ED}/usr/lib/debug/usr" vdso_install
+
+	insinto "/usr/lib/flatcar"
+	doins build/bootengine.img
 }


### PR DESCRIPTION
Still WIP

## How to use



## Testing done


- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
