### PR TITLE
common: check binfmt_misc for cross builds

### DIFF
--- a/build_image
+++ b/build_image
@@ -107,6 +107,8 @@ fi
 . "${BUILD_LIBRARY_DIR}/extra_sysexts.sh" || exit 1
 . "${BUILD_LIBRARY_DIR}/oem_sysexts.sh" || exit 1
 
+check_binfmt_for_cross_build
+
 PROD_IMAGE=0
 PROD_TAR=0
 CONTAINER=0

--- a/build_packages
+++ b/build_packages
@@ -111,6 +111,8 @@ if [ "${FLAGS_skip_chroot_upgrade}" -eq "${FLAGS_TRUE}" ]; then
   UPDATE_ARGS+=( --skip_chroot_upgrade )
 fi
 
+check_binfmt_for_cross_build
+
 "${SCRIPTS_DIR}"/setup_board --quiet --board=${FLAGS_board} "${UPDATE_ARGS[@]}"
 
 # set BOARD and BOARD_ROOT

--- a/common.sh
+++ b/common.sh
@@ -993,6 +993,38 @@ BOAT
   die "$* failed"
 }
 
+require_binfmt_entry() {
+  local entry="/proc/sys/fs/binfmt_misc/qemu-$1"
+
+  if [[ ! -d /proc/sys/fs/binfmt_misc ]]; then
+    sudo mount -t binfmt_misc binfmt_misc /proc/sys/fs/binfmt_misc || true
+  fi
+
+  if [[ ! -f "${entry}" ]] || ! grep -q '^enabled$' "${entry}"; then
+    die "Cross build requires binfmt_misc entry (missing or disabled): ${entry}
+Please install qemu-user-static package on the host"
+  fi
+}
+
+check_binfmt_for_cross_build() {
+  local host_arch
+
+  host_arch=$(uname -m)
+  case "${FLAGS_board}" in
+    amd64-usr)
+      if [[ "${host_arch}" != "x86_64" ]]; then
+        require_binfmt_entry "x86_64"
+      fi
+      ;;
+    arm64-usr)
+      if [[ "${host_arch}" != "aarch64" ]]; then
+        require_binfmt_entry "aarch64"
+      fi
+      ;;
+    *) die "Unsupported arch" ;;
+  esac
+}
+
 # The binfmt_misc support in the kernel is required.
 # The aarch64 binaries should be executed through
 # "/usr/bin/qemu-aarch64-static"


### PR DESCRIPTION
Fail early when cross builds lack the required binfmt_misc entry

in build_packages and build_image, matching SDK guidance.

Ref: https://www.flatcar.org/docs/latest/reference/developer-guides/sdk-modifying-flatcar/#select-the-target-architecture

# [Title: describe the change in one sentence]

[ describe the change in 1 - 3 paragraphs ]

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
