### PR TITLE
build_image: Allow specifying which OEM sysexts to build

### DIFF
--- a/build_image
+++ b/build_image
@@ -49,6 +49,8 @@ DEFINE_string developer_data "" \
   "Insert a custom cloudinit file into the image."
 DEFINE_string devcontainer_binhost "${DEFAULT_DEVCONTAINER_BINHOST}" \
   "Override portage binhost configuration used in development container."
+DEFINE_string oem_sysexts "everything!" \
+  "A comma-separated list of OEMs to build, by default build all the OEM sysexts. Used only if building OEM sysexts"
 
 # include upload options
 . "${BUILD_LIBRARY_DIR}/release_util.sh" || exit 1
@@ -193,7 +195,7 @@ if [[ "${SYSEXT}" -eq 1 ]]; then
   create_prod_sysexts "${FLATCAR_PRODUCTION_IMAGE_NAME}"
 fi
 if [[ "${OEM_SYSEXT}" -eq 1 ]]; then
-  create_oem_sysexts "${FLATCAR_PRODUCTION_IMAGE_NAME}"
+  create_oem_sysexts "${FLATCAR_PRODUCTION_IMAGE_NAME}" "${FLAGS_oem_sysexts}"
 fi
 
 if [[ ${FLAGS_extract_update} -eq ${FLAGS_TRUE} ]]; then

--- a/build_library/prod_image_util.sh
+++ b/build_library/prod_image_util.sh
@@ -276,13 +276,26 @@ create_prod_sysexts() {
 }
 
 create_oem_sysexts() {
-  local image_name="$1"
+  local image_name=${1}; shift
+  local requested_oem_sysexts_csv=${1}; shift
   local image_sysext_base="${image_name%.bin}_sysext.squashfs"
   local overlay_path
   overlay_path=$(portageq get_repo_path / coreos-overlay)
 
   local -a oem_sysexts
   get_oem_sysext_matrix "${ARCH}" oem_sysexts
+  if [[ ${requested_oem_sysexts_csv} != 'everything!' ]]; then
+      local -a all_oems requested_oems invalid_oems
+      all_oems=( "${oem_sysexts[@]}" )
+      all_oems=( "${all_oems[@]%%|*}" )
+      all_oems=( "${all_oems[@]#oem-}" )
+      mapfile -t requested_oems <<<"${requested_oem_sysexts_csv//,/$'\n'}"
+      mapfile -t invalid_oems < <(comm -23 <(printf '%s\n' "${requested_oems[@]}" | sort -u) <(printf '%s\n' "${all_oems[@]}" | sort -u))
+      if [[ ${#invalid_oems[@]} -gt 0 ]]; then
+          die "Requested OEMs to build sysexts for are invalid: ${invalid_oems[*]}, valid OEMs are ${all_oems[*]}"
+      fi
+      mapfile -t oem_sysexts < <(printf '%s\n' "${oem_sysexts[@]}" | grep '^oem-\('"${requested_oem_sysexts_csv//,/'\|'}"'\)|')
+  fi
 
   local sysext name metapkg useflags
   for sysext in "${oem_sysexts[@]}"; do


### PR DESCRIPTION
Useful if we want to locally generate one kind of image for testing.

Tested locally for building qemu OEM sysext only.