### PR TITLE
Improve SDK container setup messages for new users

### DIFF
--- a/ci-automation/ci_automation_common.sh
+++ b/ci-automation/ci_automation_common.sh
@@ -232,10 +232,15 @@ function docker_image_from_buildcache() {
     local url="https://${BUILDCACHE_SERVER}/containers/${version}/${tgz}"
     local url_release="https://mirror.release.flatcar-linux.net/containers/${version}/${tgz}"
 
-    curl --fail --silent --show-error --location --retry-delay 1 --retry 60 \
+    local curl_progress=(--silent --show-error)
+    if [[ -t 2 ]]; then
+        curl_progress=(--progress-bar)
+    fi
+
+    curl --fail "${curl_progress[@]}" --location --retry-delay 1 --retry 60 \
         --retry-connrefused --retry-max-time 60 --connect-timeout 20 \
         --remote-name "${url}" \
-        || curl --fail --silent --show-error --location --retry-delay 1 --retry 60 \
+        || curl --fail "${curl_progress[@]}" --location --retry-delay 1 --retry 60 \
         --retry-connrefused --retry-max-time 60 --connect-timeout 20 \
         --remote-name "${url_release}"
 
@@ -254,7 +259,7 @@ function docker_image_from_registry_or_buildcache() {
         return
     fi
 
-    echo "Falling back to tar ball download..." >&2
+    echo "Container image not found in registry, downloading SDK tarball instead (this is normal for nightly builds)..." >&2
     docker_image_from_buildcache "${image}" "${version}" zst || \
         docker_image_from_buildcache "${image}" "${version}" gz
 }

--- a/sdk_lib/sdk_container_common.sh
+++ b/sdk_lib/sdk_container_common.sh
@@ -303,6 +303,7 @@ function gnupg_ssh_gcloud_mount_opts() {
     if [[ -e ${GOOGLE_APPLICATION_CREDENTIALS:-} ]] ; then
         creds_dir=$(dirname "${GOOGLE_APPLICATION_CREDENTIALS}")
         if [[ -d ${creds_dir} ]] ; then
+            echo "Mounting gcloud credentials from ${creds_dir} (used for artifact uploads, safe to ignore if not needed, not baked into any image)"
             echo "-v $creds_dir:$creds_dir"
             args_ref+=( -v "${creds_dir}:${creds_dir}" )
         fi


### PR DESCRIPTION
## Improve SDK container setup messages for new users

When running run_sdk_container for the first time, several messages can confuse new users into thinking something is broken when the process is actually working correctly.

### Changes

- **Clarify gcloud credentials mount** - Added a message explaining that the mounted gcloud credentials are for optional artifact uploads and are not baked into any built image.
- **Improve registry fallback message** - Replaced `"Falling back to tar ball download..."` with a message explaining this is normal for nightly builds.
- **Show download progress interactively** - SDK tarballs are several GB but `curl` ran silently with no progress indication. Now shows a progress bar when a TTY is attached, stays silent in CI.

### Context

Multiple contributors were confused by all three of these when building Flatcar from `main` for the first time.

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
