### PR TITLE
Fix image scripts

### DIFF
--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -806,12 +806,12 @@ _write_qemu_common() {
     cat >"${VM_README}" <<EOF
 If you have qemu installed (or in the SDK), you can start the image with:
   cd path/to/image
-  ./$(basename "${script}") -curses
+  ./$(basename "${script}") -display curses
 
 If you need to use a different ssh key or different ssh port:
-  ./$(basename "${script}") -a ~/.ssh/authorized_keys -p 2223 -- -curses
+  ./$(basename "${script}") -a ~/.ssh/authorized_keys -p 2223 -- -display curses
 
-If you rather you can use the -nographic option instad of -curses. In this
+If you rather you can use the -nographic option instad of '-display curses'. In this
 mode you can switch from the vm to the qemu monitor console with: Ctrl-a c
 See the qemu man page for more details on the monitor console.
 
@@ -911,7 +911,7 @@ _write_pxe_conf() {
     cat >>"${VM_README}" <<EOF
 
 You can pass extra kernel parameters with -append, for example:
-  ./$(basename "${script}") -curses -append 'sshkey="PUT AN SSH KEY HERE"'
+  ./$(basename "${script}") -display curses -append 'sshkey="PUT AN SSH KEY HERE"'
 
 When using -nographic or -serial you must also enable the serial console:
   ./$(basename "${script}") -nographic -append 'console=ttyS0,115200n8'

--- a/image_to_vm.sh
+++ b/image_to_vm.sh
@@ -48,6 +48,10 @@ DEFINE_string getbinpkgver "" \
 # include upload options
 . "${BUILD_LIBRARY_DIR}/release_util.sh" || exit 1
 
+# Override the default value to false so that
+# ./flatcar_production_qemu_uefi.sh can launch the qemu VM later.
+FLAGS_only_store_compressed=${FLAGS_FALSE}
+
 # Parse command line
 FLAGS "$@" || exit 1
 eval set -- "${FLAGS_ARGV}"


### PR DESCRIPTION
Fix ./flatcar_production_qemu_uefi.sh errors

```
sdk@flatcar-sdk-all-4628_0_0_os-beta-4628_1_0 /mnt/host/source/src/build/images/arm64-usr/developer-4628.1.0+2026-04-21-1013-a1 $ ./flatcar_production_qemu_uefi_secure.sh -curses                                                     
qemu-system-aarch64: -curses: invalid option       

sdk@flatcar-sdk-all-4628_0_0_os-beta-4628_1_0 /mnt/host/source/src/build/images/arm64-usr/developer-4628.1.0+2026-04-21-1013-a1 $ ./flatcar_production_qemu_uefi.sh -display curses                                                    
qemu-system-aarch64: -drive if=pflash,unit=0,file=./flatcar_production_qemu_uefi_efi_code.qcow2,format=qcow2,readonly=on: Could not open './flatcar_production_qemu_uefi_efi_code.qcow2': No such file or directory
```
