### PR TITLE
Flatcar nano: Minor README improvements

### DIFF
--- a/nano/Readme.md
+++ b/nano/Readme.md
@@ -34,8 +34,12 @@ See
 for details.
 Core packages need a rebuild on order for this to work (hence the --[...]use flags).
 
+Create a SDK container that is ready to build the flatcar image:
+```
+./run_sdk_container -t
+```
 
-To build, run
+Then it will leave you a shell inside the container. To build, run inside the container:
 ```
 emerge-amd64-usr --unmerge util-linux cryptsetup lvm2
 USE="-cryptsetup" emerge-amd64-usr --newuse --changed-use util-linux

--- a/nano/Readme.md
+++ b/nano/Readme.md
@@ -43,7 +43,7 @@ Then it will leave you a shell inside the container. To build, run inside the co
 ```
 emerge-amd64-usr --unmerge util-linux cryptsetup lvm2
 USE="-cryptsetup" emerge-amd64-usr --newuse --changed-use util-linux
-emerge-amd64-usr --newuse --changed-use --buildpkg flatcar-nano util-linux cryptsetup lvm2 baselayout curl nghttp2 grub shim shim-signed
+emerge-amd64-usr --jobs $(($(nproc) * 2)) --newuse --changed-use --buildpkg flatcar-nano util-linux cryptsetup lvm2 baselayout curl nghttp2 grub shim shim-signed
 ./build_image --base_pkg=coreos-base/flatcar-nano --base_sysexts="" --replace
 ./image_to_vm.sh --from=../build/images/amd64-usr/latest --board=amd64-usr --image_compression_formats none
 ```


### PR DESCRIPTION
# Flatcar NANO README improvements

This adds the missing step of starting the SDK container and using parallelism for one flatcar nano specific emerge

## How to use

Follow the instructions in the readme, they should be working now :)