### PR TITLE
ci-automation: Run cl.update.payload-boot-part-too-small test

### DIFF
--- a/ci-automation/vendor-testing/qemu_update.sh
+++ b/ci-automation/vendor-testing/qemu_update.sh
@@ -100,7 +100,7 @@ query_kola_tests() {
 run_kola_tests() {
     local instance_type="${1}"; shift;
     local instance_tapfile="${1}"; shift
-    local tests=("cl.update.payload")
+    local tests=("cl.update.payload" "cl.update.payload-boot-part-too-small")
     local image
     if [ "${instance_type}" = "previous" ]; then
         image="tmp/flatcar_production_image_previous.bin"


### PR DESCRIPTION
The test was recently added to kola but wasn't executed yet. Add it to the list of update tests (which start from an old image and update to the new image that should be tested).

## How to use


## Testing done

[here](http://jenkins.infra.kinvolk.io:8080/job/container/job/test/40338/console)