### PR TITLE
Deal with distfile requests being blocked by crates.io

### DIFF
--- a/sdk_container/src/third_party/portage-stable/eclass/cargo.eclass
+++ b/sdk_container/src/third_party/portage-stable/eclass/cargo.eclass
@@ -280,7 +280,7 @@ _cargo_set_crate_uris() {
 			name="${BASH_REMATCH[1]}"
 			version="${BASH_REMATCH[2]}"
 		fi
-		url="https://crates.io/api/v1/crates/${name}/${version}/download -> ${name}-${version}.crate"
+		url="https://static.crates.io/crates/${name}/${name}-${version}.crate"
 		CARGO_CRATE_URIS+="${url} "
 
 		# when invoked by pkgbump, avoid fetching all the crates

--- a/setup_board
+++ b/setup_board
@@ -299,9 +299,7 @@ sudo_clobber "${BOARD_ETC}/portage/make.conf" <<EOF
 # Settings derived from the host environment
 CBUILD="$(portageq envvar CHOST)"
 HOSTCC="$(portageq envvar CHOST)-gcc"
-DISTDIR="$(portageq envvar DISTDIR)"
-MAKEOPTS="$(portageq envvar MAKEOPTS)"
-PORTAGE_USERNAME="$(portageq envvar PORTAGE_USERNAME)"
+$(portageq envvar -v DISTDIR MAKEOPTS PORTAGE_USERNAME FETCHCOMMAND RESUMECOMMAND | sed 's:\$:\\$:g')
 
 # Board specific settings
 CHOST="${BOARD_CHOST}"

--- a/update_chroot
+++ b/update_chroot
@@ -91,6 +91,8 @@ PORT_LOGDIR="/var/log/portage"
 PORTAGE_BINHOST="$PORTAGE_BINHOST"
 PORTAGE_USERNAME="${PORTAGE_USERNAME}"
 MAKEOPTS="--jobs=${NUM_JOBS} --load-average=$((NUM_JOBS * 2))"
+FETCHCOMMAND='wget -t 3 -T 60 --passive-ftp -U "Portage (Flatcar SDK ${FLATCAR_SDK_VERSION}, https://www.flatcar.org) distfile-fetch" -O "\\\${DISTDIR}/\\\${FILE}" "\\\${URI}"'
+RESUMECOMMAND='wget -c -t 3 -T 60 --passive-ftp -U "Portage (Flatcar SDK ${FLATCAR_SDK_VERSION}, https://www.flatcar.org) distfile-fetch" -O "\\\${DISTDIR}/\\\${FILE}" "\\\${URI}"'
 
 # Generally there isn't any need to add packages to @world by default.
 # You can use --select to override this.


### PR DESCRIPTION
crates.io (on Amazon CloudFront) is now rejecting our requests with 403. This can be avoided by setting a custom user-agent for wget. I have made a similar change to upstream Portage, but let's use our own string for Flatcar.

While the user-agent change deals with the blocked requests, it turns out we should be using a different faster and less restricted endpoint anyway, so let's also take the (about to be merged upstream) cargo.eclass change as well.

## How to use

Try building a Rust-based package with `GENTOO_MIRRORS=""`.

## Testing done

[Jenkins](https://jenkins.flatcar.org/job/container/job/sdk/39/) got as far as the image job, which failed for an unrelated reason.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.