### PR TITLE
build_library: fix Exoscale image format, size, and compression

### DIFF
--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -187,7 +187,8 @@ IMG_cloudstack_vhd_OEM_SYSEXT=cloudstack
 IMG_digitalocean_OEM_SYSEXT=digitalocean
 
 ## exoscale
-IMG_exoscale_DISK_FORMAT=qcow2
+IMG_exoscale_DISK_FORMAT=exoscale
+IMG_exoscale_DISK_EXTENSION=qcow2
 IMG_exoscale_OEM_SYSEXT=exoscale
 
 ## azure
@@ -474,6 +475,15 @@ _write_raw_disk() {
 
 _write_qcow2_disk() {
     qemu-img convert -f raw "$1" -O qcow2 -c -o compat=0.10 "$2"
+    assert_image_size "$2" qcow2
+}
+
+_write_exoscale_disk() {
+    qemu-img convert -f raw "$1" -O qcow2 -c -o compat=0.10 "$2"
+    # Exoscale images should be exactly 10G. This is the minimum for
+    # Custom Templates, and it also can't be any larger because it
+    # would prevent creation of an instance with the 10G disk size option.
+    qemu-img resize "$2" 10G
     assert_image_size "$2" qcow2
 }
 

--- a/changelog/changes/2026-06-06-fix-exoscale-image.md
+++ b/changelog/changes/2026-06-06-fix-exoscale-image.md
@@ -1,0 +1,1 @@
+ - Exoscale images are now built as 10G .qcow2 so they can be directly used with Exoscale Custom Templates

--- a/changelog/changes/2026-06-06-fix-exoscale-image.md
+++ b/changelog/changes/2026-06-06-fix-exoscale-image.md
@@ -1,1 +1,1 @@
- - Exoscale images are now built as 10G .qcow2 so they can be directly used with Exoscale Custom Templates
+ - Exoscale: images are now built as 10G .qcow2 so they can be directly used with Exoscale Custom Templates ([scripts#4075](https://github.com/flatcar/scripts/pull/4075))

--- a/ci-automation/vms.sh
+++ b/ci-automation/vms.sh
@@ -137,7 +137,7 @@ function _vm_build_impl() {
             COMPRESSION_FORMAT="bz2,none"
         elif [[ "${format}" =~ ^(hyperv|hyperv_vhdx)$ ]];then
             COMPRESSION_FORMAT="zip"
-        elif [[ "${format}" =~ ^(scaleway|kubevirt|proxmoxve|stackit)$ ]];then
+        elif [[ "${format}" =~ ^(scaleway|kubevirt|proxmoxve|stackit|exoscale)$ ]];then
             COMPRESSION_FORMAT="none"
         elif [[ "${format}" =~ ^(akamai)$ ]];then
             COMPRESSION_FORMAT="gz"


### PR DESCRIPTION
# Fix Exoscale image format, size, and compression

Exoscale requires Custom Templates to be at least 10GB, expects a .qcow2 extension, and Exoscale Custom Templates do not support compressed (.bz2) images. Currently, Flatcar releases an 8GB compressed .img.bz file.

This change ensures the output file uses the .qcow2 extension, applies a post-conversion resize to exactly 10G, and disables compression in the release pipeline, matching that of similar platforms (scaleway, etc).

Related to https://github.com/flatcar/Flatcar/issues/2163

## How to use

Reviewers can verify that the generated .qcow2 image can be directly used by Exoscale Custom Template and that this instance can be used to create a new compute instance with 10G disk size.

## Testing done

The changes were verified using the Flatcar SDK:

1. Build base image and oem sysexts:

  ```bash
  ./run_sdk_container ./build_image --board=amd64-usr --getbinpkg
  ./run_sdk_container ./build_image --board=amd64-usr --getbinpkg oem_sysext
  ```

2. Generate Exoscale image:

  ```bash
  ./run_sdk_container ./image_to_vm.sh --board=amd64-usr --getbinpkg --format=exoscale --image_compression_formats=none
  ```

3. Verify image metadata:

   ```bash
   qemu-img info __build__/images/amd64-usr/latest/flatcar_production_exoscale_image.qcow2
   ```
   
   ```
    image: flatcar_production_exoscale_image.qcow2
    file format: qcow2
    virtual size: 10 GiB (10737418240 bytes)
    disk size: 522 MiB
   ```

4. Real-world test: The resulting image was hosted on a public web server and successfully imported into Exoscale's 'Add Custom Template' UI without any manual renaming, resizing, or decompression required.


CI: https://jenkins.flatcar.org/job/container/job/packages_all_arches/163/cldsv/