### PR TITLE
build_library: Make some strings raw to avoid SyntaxWarning messages

### DIFF
--- a/build_library/generate_au_zip.py
+++ b/build_library/generate_au_zip.py
@@ -88,8 +88,8 @@ def _SplitAndStrip(data):
     if 'not found' in line:
       raise _LibNotFound(line)
     line = re.sub('.*not a dynamic executable.*', '', line)
-    line = re.sub('.* =>\s+', '', line)
-    line = re.sub('\(0x.*\)\s?', '', line)
+    line = re.sub(r'.* =>\s+', '', line)
+    line = re.sub(r'\(0x.*\)\s?', '', line)
     line = line.strip()
     if not len(line):
       continue

--- a/build_library/generate_grub_hashes.py
+++ b/build_library/generate_grub_hashes.py
@@ -40,13 +40,13 @@ with open(os.path.join(outputdir, "grub_modules.config"), "w") as f:
     f.write(json.dumps({"9": {"binaryvalues": [{"prefix": "grub_module", "values": hashvalues}]}}))
 
 with open(os.path.join(outputdir, "kernel_cmdline.config"), "w") as f:
-    f.write(json.dumps({"8": {"asciivalues": [{"prefix": "grub_kernel_cmdline", "values": [{"value": "rootflags=rw mount.usrflags=ro BOOT_IMAGE=/flatcar/vmlinuz-[ab] mount.usr=PARTUUID=\S{36} rootflags=rw mount.usrflags=ro consoleblank=0 root=LABEL=ROOT (console=\S+)? (flatcar.autologin=\S+)? verity.usrhash=\\S{64}", "description": "Flatcar kernel command line %s" % version}]}]}}))
+    f.write(json.dumps({"8": {"asciivalues": [{"prefix": "grub_kernel_cmdline", "values": [{"value": r"rootflags=rw mount.usrflags=ro BOOT_IMAGE=/flatcar/vmlinuz-[ab] mount.usr=PARTUUID=\S{36} rootflags=rw mount.usrflags=ro consoleblank=0 root=LABEL=ROOT (console=\S+)? (flatcar.autologin=\S+)? verity.usrhash=\\S{64}", "description": "Flatcar kernel command line %s" % version}]}]}}))
 
-commands = [{"value": '\[.*\]', "description": "Flatcar Grub configuration %s" % version},
+commands = [{"value": r'\[.*\]', "description": "Flatcar Grub configuration %s" % version},
             {"value": 'gptprio.next -d usr -u usr_uuid', "description": "Flatcar Grub configuration %s" % version},
             {"value": 'insmod all_video', "description": "Flatcar Grub configuration %s" % version},
-            {"value": 'linux /flatcar/vmlinuz-[ab] rootflags=rw mount.usrflags=ro consoleblank=0 root=LABEL=ROOT (console=\S+)? (flatcar.autologin=\S+)?', "description": "Flatcar Grub configuration %s" % version},
-            {"value": 'menuentry Flatcar \S+ --id=flatcar\S* {', "description": "Flatcar Grub configuration %s" % version},
+            {"value": r'linux /flatcar/vmlinuz-[ab] rootflags=rw mount.usrflags=ro consoleblank=0 root=LABEL=ROOT (console=\S+)? (flatcar.autologin=\S+)?', "description": "Flatcar Grub configuration %s" % version},
+            {"value": r'menuentry Flatcar \S+ --id=flatcar\S* {', "description": "Flatcar Grub configuration %s" % version},
             {"value": 'search --no-floppy --set randomize_disk_guid --disk-uuid 00000000-0000-0000-0000-000000000001', "description": "Flatcar Grub configuration %s" % version},
             {"value": 'search --no-floppy --set oem --part-label OEM --hint hd0,gpt1', "description": "Flatcar Grub configuration %s" % version},
             {"value": 'set .+', "description": "Flatcar Grub configuration %s" % version},


### PR DESCRIPTION
The warnings were:

```
/mnt/host/source/src/scripts/build_library/generate_grub_hashes.py:43: SyntaxWarning: invalid escape sequence '\S'
  f.write(json.dumps({"8": {"asciivalues": [{"prefix": "grub_kernel_cmdline", "values": [{"value": "rootflags=rw mount.usrflags=ro BOOT_IMAGE=/flatcar/vmlinuz-[ab] mount.usr=PARTUUID=\S{36} rootflags=rw mount.usrflags=ro consoleblank=0 root=LABEL=ROOT (console=\S+)? (flatcar.autologin=\S+)? verity.usrhash=\\S{64}", "description": "Flatcar kernel command line %s" % version}]}]}}))
/mnt/host/source/src/scripts/build_library/generate_grub_hashes.py:45: SyntaxWarning: invalid escape sequence '\['
  commands = [{"value": '\[.*\]', "description": "Flatcar Grub configuration %s" % version},
/mnt/host/source/src/scripts/build_library/generate_grub_hashes.py:48: SyntaxWarning: invalid escape sequence '\S'
  {"value": 'linux /flatcar/vmlinuz-[ab] rootflags=rw mount.usrflags=ro consoleblank=0 root=LABEL=ROOT (console=\S+)? (flatcar.autologin=\S+)?', "description": "Flatcar Grub configuration %s" % version},
/mnt/host/source/src/scripts/build_library/generate_grub_hashes.py:49: SyntaxWarning: invalid escape sequence '\S'
  {"value": 'menuentry Flatcar \S+ --id=flatcar\S* {', "description": "Flatcar Grub configuration %s" % version},
```

and

```
/mnt/host/source/src/scripts/build_library/generate_au_zip.py:91: SyntaxWarning: invalid escape sequence '\s'
  line = re.sub('.* =>\s+', '', line)
/mnt/host/source/src/scripts/build_library/generate_au_zip.py:92: SyntaxWarning: invalid escape sequence '\('
  line = re.sub('\(0x.*\)\s?', '', line)
```

Tested locally.