### PR TITLE
ci-automation/gc: drop openstack occurences

### DIFF
--- a/ci-automation/garbage_collect.sh
+++ b/ci-automation/garbage_collect.sh
@@ -261,7 +261,6 @@ function _garbage_collect_impl() {
       --env EQUINIXMETAL_KEY --env EQUINIXMETAL_PROJECT \
       --env GCP_JSON_KEY \
       --env VMWARE_ESX_CREDS \
-      --env OPENSTACK_CREDS \
       --env BRIGHTBOX_CLIENT_ID --env BRIGHTBOX_CLIENT_SECRET \
       --env AKAMAI_TOKEN \
       -w /work -v "$PWD":/work "${mantle_ref}" /work/ci-automation/garbage_collect_cloud.sh

--- a/ci-automation/garbage_collect_cloud.sh
+++ b/ci-automation/garbage_collect_cloud.sh
@@ -7,8 +7,6 @@ timeout --signal=SIGQUIT 60m ore gcloud gc --json-key <(echo "${GCP_JSON_KEY}" |
 timeout --signal=SIGQUIT 60m ore azure gc --duration 6h
 timeout --signal=SIGQUIT 60m ore equinixmetal gc --duration 6h \
   --project="${EQUINIXMETAL_PROJECT}" --gs-json-key=<(echo "${GCP_JSON_KEY}" | base64 --decode) --api-key="${EQUINIXMETAL_KEY}"
-timeout --signal=SIGQUIT 60m ore openstack gc --duration 6h \
-  --config-file=<(echo "${OPENSTACK_CREDS}" | base64 --decode)
 timeout --signal=SIGQUIT 60m ore brightbox gc --duration 6h \
   --brightbox-client-id="${BRIGHTBOX_CLIENT_ID}" --brightbox-client-secret="${BRIGHTBOX_CLIENT_SECRET}"
 timeout --signal=SIGQUIT 60m ore akamai gc --duration 6h \


### PR DESCRIPTION
garbage-collection was failing since we dropped the openstack credentials, so Akamai was "full" of Flatcar images. I manually ran the GC against Akamai to free the CI.

