### PR TITLE
build_image: export FLATCAR_BUILD_ID to ensure consistency

### DIFF
--- a/build_image
+++ b/build_image
@@ -12,6 +12,12 @@
 SCRIPT_ROOT=$(dirname $(readlink -f "$0"))
 . "${SCRIPT_ROOT}/common.sh" || exit 1
 
+# Ensure all contexts share the same FLATCAR_BUILD_ID. Otherwise,
+# ${BUILD_DIR}/version.txt and ${rootfs}/lib/os-release could have different
+# FLATCAR_BUILD_ID values, causing the QEMU image to fail to start.
+# https://github.com/flatcar/Flatcar/issues/2041
+export FLATCAR_BUILD_ID
+
 # Script must run inside the chroot
 assert_inside_chroot
 


### PR DESCRIPTION
If FLATCAR_BUILD_ID is not exported, child processes or subsequent scripts may not inherit the variable. This can lead to mismatched build IDs between ${BUILD_DIR}/version.txt and ${rootfs}/lib/os-release, causing the generated QEMU image to fail to start.

Export the variable so that all related contexts share the same FLATCAR_BUILD_ID.

Link: https://github.com/flatcar/Flatcar/issues/2041


/cc stable and main branch
