### PR TITLE
update_engine: postinst: Make sure Flatcar extension folder exists

### DIFF
--- a/sdk_container/src/third_party/coreos-overlay/coreos-base/update_engine/update_engine-9999.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/coreos-base/update_engine/update_engine-9999.ebuild
@@ -7,7 +7,7 @@ EGIT_REPO_URI="https://github.com/flatcar/update_engine.git"
 if [[ "${PV}" == 9999 ]]; then
 	KEYWORDS="~amd64 ~arm ~arm64 ~x86"
 else
-	EGIT_COMMIT="4ecb5e3b073dfc3818d8d0db2f4c3e15dccb0e5c" # main
+	EGIT_COMMIT="aa31b3ea36b2c4d585406ab13dbdf2c4e8959a99" # main
 	KEYWORDS="amd64 arm64"
 fi
 


### PR DESCRIPTION
This pulls in https://github.com/flatcar/update_engine/pull/50 to fix a corner case when the extension file exists on old nodes that don't yet support extensions but should pull them on their update.


## How to use



## Testing done

See https://github.com/flatcar/update_engine/pull/50

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
