### PR TITLE
build_sysext: Squash build Portage profile parsing failure warning

### DIFF
--- a/build_sysext
+++ b/build_sysext
@@ -248,7 +248,7 @@ if [[ "$FLAGS_generate_pkginfo" = "${FLAGS_TRUE}" ]] ; then
 fi
 
 info "Writing ${SYSEXTNAME}_packages.txt"
-ROOT="${BUILD_DIR}/${FLAGS_install_root_basename}" PORTAGE_CONFIGROOT="${BUILD_DIR}/${FLAGS_install_root_basename}" \
+ROOT="${BUILD_DIR}/${FLAGS_install_root_basename}" PORTAGE_CONFIGROOT="/build/${FLAGS_board}" \
       equery --no-color list --format '$cpv::$repo' '*' > "${BUILD_DIR}/${SYSEXTNAME}_packages.txt"
 
 


### PR DESCRIPTION
# Squash build Portage profile parsing failure warning

The Portage config is visible through the sysext root directory via overlayfs while installing packages, but the overlay gets unmounted before `equery` is called. Use the board root's config instead.

## How to use

Check the `image` job log and the *_packages.txt files that get uploaded to bincache.

## Testing done

[This Jenkins run](http://jenkins.infra.kinvolk.io:8080/job/container/job/packages_all_arches/7457/cldsv/) passed. There were no signs of the warning, and the *_packages.txt files looked normal.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update) -- N/A
- [x] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.