### PR TITLE
Dockerfile.sdk-*: Disable Portage sandboxes during all image builds

### DIFF
--- a/sdk_lib/Dockerfile.lean-arch
+++ b/sdk_lib/Dockerfile.lean-arch
@@ -5,7 +5,8 @@ ARG RMARCH
 ARG RMCROSS
 
 RUN if [ -n "$RMCROSS" ]; then \
-        sudo crossdev --clean --force "$RMCROSS"; \
+        FEATURES="-ipc-sandbox -network-sandbox -pid-sandbox" \
+            sudo crossdev --clean --force "$RMCROSS"; \
     fi
 
 RUN if [ -n "$RMARCH" ]; then \

--- a/sdk_lib/Dockerfile.sdk-build
+++ b/sdk_lib/Dockerfile.sdk-build
@@ -7,7 +7,8 @@ ARG OFFICIAL=0
 # mark build as official where appropriate
 RUN echo "export COREOS_OFFICIAL=$OFFICIAL" > /mnt/host/source/.env
 
-RUN /home/sdk/sdk_entry.sh ./sdk_lib/setup_boards.sh start "${BINHOST}"
+RUN FEATURES="-ipc-sandbox -network-sandbox -pid-sandbox" \
+        /home/sdk/sdk_entry.sh ./sdk_lib/setup_boards.sh start "${BINHOST}"
 
 RUN rm /mnt/host/source/.env
 RUN rm -rf /home/sdk/toolchain-pkgs

--- a/sdk_lib/Dockerfile.sdk-import
+++ b/sdk_lib/Dockerfile.sdk-import
@@ -48,7 +48,8 @@ RUN chmod 755 /home/sdk/sdk_entry.sh
 
 # This should be a NOP; if you see packages being rebuilt
 #  it's likely that scripts and SDK tarball are out of sync
-RUN /home/sdk/sdk_entry.sh ./update_chroot --toolchain_boards="amd64-usr arm64-usr"
+RUN FEATURES="-ipc-sandbox -network-sandbox -pid-sandbox" \
+        /home/sdk/sdk_entry.sh ./update_chroot --toolchain_boards="amd64-usr arm64-usr"
 
 # Clean up ephemeral key directory variables that were added during build
 RUN sed -i -e '/export MODULE_SIGNING_KEY_DIR=/d' \


### PR DESCRIPTION
In #3955, I stopped disabling these sandboxes permanently, but they still need to be disabled temporarily during all the (unprivileged) image builds, not just Dockerfile.sdk-update.

## How to use

Check for `EPERM` warnings during the SDK build.

## Testing done

An SDK build in [Jenkins](https://jenkins.flatcar.org/job/container/job/sdk/50/cldsv/) made it to the packages job. I did find a single `EPERM` warning from Dockerfile.sdk-build when it breaks the dependency loops, but I stuck a `declare -p FEATURES` literally right before the emerge invocation, and it reported the expected value. It's not sudo masking the variable either. I can only guess that it's leftover state from /var/db/pkgs, which will go away with a further SDK build. One warning isn't a big deal anyway, and we were seeing a lot more than that before this change.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update) -- N/A
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc. -- N/A