### PR TITLE
Add hvf acceleration support for macOS

### DIFF
--- a/build_library/qemu_template.sh
+++ b/build_library/qemu_template.sh
@@ -247,8 +247,8 @@ else
             ;;
         amd64-usr+*)
             set -- -machine q35 -cpu kvm64 -smp 1 -nographic "$@" ;;
-        arm64-usr+aarch64)
-            set -- -machine virt,accel=kvm,gic-version=3 -cpu host -smp "${VM_NCPUS}" -nographic "$@" ;;
+        arm64-usr+aarch64|arm64-usr+arm64)
+            set -- -machine virt,accel=kvm:hvf:tcg,gic-version=3 -cpu host -smp "${VM_NCPUS}" -nographic "$@" ;;
         arm64-usr+*)
             if test "${VM_NCPUS}" -gt 4 ; then
                 VM_NCPUS=4

--- a/changelog/bugfixes/2025-10-08-macos-hvf-accel.md
+++ b/changelog/bugfixes/2025-10-08-macos-hvf-accel.md
@@ -1,0 +1,1 @@
+- Fixed the QEMU launcher script to include HVF acceleration on arm64-based Macs for faster performance ([Flatcar#1901](https://github.com/flatcar/Flatcar/issues/1901))


### PR DESCRIPTION
Modified the qemu_template.sh script to include accel for macOS

```
arm64-usr+aarch64|arm64-usr+arm64)
            set -- -machine virt,accel=kvm:hvf:tcg,gic-version=3 -cpu host -smp "${VM_NCPUS}" -nographic "$@" ;;
        
```
