### PR TITLE
overlay profiles: use unstable version of libxml2

### DIFF
--- a/sdk_container/src/third_party/coreos-overlay/profiles/coreos/base/package.accept_keywords
+++ b/sdk_container/src/third_party/coreos-overlay/profiles/coreos/base/package.accept_keywords
@@ -62,6 +62,9 @@ dev-cpp/azure-security-keyvault-keys
 =dev-libs/jose-12 **
 =dev-libs/luksmeta-9-r1 **
 
+# CVE-2025-49794, CVE-2025-49795, CVE-2025-49796
+=dev-libs/libxml2-2.14.5 ~amd64 ~arm64
+
 # Keep versions on both arches in sync.
 =dev-libs/raft-0.22.1 ~arm64
 


### PR DESCRIPTION
This solves 3 CVEs.

---

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

Closes: https://github.com/flatcar/Flatcar/issues/1813
