### PR TITLE
Flatcar nano: remove ~14 more packages

### DIFF
--- a/sdk_container/src/third_party/coreos-overlay/coreos-base/flatcar-nano/flatcar-nano-0.0.1.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/coreos-base/flatcar-nano/flatcar-nano-0.0.1.ebuild
@@ -37,6 +37,7 @@ RDEPEND="${RDEPEND}
 # Removed 
 #	app-admin/etcd-wrapper
 #	app-admin/flannel-wrapper
+#	app-admin/locksmith
 #	app-admin/sdnotify-proxy
 #	app-admin/sudo
 #	app-admin/toolbox
@@ -59,6 +60,7 @@ RDEPEND="${RDEPEND}
 #	app-misc/pax-utils
 #	app-shells/bash
 #	coreos-base/update-ssh-keys
+#	coreos-base/update_engine
 #	dev-db/etcdctl
 #	dev-debug/strace
 #	dev-libs/libsodium
@@ -69,12 +71,15 @@ RDEPEND="${RDEPEND}
 #	net-analyzer/openbsd-netcat
 #	net-analyzer/tcpdump
 #	net-analyzer/traceroute
+#	net-dns/bind
 #	net-fs/nfs-utils
 #	net-fs/cifs-utils
+#	net-misc/ntp
 #	net-misc/rsync
 #	net-misc/socat
 #	net-misc/wget
 #	net-misc/whois
+#	net-vpn/wireguard-tools
 #	sys-apps/acl
 #	sys-apps/attr
 # sys-apps/azure-vm-utils  -- This should go into the Azure OEM sysext?
@@ -83,6 +88,7 @@ RDEPEND="${RDEPEND}
 #	sys-apps/ethtool
 #	sys-apps/findutils
 #	sys-apps/grep
+#	sys-apps/kexec-tools
 #	sys-apps/less
 #	sys-apps/lshw
 #	sys-apps/usbutils
@@ -92,10 +98,13 @@ RDEPEND="${RDEPEND}
 #	)
 #	sys-auth/realmd
 #	sys-auth/sssd
+#	sys-boot/mokutil
 #	sys-devel/gettext
+#	sys-fs/dosfstools
 #	sys-fs/lsscsi
 #	sys-fs/quota
 #	sys-libs/glibc
+#	sys-power/acpid
 #	sys-process/lsof
 #	sys-process/procps
 #	x11-drivers/nvidia-drivers-service
@@ -105,7 +114,6 @@ RDEPEND="${RDEPEND}
 # Early boot needs 'net-tools' on some platforms.
 
 RDEPEND="${RDEPEND}
-	app-admin/locksmith
 	app-admin/mayday
 	app-crypt/clevis
 	app-crypt/gnupg
@@ -117,9 +125,7 @@ RDEPEND="${RDEPEND}
 	coreos-base/coreos-cloudinit
 	coreos-base/coreos-init
 	coreos-base/misc-files
-	coreos-base/update_engine
 	coreos-base/ue-rs
-	net-dns/bind
 	net-firewall/conntrack-tools
 	net-firewall/ebtables
 	net-firewall/ipset
@@ -127,10 +133,8 @@ RDEPEND="${RDEPEND}
 	net-firewall/nftables
 	net-libs/nghttp2
 	net-misc/bridge-utils
-	net-misc/iputils
-	net-misc/ntp
 	net-misc/curl
-	net-vpn/wireguard-tools
+	net-misc/iputils
 	sec-policy/selinux-base
 	sec-policy/selinux-base-policy
 	sec-policy/selinux-container
@@ -142,7 +146,6 @@ RDEPEND="${RDEPEND}
 	sys-apps/gptfdisk
 	sys-apps/ignition
 	sys-apps/iproute2
-	sys-apps/kexec-tools
 	sys-apps/keyutils
 	sys-apps/net-tools
 	sys-apps/nvme-cli
@@ -157,11 +160,9 @@ RDEPEND="${RDEPEND}
 	sys-block/open-iscsi
 	sys-block/parted
 	sys-boot/efibootmgr
-	sys-boot/mokutil
 	sys-cluster/ipvsadm
 	sys-fs/btrfs-progs
 	sys-fs/cryptsetup
-	sys-fs/dosfstools
 	sys-fs/e2fsprogs
 	sys-fs/lvm2
 	sys-fs/mdadm
@@ -171,5 +172,4 @@ RDEPEND="${RDEPEND}
 	sys-kernel/coreos-kernel
 	sys-libs/nss-usrfiles
 	sys-libs/timezone-data
-	sys-power/acpid
 "

--- a/sdk_container/src/third_party/coreos-overlay/profiles/coreos/base/package.use
+++ b/sdk_container/src/third_party/coreos-overlay/profiles/coreos/base/package.use
@@ -30,7 +30,7 @@ app-admin/sudo -sendmail
 
 # disable hybrid cgroup as we use the unified mode now
 # use lzma which is the default on non-gentoo systems, enable selinux,
-sys-apps/systemd -cgroup-hybrid curl idn lzma selinux tpm
+sys-apps/systemd -cgroup-hybrid -curl -pwquality -http -homed idn lzma selinux tpm
 net-libs/libmicrohttpd -ssl
 
 # disable kernel config detection and module building

--- a/sdk_container/src/third_party/coreos-overlay/profiles/coreos/targets/generic/package.use
+++ b/sdk_container/src/third_party/coreos-overlay/profiles/coreos/targets/generic/package.use
@@ -11,7 +11,7 @@ app-editors/vim-core	minimal
 #
 # Install a SELinux policy directory symlink
 #coreos-base/misc-files audit ntp openssh policycoreutils
-coreos-base/misc-files audit ntp policycoreutils
+coreos-base/misc-files audit policycoreutils
 
 dev-lang/python		gdbm
 dev-libs/dbus-glib	tools
@@ -19,7 +19,7 @@ dev-libs/elfutils	-utils
 dev-libs/openssl	pkcs11
 dev-util/perf		-perl -python
 net-misc/dhcp	        -server
-net-misc/ntp            caps
+#net-misc/ntp            caps
 sys-apps/smartmontools	-daemon -update-drivedb -systemd
 sys-block/parted        device-mapper
 sys-fs/lvm2		-readline thin lvm
@@ -27,7 +27,7 @@ sys-libs/ncurses	minimal
 sys-libs/pam		audit
 
 # enable journal gateway, bootctl and container features
-sys-apps/systemd audit elfutils gnuefi http importd iptables
+sys-apps/systemd audit elfutils gnuefi http -importd -curl iptables
 
 # epoll is needed for systemd-journal-remote to work. coreos/bugs#919
 net-libs/libmicrohttpd epoll


### PR DESCRIPTION
# Remove some more packages in flatcar nano hackathon

This makes nano now ~1/3 smaller than a regular flatcar release.
I think we can try to reduce this further, though.

## How to use

Compile following the readme in the nano folder.

## Testing done

Doom in wasm as a container works fine. For a hackathon, this is all the testing done :-D