### PR TITLE
Various SDK fixes

### DIFF
--- a/build_library/build_image_util.sh
+++ b/build_library/build_image_util.sh
@@ -150,7 +150,7 @@ emerge_to_image() {
   fi
 
   sudo -E ROOT="${root_fs_dir}" \
-      FEATURES="-ebuild-locks" \
+      FEATURES="-ebuild-locks -merge-wait" \
       PORTAGE_CONFIGROOT="${BUILD_DIR}"/configroot \
       emerge --usepkgonly --jobs="${NUM_JOBS}" --verbose "$@"
 

--- a/build_library/build_image_util.sh
+++ b/build_library/build_image_util.sh
@@ -166,26 +166,6 @@ emerge_to_image() {
       test_image_content "${root_fs_dir}"
 }
 
-# emerge_to_image without a rootfs check; you should use emerge_to_image unless
-# here's a good reason not to.
-emerge_to_image_unchecked() {
-  local root_fs_dir="$1"; shift
-
-  if [[ ${FLAGS_getbinpkg} -eq ${FLAGS_TRUE} ]]; then
-    set -- --getbinpkg "$@"
-  fi
-
-  sudo -E ROOT="${root_fs_dir}" \
-      PORTAGE_CONFIGROOT="${BUILD_DIR}"/configroot \
-      emerge --usepkgonly --jobs="${NUM_JOBS}" --verbose "$@"
-
-  # Shortcut if this was just baselayout
-  [[ "$*" == *sys-apps/baselayout ]] && return
-
-  # Make sure profile.env has been generated
-  sudo -E ROOT="${root_fs_dir}" env-update --no-ldconfig
-}
-
 # Switch to the dev or prod sub-profile
 set_image_profile() {
   local suffix="$1"

--- a/common.sh
+++ b/common.sh
@@ -296,12 +296,10 @@ load_environment_allowlist() {
 }
 
 load_environment_var() {
-  local file="$1" name value
-  shift
-  for name in "$@"; do
-    value=$(grep "^${name}=" "${file}" | sed 's|"||g')
-    [[ -n "${value}" ]] && export "${value}"
-  done
+  local file="$1"; shift
+  unset "${@}"
+  . <(grep -f <(printf "^%s=\n" "${@}") "${file}")
+  export "${@}"
 }
 
 # Find root of source tree

--- a/sdk_lib/sdk_entry.sh
+++ b/sdk_lib/sdk_entry.sh
@@ -126,16 +126,16 @@ grep -q 'export SYSEXT_SIGNING_KEY_DIR' /home/sdk/.bashrc || {
 }
 
 # This is ugly.
-#   We need to sudo su - sdk -c so the SDK user gets a fresh login.
+#   We need to sudo -u sdk -i so the SDK user gets a fresh login.
 #    'sdk' is member of multiple groups, and plain docker USER only
 #    allows specifying membership of a single group.
 #    When a command is passed to the container, we run, respectively:
-#    sudo su - sdk -c "<command>".
+#    sudo -u sdk "<command>".
 #   Then, we need to preserve whitespaces in arguments of commands
 #    passed to the container, e.g.
 #    ./update_chroot --toolchain_boards="amd64-usr arm64-usr".
 #    This is done via a separate ".cmd" file since we have used up
-#    our quotes for su -c "<cmd>" already.
+#    our quotes for sudo "<cmd>" already.
 if [ $# -gt 0 ] ; then
     cmd="/home/sdk/.cmd"
     echo -n "exec bash -l -i -c '" >"$cmd"
@@ -144,10 +144,10 @@ if [ $# -gt 0 ] ; then
     done
     echo "'" >>"$cmd"
     chmod 755 "$cmd"
-    sudo su sdk -c "$cmd"
+    sudo -u sdk "$cmd"
     rc=$?
     rm -f "$cmd"
     exit $rc
 else
-    exec sudo su -l sdk
+    exec sudo -u sdk -i
 fi


### PR DESCRIPTION
# Various SDK fixes

* Fixes writing to /dev/stdout and /dev/stderr. I noticed `set_version --file /dev/stdout` was broken.
* Fixes writing /etc/os-release with bad quotes following a Jenkins revert. This will also be fixed in flatcar/jenkins-os#431, but I wanted to make this more robust anyway.
* Speeds up build_image. It doesn't seem to make much difference in CI, but it definitely makes a difference locally.
* Drops an unused function.

## How to use

The most important thing to test is `./run_sdk_container`.

## Testing done

I've used these changes locally for a few days. A [Jenkins run](https://jenkins.flatcar.org/job/container/job/sdk/7/cldsv/) passed, although we cannot currently run the arm64 tests.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update) -- **N/A**
- [X] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.