### PR TITLE
nutanix AHV support

### DIFF
--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -43,6 +43,7 @@ VALID_IMG_TYPES=(
     vmware_ova
     vmware_raw
     xen
+    nutanix
 )
 
 #list of oem package names, minus the oem- prefix
@@ -352,6 +353,13 @@ IMG_proxmoxve_DISK_LAYOUT=vm
 IMG_proxmoxve_OEM_PACKAGE=common-oem-files
 IMG_proxmoxve_OEM_USE=proxmoxve
 IMG_proxmoxve_OEM_SYSEXT=oem-proxmoxve
+
+## nutanix
+IMG_nutanix_DISK_FORMAT=qcow2
+IMG_nutanix_DISK_LAYOUT=vm
+IMG_nutanix_OEM_USE=nutanix
+IMG_nutanix_OEM_PACKAGE=common-oem-files
+IMG_nutanix_OEM_SYSEXT=oem-nutanix
 
 ###########################################################
 

--- a/changelog/changes/2025-11-05-nutanix.md
+++ b/changelog/changes/2025-11-05-nutanix.md
@@ -1,0 +1,1 @@
+- Added Nutanix images ([flatcar/scripts#3311](https://github.com/flatcar/scripts/pull/3311))

--- a/sdk_container/src/third_party/coreos-overlay/coreos-base/common-oem-files/common-oem-files-0-r11.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/coreos-base/common-oem-files/common-oem-files-0-r11.ebuild
@@ -50,6 +50,7 @@ AMD64_ONLY_OEMIDS=(
     gce
     hyperv
     vmware
+    nutanix
 )
 
 OEMIDS=(

--- a/sdk_container/src/third_party/coreos-overlay/coreos-base/oem-nutanix/metadata.xml
+++ b/sdk_container/src/third_party/coreos-overlay/coreos-base/oem-nutanix/metadata.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+</pkgmetadata>

--- a/sdk_container/src/third_party/coreos-overlay/coreos-base/oem-nutanix/oem-nutanix-0.0.1.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/coreos-base/oem-nutanix/oem-nutanix-0.0.1.ebuild
@@ -1,0 +1,15 @@
+# Copyright (c) 2020 Kinvolk GmbH. All rights reserved.
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+DESCRIPTION="OEM suite for Nutanix"
+HOMEPAGE="https://www.nutanix.com/"
+SRC_URI=""
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="amd64"
+IUSE=""
+
+OEM_NAME="Nutanix"


### PR DESCRIPTION
# add nutanix AHV support

ignition support nutanix AHV, the only thing to do is to add `flatcar.oem.id=nutanix` in the kernel cmdline.
However, Nutanix doesn't provide its "Nutanix Guest Tools" in any other format than .deb or .rpm -> so I didn't port it to flatcar.

I managed to create a nutanix AHV flatcar image (without nutanix guest tools... but that doesn't forbid the VM to run) by following this path:
```
wget https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_image.bin.bz2
bunzip2 flatcar_production_image.bin.bz2
PART=6
LOOP=$(sudo losetup --partscan --find --show flatcar_production_image.bin)
TARGET=$(sudo mktemp -d -p /mnt --suffix -flatcar)
sudo mount "${LOOP}p${PART}" "$TARGET"
echo 'set oem_id="nutanix"' | sudo tee "$TARGET"/grub.cfg
sudo umount "${TARGET}"
sudo rmdir "${TARGET}"
sudo losetup -d "${LOOP}"
qemu-img convert -f raw -O qcow2 flatcar_production_image.bin flatcar_production_image_nutanix.qcow2
rm flatcar_production_image.bin
```
(it tested it on a Nutanix AHV infra, also tried a flatcar update (via nebraska) -> it works)

And creating the VM with the ignition config provided as "cloud_init" "guest_customization":
```
...
        "guest_customization": {
          "cloud_init": {
            "user_data": "<base64 ignition conf>"
          }
          "is_overridable": false
        }
...
```
https://www.nutanix.dev/api_reference/apis/prism_v3.html#tag/vms/paths/~1vms/post

I tried to reproduce this path in this PR, **but I can't try the resulting image myself**.
It build on my desktop, but I can't upload it to a nutanix AHV platform due to my poor home network connection.
And I failed to build the image on the remote host (where I updated the `flatcar_production_image.bin.bz2` official image).

## How to use

If what I changed in the code is in fact the equivalent of the adding `oem_id="nutanix"` in the `grub.cfg` of the OEM partition.
This PR should be ok.

Otherwise, please guide me (I am a noob in flatcar dev).

## Testing done

I created an image :
```
wget https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_image.bin.bz2
bunzip2 flatcar_production_image.bin.bz2
PART=6
LOOP=$(sudo losetup --partscan --find --show flatcar_production_image.bin)
TARGET=$(sudo mktemp -d -p /mnt --suffix -flatcar)
sudo mount "${LOOP}p${PART}" "$TARGET"
echo 'set oem_id="nutanix"' | sudo tee "$TARGET"/grub.cfg
sudo umount "${TARGET}"
sudo rmdir "${TARGET}"
sudo losetup -d "${LOOP}"
qemu-img convert -f raw -O qcow2 flatcar_production_image.bin flatcar_production_image_nutanix.qcow2
rm flatcar_production_image.bin
```

* upload it to a nutanix ahv cluster
* created multiple hosts using this image via terraform restapi provider (the nutanix official provider is currently unable to create VM with ignition configuration as "cloudinit" guest info).
* created a k8s cluster on thoses hosts via rke
* tried an update via nebraska (flatcar downloaded the new image, I reboot the hosts, it booted on the new version).

I tried this ignition config:
```
{"ignition":{"version":"3.3.0"},"storage":{"files":[{"path":"/toto","contents":{"compression":"","source":"data:,toto"},"mode":292}]}}
```
and checked that `/toto` was actually created at boot.
(I also tried some more advanced ignition config).


CI: http://localhost:8080/job/container/job/packages_all_arches/6848/cldsv/