### PR TITLE
tests: remove NVIDIA tests for Azure

### DIFF
--- a/ci-automation/vendor-testing/azure.sh
+++ b/ci-automation/vendor-testing/azure.sh
@@ -71,7 +71,7 @@ query_kola_tests() {
 
 other_instance_types=()
 if [[ "${CIA_ARCH}" = 'amd64' ]]; then
-    other_instance_types+=('V1' 'Standard_NC6s_v3')
+    other_instance_types+=('V1')
 fi
 
 run_kola_tests_on_instances \


### PR DESCRIPTION
For now, we don't have sponsoring anymore to test NVIDIA on Azure

---

This slow downs CI and it's not relevant to keep this for now.