### PR TITLE
Parameterize secure boot keys

### DIFF
--- a/build_library/grub_install.sh
+++ b/build_library/grub_install.sh
@@ -37,6 +37,9 @@ switch_to_strict_mode
 . "${BUILD_LIBRARY_DIR}/board_options.sh" || exit 1
 . "${BUILD_LIBRARY_DIR}/sbsign_util.sh" || exit 1
 
+SBSIGN_DB_KEY="${SBSIGN_DB_KEY:-/usr/share/sb_keys/DB.key}"
+SBSIGN_DB_CERT="${SBSIGN_DB_CERT:-/usr/share/sb_keys/DB.crt}"
+
 # Our GRUB lives under flatcar/grub so new pygrub versions cannot find grub.cfg
 GRUB_DIR="flatcar/grub/${FLAGS_target}"
 
@@ -202,8 +205,8 @@ case "${FLAGS_target}" in
 
             # Unofficial build: Sign shim with our development key.
             sudo sbsign \
-                --key /usr/share/sb_keys/DB.key \
-                --cert /usr/share/sb_keys/DB.crt \
+                --key "${SBSIGN_DB_KEY}" \
+                --cert "${SBSIGN_DB_CERT}" \
                 --output "${ESP_DIR}/EFI/boot/boot${EFI_ARCH}.efi" \
                 "${BOARD_ROOT}/usr/lib/shim/shim${EFI_ARCH}.efi"
         else

--- a/build_library/sbsign_util.sh
+++ b/build_library/sbsign_util.sh
@@ -3,8 +3,8 @@
 # found in the LICENSE file.
 
 if [[ ${COREOS_OFFICIAL:-0} -ne 1 ]]; then
-    SBSIGN_KEY="/usr/share/sb_keys/shim.key"
-    SBSIGN_CERT="/usr/share/sb_keys/shim.pem"
+    SBSIGN_KEY="${SBSIGN_KEY:-/usr/share/sb_keys/shim.key}"
+    SBSIGN_CERT="${SBSIGN_CERT:-/usr/share/sb_keys/shim.pem}"
 else
     SBSIGN_KEY="pkcs11:token=flatcar-secure-boot-prod-2026-04"
     unset SBSIGN_CERT

--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -890,11 +890,17 @@ _write_qemu_uefi_secure_conf() {
     esac
 
     # TODO: Remove the temporary flatcar shim signing cert
+    local _sb_db_cert="${SBSIGN_DB_CERT:-/usr/share/sb_keys/DB.crt}"
+    local _sb_extra_db_certs=()
+    if [[ -z ${SBSIGN_DB_CERT:-} ]]; then
+        # Default behavior: include the temporary dev shim cert alongside DB.crt
+        _sb_extra_db_certs=( --add-db "${owner}" "${BUILD_LIBRARY_DIR}/flatcar-sb-dev-shim-2025.cert" )
+    fi
     virt-fw-vars \
         --input "${flash_in}" \
         --output "$(_dst_dir)/${flash_rw}" \
-        --add-db "${owner}" /usr/share/sb_keys/DB.crt \
-        --add-db "${owner}" "${BUILD_LIBRARY_DIR}/flatcar-sb-dev-shim-2025.cert"
+        --add-db "${owner}" "${_sb_db_cert}" \
+        "${_sb_extra_db_certs[@]}"
 
     sed -e "s%^SECURE_BOOT=.*%SECURE_BOOT=1%" -i "${script}"
 }

--- a/sdk_container/src/third_party/coreos-overlay/sys-boot/shim/shim-15.8-r3.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/sys-boot/shim/shim-15.8-r3.ebuild
@@ -54,7 +54,7 @@ src_compile() {
     fi
     emake_args+=( VENDOR_CERT_FILE="${SHIM_SIGNING_CERTIFICATE}" )
   else
-    emake_args+=( VENDOR_CERT_FILE="/usr/share/sb_keys/shim.der" )
+    emake_args+=( VENDOR_CERT_FILE="${SHIM_SIGNING_CERTIFICATE:-/usr/share/sb_keys/shim.der}" )
   fi
   emake "${emake_args[@]}" || die
 }

--- a/sdk_lib/sdk_container_common.sh
+++ b/sdk_lib/sdk_container_common.sh
@@ -213,6 +213,9 @@ function setup_sdk_env() {
         \
         USE FEATURES PORTAGE_USERNAME FORCE_STAGES \
         SIGNER \
+        SBSIGN_KEY SBSIGN_CERT SBSIGN_DB_KEY SBSIGN_DB_CERT \
+        SHIM_SIGNING_CERTIFICATE \
+        MODULE_SIGNING_KEY_DIR SYSEXT_SIGNING_KEY_DIR \
         all_proxy ftp_proxy http_proxy https_proxy no_proxy; do
 
         if [ -n "${!var:-}" ] ; then

--- a/sdk_lib/sdk_entry.sh
+++ b/sdk_lib/sdk_entry.sh
@@ -72,10 +72,14 @@ fi
 
 # Create key directory if not already configured in .bashrc
 if ! grep -q 'export MODULE_SIGNING_KEY_DIR=' /home/sdk/.bashrc; then
-    # For official builds, use ephemeral keys. For unofficial builds, use persistent directory
-    if [[ ${COREOS_OFFICIAL:-0} -eq 1 ]]; then
+    if [[ -n ${MODULE_SIGNING_KEY_DIR:-} ]]; then
+        # Pre-set via environment (e.g. .sdkenv) — use as-is
+        :
+    elif [[ ${COREOS_OFFICIAL:-0} -eq 1 ]]; then
+        # For official builds, use ephemeral keys
         MODULE_SIGNING_KEY_DIR=$(su sdk -c "mktemp -d")
     else
+        # For unofficial builds, use persistent directory
         MODULE_SIGNING_KEY_DIR="/home/sdk/.module-signing-keys"
         su sdk -c "mkdir -p ${MODULE_SIGNING_KEY_DIR@Q}"
     fi
@@ -97,7 +101,10 @@ if grep -q 'export SYSEXT_SIGNING_KEY_DIR' /home/sdk/.bashrc; then
     fi
 fi
 grep -q 'export SYSEXT_SIGNING_KEY_DIR' /home/sdk/.bashrc || {
-    if [[ ${COREOS_OFFICIAL:-0} -eq 1 ]]; then
+    if [[ -n ${SYSEXT_SIGNING_KEY_DIR:-} ]]; then
+        # Pre-set via environment (e.g. .sdkenv) — use as-is
+        :
+    elif [[ ${COREOS_OFFICIAL:-0} -eq 1 ]]; then
         SYSEXT_SIGNING_KEY_DIR=$(su sdk -c "mktemp -d")
     else
         SYSEXT_SIGNING_KEY_DIR="/home/sdk/.sysext-signing-keys"


### PR DESCRIPTION
# Parameterize Secure Boot keys

The current Secure Boot pipeline uses two different set of keys, one is public, hard-coded in the SDK container filesystem, and intended for test builds, the other is pulled from an Azure KMS and intended for release builds. Neither can be meaningfully parameterized to sign builds with custom keys.

This merge request attempts to parameterize the test keys to allow using custom keys instead. I tried to minimize actual changes to the codebase and as such opted for environment variables, at least to validate the initial approach. I feel they're a bit too "magic" and obscure though, and CLI arguments could be added to the necessary scripts if preferred.

Also, the generation, env preparation and artefact verification could be offloaded to proper scripts (ie, `verify_sbkey_images`, `generate_sbkeys` and `set_sbkeys_env`) to ease custom key workflow as well as act as documentation for the process.

## How to use

Generate keys:

```sh
OUTPUT_DIR="./sb-keys"
SUBJ_PREFIX="Flatcar Derivative"
DAYS=7300

openssl req -new -x509 -newkey rsa:2048 -sha256 -days "${DAYS}" \
    -subj "/CN=${SUBJ_PREFIX} Platform Key/" -nodes \
    -keyout "${OUTPUT_DIR}/PK.key" -out "${OUTPUT_DIR}/PK.crt"

openssl req -new -x509 -newkey rsa:2048 -sha256 -days "${DAYS}" \
    -subj "/CN=${SUBJ_PREFIX} Key Exchange Key/" -nodes \
    -keyout "${OUTPUT_DIR}/KEK.key" -out "${OUTPUT_DIR}/KEK.crt"

openssl req -new -x509 -newkey rsa:2048 -sha256 -days "${DAYS}" \
    -subj "/CN=${SUBJ_PREFIX} Secure Boot DB/" -nodes \
    -keyout "${OUTPUT_DIR}/DB.key" -out "${OUTPUT_DIR}/DB.crt"

openssl genrsa -out "${OUTPUT_DIR}/shim.key" 2048
openssl req -new -x509 -sha256 -days "${DAYS}" \
    -subj "/CN=${SUBJ_PREFIX} Shim Key/" \
    -key "${OUTPUT_DIR}/shim.key" -out "${OUTPUT_DIR}/shim.pem"
openssl x509 -in "${OUTPUT_DIR}/shim.pem" -inform PEM \
    -out "${OUTPUT_DIR}/shim.der" -outform DER
```

Set a proper environment:

```sh
CONTAINER_KEYS_DIR="/home/sdk/trunk/src/scripts/sb-keys"

export SBSIGN_KEY="${CONTAINER_KEYS_DIR}/shim.key"
export SBSIGN_CERT="${CONTAINER_KEYS_DIR}/shim.pem"
export SBSIGN_DB_KEY="${CONTAINER_KEYS_DIR}/DB.key"
export SBSIGN_DB_CERT="${CONTAINER_KEYS_DIR}/DB.crt"
export SHIM_SIGNING_CERTIFICATE="${CONTAINER_KEYS_DIR}/shim.der"
```

Build Flatcar as usual:

```sh
./build_packages
./build_image ...
./image_to_vm.sh ...
```

## Testing done

Verify artefacts have been signed with the correct keys:

```sh
sbverify __build__/images/images/amd64-usr/latest/flatcar_production_image.vmlinuz --cert sb-keys/shim.pem
Signature verification OK
```

