### PR TITLE
run_local_tests.sh: set QEMU_DEVCONTAINER_FILE for locally built images

### DIFF
--- a/ci-automation/vendor-testing/qemu.sh
+++ b/ci-automation/vendor-testing/qemu.sh
@@ -65,7 +65,7 @@ declare -a devcontainer_opts
 if [ -n "${QEMU_DEVCONTAINER_URL}" ] ; then
     echo "++++ Using custom devcontainer URL '${QEMU_DEVCONTAINER_URL}'"
     devcontainer_opts+=( "--devcontainer-url" "${QEMU_DEVCONTAINER_URL}" )
-elif [ -n "${QEMU_DEVCONTAINER_FILE}" ]; then
+elif [[ -n "${QEMU_DEVCONTAINER_FILE}" && -f "${QEMU_DEVCONTAINER_FILE}" ]]; then
     echo "++++ Using custom devcontainer FILE '${QEMU_DEVCONTAINER_FILE}'"
     devcontainer_opts+=( "--devcontainer-file" "${QEMU_DEVCONTAINER_FILE}" )
 fi

--- a/run_local_tests.sh
+++ b/run_local_tests.sh
@@ -55,6 +55,7 @@ export QEMU_IMAGE_NAME=/work/__build__/images/images/${arch@Q}-usr/latest/flatca
 export QEMU_UEFI_FIRMWARE=/work/__build__/images/images/${arch@Q}-usr/latest/flatcar_production_qemu_uefi_efi_code.qcow2
 export QEMU_UEFI_OVMF_VARS=/work/__build__/images/images/${arch@Q}-usr/latest/flatcar_production_qemu_uefi_efi_vars.qcow2
 export QEMU_UPDATE_PAYLOAD=/work/__build__/images/images/${arch@Q}-usr/latest/flatcar_test_update.gz
+export QEMU_DEVCONTAINER_FILE=/work/__build__/images/images/${arch@Q}-usr/latest/flatcar_developer_container.bin.bz2
 export PARALLEL_TESTS=${parallel@Q}
 EOF
 


### PR DESCRIPTION
The sysext.custom-oem test requires a developer container image to build the sysext inside systemd-nspawn. For locally built Flatcar images, the developer container is available in the build output directory but was not passed to the test suite.

Export QEMU_DEVCONTAINER_FILE pointing to the locally built flatcar_developer_container.bin.bz2 so that the test can use it without attempting to download from upstream bincache, which would fail because the locally built version (with build timestamp) does not exist on the upstream server.

Fix errors:
2026-06-10T06:07:20Z kola/cluster: SSH: stderr: ++ source /usr/share/flatcar/release 2026-06-10T06:07:20Z kola/cluster: SSH: stderr: +++ FLATCAR_RELEASE_VERSION=4593.2.2+2026-06-04-0327 2026-06-10T06:07:20Z kola/cluster: SSH: stderr: +++ FLATCAR_RELEASE_BOARD=arm64-usr 2026-06-10T06:07:20Z kola/cluster: SSH: stderr: +++ FLATCAR_RELEASE_APPID='{e96281a6-d1af-4bde-9a0a-97b76e56dc57}' 2026-06-10T06:07:20Z kola/cluster: SSH: stderr: ++ echo 4593.2.2+2026-06-04-0327 2026-06-10T06:07:20Z kola/cluster: SSH: stderr: + version=4593.2.2+2026-06-04-0327 2026-06-10T06:07:20Z kola/cluster: SSH: stderr: ++ process_template http://bincache.flatcar-linux.net/images/@ARCH@/@VERSION@/flatcar_developer_container.bin.bz2 arm64 4593.2.2+2026-06-04-0327 2026-06-10T06:07:20Z kola/cluster: SSH: stderr: ++ local template=http://bincache.flatcar-linux.net/images/@ARCH@/@VERSION@/flatcar_developer_container.bin.bz2 2026-06-10T06:07:20Z kola/cluster: SSH: stderr: ++ shift 2026-06-10T06:07:20Z kola/cluster: SSH: stderr: ++ local arch=arm64 2026-06-10T06:07:20Z kola/cluster: SSH: stderr: ++ shift 2026-06-10T06:07:20Z kola/cluster: SSH: stderr: ++ local version=4593.2.2+2026-06-04-0327 2026-06-10T06:07:20Z kola/cluster: SSH: stderr: ++ shift 2026-06-10T06:07:20Z kola/cluster: SSH: stderr: ++ local result=http://bincache.flatcar-linux.net/images/@ARCH@/@VERSION@/flatcar_developer_container.bin.bz2 2026-06-10T06:07:20Z kola/cluster: SSH: stderr: ++ result=http://bincache.flatcar-linux.net/images/arm64/@VERSION@/flatcar_developer_container.bin.bz2 2026-06-10T06:07:20Z kola/cluster: SSH: stderr: ++ result=http://bincache.flatcar-linux.net/images/arm64/4593.2.2+2026-06-04-0327/flatcar_developer_container.bin.bz2 2026-06-10T06:07:20Z kola/cluster: SSH: stderr: ++ echo http://bincache.flatcar-linux.net/images/arm64/4593.2.2+2026-06-04-0327/flatcar_developer_container.bin.bz2 2026-06-10T06:07:20Z kola/cluster: SSH: stderr: + image_url=http://bincache.flatcar-linux.net/images/arm64/4593.2.2+2026-06-04-0327/flatcar_developer_container.bin.bz2 2026-06-10T06:07:20Z kola/cluster: SSH: stderr: + echo 'Fetching developer container from http://bincache.flatcar-linux.net/images/arm64/4593.2.2+2026-06-04-0327/flatcar_developer_container.bin.bz2' 2026-06-10T06:07:20Z kola/cluster: SSH: stderr: + curl --fail --silent --show-error --location --retry-delay 1 --retry 60 --retry-connrefused --retry-max-time 60 --connect-timeout 20 --remote-name http://bincache.flatcar-linux.net/images/arm64/4593.2.2+2026-06-04-0327/flatcar_developer_container.bin.bz2 2026-06-10T06:07:20Z kola/cluster: SSH: stderr: curl: (22) The requested URL returned error: 404 2026-06-10T06:07:20Z kola/cluster: SSH: stdout: Fetching developer container from http://bincache.flatcar-linux.net/images/arm64/4593.2.2+2026-06-04-0327/flatcar_developer_container.bin.bz2

# [Title: describe the change in one sentence]

[ describe the change in 1 - 3 paragraphs ]

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
