### PR TITLE
common: Filter dmesg on failure to warnings and errors

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -177,9 +177,9 @@ die_notrace() {
       error "${DIE_PREFIX}========"
       error_command_output "${DIE_PREFIX}" df -h
       error
-      error "${DIE_PREFIX}== DMESG =="
-      error "${DIE_PREFIX}==========="
-      error_command_output "${DIE_PREFIX}" sudo dmesg
+      error "${DIE_PREFIX}== DMESG (warn/error) =="
+      error "${DIE_PREFIX}========================"
+      error_command_output "${DIE_PREFIX}" sudo dmesg --color=never --ctime --level=err,warn
       error
       error "${DIE_PREFIX}!!!!!!!!!!!!!!!!!!!!!!!"
       error "${DIE_PREFIX}!! END DEBUG OUTPUT: !!"


### PR DESCRIPTION
When a script fails, the die_notrace function dumps the entire dmesg buffer for debugging purposes. On a busy system, this log can be excessively long, making it difficult to locate the actual kernel-level warnings or errors that may have caused the failure. The important messages are often buried in a flood of unrelated informational output.

Modify the dmesg call in the error handler to make debugging easier. Use the --level=err,warn option to limit the output to only warning and error messages, which significantly reduces noise and focuses on potential problems.

In addition, add the --ctime option to print human-readable timestamps for better event correlation and --color=never to ensure clean, parseable output in log files. The debug section header is also updated to reflect this change.
