### PR TITLE
overlay profiles: Try a more elegant solution to python version pinning

### DIFF
--- a/sdk_container/src/third_party/coreos-overlay/profiles/coreos/base/make.defaults
+++ b/sdk_container/src/third_party/coreos-overlay/profiles/coreos/base/make.defaults
@@ -18,15 +18,6 @@ USE_EXPAND="${USE_EXPAND} GO_VERSION"
 
 USE="${USE} -cracklib -cups -tcpd -berkdb"
 
-# Use Python 3.12 as the default version.
-PYTHON_SINGLE_TARGET="-pypy3_11 -python3_11 python3_12 -python3_13 -python3_14 -python3_13t -python3_14t"
-PYTHON_TARGETS="-pypy3_11 -python3_11 python3_12 -python3_13 -python3_14 -python3_13t -python3_14t"
-
-# Same as above, but for bootstrapping.
-BOOTSTRAP_USE="${BOOTSTRAP_USE} -python_single_target_pypy3_11 -python_single_target_python3_11 python_single_target_python3_12 -python_single_target_python3_13 -python_single_target_python3_14  -python_single_target_python3_13t -python_single_target_python3_14t"
-BOOTSTRAP_USE="${BOOTSTRAP_USE} -python_targets_pypy3_11 -python_targets_python3_11 python_targets_python3_12 -python_targets_python3_13 -python_targets_python3_14 -python_targets_python3_13t -python_targets_python3_14t"
-
-
 # Never install cron or cron jobs
 USE="${USE} -cron"
 

--- a/sdk_container/src/third_party/coreos-overlay/profiles/coreos/base/package.use
+++ b/sdk_container/src/third_party/coreos-overlay/profiles/coreos/base/package.use
@@ -3,6 +3,10 @@
 # to the host packages in the chroot, as well as packages built for a
 # target board.
 
+# Use Python 3.12 as the default version.
+*/* PYTHON_TARGETS: -* python3_12
+*/* PYTHON_SINGLE_TARGET: -* python3_12
+
 app-arch/tar		minimal
 app-crypt/mit-krb5	-keyutils
 dev-libs/dbus-glib	tools

--- a/sdk_container/src/third_party/coreos-overlay/profiles/coreos/targets/sdk/transition/make.defaults
+++ b/sdk_container/src/third_party/coreos-overlay/profiles/coreos/targets/sdk/transition/make.defaults
@@ -1,9 +1,0 @@
-# Override python settings
-
-# Use Python 3.12 as the default version, allow python 3.11 for a transition.
-PYTHON_SINGLE_TARGET="-pypy3_11 -python3_11 python3_12 -python3_13 -python3_14 -python3_13t -python3_14t"
-PYTHON_TARGETS="-pypy3_11 python3_11 python3_12 -python3_13 -python3_14 -python3_13t -python3_14t"
-
-# Same as above, but for bootstrapping.
-BOOTSTRAP_USE="${BOOTSTRAP_USE} -python_single_target_pypy3_11 -python_single_target_python3_11 python_single_target_python3_12 -python_single_target_python3_13 -python_single_target_python3_14  -python_single_target_python3_13t -python_single_target_python3_14t"
-BOOTSTRAP_USE="${BOOTSTRAP_USE} -python_targets_pypy3_11 python_targets_python3_11 python_targets_python3_12 -python_targets_python3_13 -python_targets_python3_14 -python_targets_python3_13t -python_targets_python3_14t"

--- a/sdk_container/src/third_party/coreos-overlay/profiles/coreos/targets/sdk/transition/package.use
+++ b/sdk_container/src/third_party/coreos-overlay/profiles/coreos/targets/sdk/transition/package.use
@@ -1,0 +1,3 @@
+# Allow python 3.11 for a transition.
+*/* PYTHON_TARGETS: python3_11
+*/* PYTHON_SINGLE_TARGET: python3_11


### PR DESCRIPTION
Got a suggestion via recent Gentoo news.

CI: https://jenkins.flatcar.org/job/container/job/sdk/51/cldsv/