### PR TITLE
Add overlaybd sysext mangle script to start the services automatically

### DIFF
--- a/build_library/sysext_mangle_flatcar-overlaybd
+++ b/build_library/sysext_mangle_flatcar-overlaybd
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -euo pipefail
+rootfs="${1}"
+
+pushd "${rootfs}"
+
+pushd ./usr/lib/systemd/system
+mkdir -p "multi-user.target.d"
+{ echo "[Unit]"; echo "Upholds=overlaybd-tcmu.service overlaybd-snapshotter.service"; } > "multi-user.target.d/10-overlaybd.conf"
+popd

--- a/changelog/bugfixes/2025-10-01-overlaybd-autostart.md
+++ b/changelog/bugfixes/2025-10-01-overlaybd-autostart.md
@@ -1,0 +1,1 @@
+- Configured the services in the overlaybd sysext to start automatically like the other sysexts. Note that the sysext must be enabled at boot time for this to happen, otherwise you need to call `systemd-tmpfiles --create` and `systemctl daemon-reload` first.


### PR DESCRIPTION
# Start overlaybd services automatically

This is consistent with other sysexts. Note that the sysext must be enabled at boot time for this to happen, otherwise you need to call `systemd-tmpfiles --create` and `systemctl daemon-reload` first.

## How to use

Provision the sysext and see whether overlaybd-tcmu and overlaybd-snapshotter are running.

## Testing done

...

- [X] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc. -- **N/A**