### PR TITLE
update_chroot: Fix /etc/portage/patches symlink

### DIFF
--- a/update_chroot
+++ b/update_chroot
@@ -80,7 +80,7 @@ info "Setting up portage..."
 sudo mkdir -p "${REPO_CACHE_DIR}/distfiles"
 sudo chown "${PORTAGE_USERNAME}:portage" "${REPO_CACHE_DIR}/distfiles"
 sudo mkdir -p /etc/portage/repos.conf /var/lib/portage/pkgs
-sudo ln -sfT "${COREOS_OVERLAY}/coreos/user-patches" '/etc/portage/patches'
+sudo ln -sfT "${REPO_ROOT}/src/third_party/coreos-overlay/coreos/user-patches" /etc/portage/patches
 sudo touch /etc/portage/make.conf.user
 
 sudo_clobber "/etc/portage/make.conf" <<EOF


### PR DESCRIPTION
This was accidentally broken by #3795. I took that change from a branch where the `COREOS_OVERLAY` variable was no longer used at all.

## How to use

In the SDK:

```
$ ls -l /etc/portage/patches 
lrwxrwxrwx 1 root root 20 Apr 15 11:07 /etc/portage/patches -> /coreos/user-patches

$ ./update_chroot --setuponly

$ ls -l /etc/portage/patches 
lrwxrwxrwx 1 root root 67 Apr 15 11:13 /etc/portage/patches -> /mnt/host/source/src/third_party/coreos-overlay/coreos/user-patches
```

## Testing done

I've done the above.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update) -- N/A
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.