### PR TITLE
More SDK fixes

### DIFF
--- a/build_library/build_image_util.sh
+++ b/build_library/build_image_util.sh
@@ -152,7 +152,12 @@ emerge_to_image() {
   sudo -E ROOT="${root_fs_dir}" \
       FEATURES="-ebuild-locks -merge-wait" \
       PORTAGE_CONFIGROOT="${BUILD_DIR}"/configroot \
-      emerge --usepkgonly --jobs="${NUM_JOBS}" --verbose "$@"
+      emerge \
+      --usepkgonly \
+      --binpkg-respect-use=y \
+      --jobs="${NUM_JOBS}" \
+      --verbose \
+      "$@"
 
   # Shortcut if this was just baselayout
   [[ "$*" == *sys-apps/baselayout ]] && return

--- a/build_sdk_container_image
+++ b/build_sdk_container_image
@@ -125,10 +125,6 @@ fi
 
 # --
 
-docker_build() {
-    PROGRESS_NO_TRUNC=1 $docker build --progress plain "${@}"
-}
-
 # build plain SDK container w/o board support
 #
 import_image="flatcar-sdk-import:${docker_vernum}"

--- a/sdk_container/src/third_party/coreos-overlay/coreos/user-patches/app-shells/bash/bash-jobs-del-pid-async.patch
+++ b/sdk_container/src/third_party/coreos-overlay/coreos/user-patches/app-shells/bash/bash-jobs-del-pid-async.patch
@@ -1,0 +1,45 @@
+https://bugs.gentoo.org/970713
+
+From e359bdc261f9493d91b3cf792fe4fc480ecd6dc3 Mon Sep 17 00:00:00 2001
+From: Kerin Millar <kfm@plushkava.net>
+Date: Thu, 13 Nov 2025 18:39:28 +0000
+Subject: [PATCH] jobs.c: only call bgp_delete on a newly-created pid if
+ asynchronous
+
+This is a backport of the following change from the devel branch.
+
+jobs.c
+    - make_child: only call bgp_delete on a newly-created pid if that
+      process is asynchronous, since that is what will cause it to be
+      put into the bgpids table. This mostly matters for procsubs and
+      asynchronous jobs, but will happen for comsubs in async jobs
+      and coprocs as well.
+
+Bug: https://bugs.gentoo.org/965423
+Signed-off-by: Kerin Millar <kfm@plushkava.net>
+---
+ jobs.c | 8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/jobs.c b/jobs.c
+index cbcc2c15..bafa7c26 100644
+--- a/jobs.c
++++ b/jobs.c
+@@ -2482,9 +2482,11 @@ make_child (char *command, int flags)
+ 	 been reused. */
+       delete_old_job (pid);
+ 
+-      /* Perform the check for pid reuse unconditionally.  Some systems reuse
+-	 PIDs before giving a process CHILD_MAX/_SC_CHILD_MAX unique ones. */
+-      bgp_delete (pid);		/* new process, discard any saved status */
++      /* Perform the check for background pid reuse unconditionally.
++	 Some systems reuse PIDs before giving a process
++	 CHILD_MAX/_SC_CHILD_MAX unique ones. */
++      if (async_p)
++	bgp_delete (pid);	/* new background process, discard any saved status */
+ 
+       last_made_pid = pid;
+ 
+-- 
+2.51.2
+

--- a/sdk_container/src/third_party/coreos-overlay/profiles/coreos/base/profile.bashrc
+++ b/sdk_container/src/third_party/coreos-overlay/profiles/coreos/base/profile.bashrc
@@ -128,7 +128,7 @@ cros_pre_pkg_setup_sysroot_build_bin_dir() {
 # and also remove their associated debug files to avoid wasting space.
 cros_post_pkg_preinst_rm_masked_debug_files() {
 	local link debug dir=${ED}/usr/lib/debug
-	[[ -d ${dir}/.build-id ]] || return
+	[[ -d ${dir}/.build-id ]] || return 0
 	while read -d $'\n' -r link; do
 		debug=$(realpath "${link}.debug") || die
 		rm -f -- "${link}" "${link}.debug" "${debug}" || die

--- a/sdk_container/src/third_party/coreos-overlay/sys-apps/baselayout/baselayout-9999.ebuild
+++ b/sdk_container/src/third_party/coreos-overlay/sys-apps/baselayout/baselayout-9999.ebuild
@@ -94,7 +94,7 @@ pkg_preinst() {
 	libdirs=$(get_all_libdirs)
 	emake -C "${ED}/usr/share/${PN}" DESTDIR="${EROOT}" LIBDIRS="${libdirs}" layout
 	SYSTEMD_JOURNAL_GID=${ACCT_GROUP_SYSTEMD_JOURNAL_ID:-190} ROOT_UID=0 ROOT_GID=0 CORE_UID=500 CORE_GID=500 \
-		DESTDIR=${D} "${ED}/usr/share/${PN}/dumb-tmpfiles-proc.sh" "${ED}/usr/lib/tmpfiles.d" || die
+		DESTDIR=${ROOT} "${ED}/usr/share/${PN}/dumb-tmpfiles-proc.sh" --exclude CZL+ "${ED}/usr/lib/tmpfiles.d" || die
 	rm -f "${ED}/usr/share/${PN}/Makefile" "${ED}/usr/share/${PN}/dumb-tmpfiles-proc.sh" || die
 }
 

--- a/sdk_lib/Dockerfile.sdk-import
+++ b/sdk_lib/Dockerfile.sdk-import
@@ -17,11 +17,6 @@ RUN if ! grep -q portage /etc/passwd; then \
         echo "portage:x:250:250:portage:/var/tmp/portage:/bin/false" >>/etc/passwd; \
     fi
 
-# fix "Unable to unshare: EPERM ..." in containers
-#  (see https://github.com/gentoo/gentoo-docker-images/issues/81)
-RUN echo 'export FEATURES="-ipc-sandbox -network-sandbox -pid-sandbox"' \
-        >> /etc/skel/.bashrc
-
 RUN groupadd sdk
 RUN useradd -g sdk -G portage sdk
 RUN echo "sdk ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/sdk-user

--- a/sdk_lib/Dockerfile.sdk-update
+++ b/sdk_lib/Dockerfile.sdk-update
@@ -4,21 +4,12 @@ FROM ${BASE}
 COPY --chown=sdk:sdk sdk_container/ /mnt/host/source
 COPY --chown=sdk:sdk . /mnt/host/source/src/scripts
 
-# Disable all sandboxing for SDK updates since some core packages
-#  (like GO) fail to build from a permission error otherwise.
-RUN cp /home/sdk/.bashrc /home/sdk/.bashrc.bak
-RUN echo 'export FEATURES="-sandbox -usersandbox -ipc-sandbox -network-sandbox -pid-sandbox"' \
-        >> /home/sdk/.bashrc
-
 RUN chown sdk:sdk /mnt/host/source
-RUN /home/sdk/sdk_entry.sh ./update_chroot --toolchain_boards="amd64-usr arm64-usr"
+RUN FEATURES="-ipc-sandbox -network-sandbox -pid-sandbox" \
+        /home/sdk/sdk_entry.sh ./update_chroot --toolchain_boards="amd64-usr arm64-usr"
 
 RUN /home/sdk/sdk_entry.sh ./setup_board --board="arm64-usr" --regen_configs
 RUN /home/sdk/sdk_entry.sh ./setup_board --board="amd64-usr" --regen_configs
-
-# Restore original .bashrc to remove sandbox disablement
-RUN mv /home/sdk/.bashrc.bak /home/sdk/.bashrc
-RUN chown sdk:sdk /home/sdk/.bashrc
 
 # Clean up ephemeral key directory variables that were added during build
 RUN sed -i -e '/export MODULE_SIGNING_KEY_DIR=/d' \

--- a/sdk_lib/sdk_container_common.sh
+++ b/sdk_lib/sdk_container_common.sh
@@ -41,6 +41,11 @@ docker=${docker_a[*]}
 function call_docker() {
     "${docker_a[@]}" "${@}"
 }
+
+function docker_build() {
+    PROGRESS_NO_TRUNC=1 call_docker build --progress plain "${@}"
+}
+
 # --
 
 # Common "echo" function

--- a/update_sdk_container_image
+++ b/update_sdk_container_image
@@ -75,7 +75,8 @@ fi
 yell "Creating new SDK container image ${new_sdk_version} from ${base_sdk_version}"
 create_versionfile "${new_sdk_version}" "${os_version}"
 
-$docker build -t "${sdk_build_image}" \
+docker_build \
+    -t "${sdk_build_image}" \
     --build-arg BASE="$sdk_container_common_registry/flatcar-sdk-all:${base_sdk_version}" \
     -f sdk_lib/Dockerfile.sdk-update \
     .
@@ -87,7 +88,7 @@ for a in all arm64 amd64; do
         arm64) rmarch="amd64-usr"; rmcross="x86_64-cros-linux-gnu";;
         amd64) rmarch="arm64-usr"; rmcross="aarch64-cros-linux-gnu";;
     esac
-    $docker build -t "$sdk_container_common_registry/flatcar-sdk-${a}:${docker_vernum}" \
+    docker_build -t "$sdk_container_common_registry/flatcar-sdk-${a}:${docker_vernum}" \
                  --build-arg VERSION="${docker_vernum}" \
                  --build-arg RMARCH="${rmarch}" \
                  --build-arg RMCROSS="${rmcross}" \


### PR DESCRIPTION
* Stops `rm_masked_debug_files` Portage hook from complaining when it does nothing.
* Stops truncating the `docker build` output in `update_sdk_container_image`.
* Stops disabling the Portage sandboxes most of the time.
* Applies a tentative patch to Bash to try to fix [this](https://bugs.gentoo.org/970713).
* Stops `build_image` from installnig packages to the image with bad USE flags.
* Fixes baselayout so that it doesn't break `update_sdk_container_image`.

## How to use

Try running `update_sdk_container_image` with a baselayout bump.

## Testing done

A [two-phase SDK build in Jenkins](https://jenkins.flatcar.org/job/container/job/sdk/32/cldsv/) has succeeded. I also did the above.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update) -- **N/A**
- [X] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.