### PR TITLE
ci-automation/vm: do not compress OCI images

### DIFF
--- a/ci-automation/vms.sh
+++ b/ci-automation/vms.sh
@@ -137,7 +137,7 @@ function _vm_build_impl() {
             COMPRESSION_FORMAT="bz2,none"
         elif [[ "${format}" =~ ^(hyperv|hyperv_vhdx)$ ]];then
             COMPRESSION_FORMAT="zip"
-        elif [[ "${format}" =~ ^(scaleway|kubevirt|proxmoxve|stackit|exoscale)$ ]];then
+        elif [[ "${format}" =~ ^(scaleway|kubevirt|proxmoxve|stackit|exoscale|oraclecloud)$ ]];then
             COMPRESSION_FORMAT="none"
         elif [[ "${format}" =~ ^(akamai)$ ]];then
             COMPRESSION_FORMAT="gz"


### PR DESCRIPTION
```
$ du --si flatcar_production_oraclecloud_image.img*
592M    flatcar_production_oraclecloud_image.img
590M    flatcar_production_oraclecloud_image.img.bz2
```

(cc @navaneeth-dev)

---

This saves an extra decompression step.

TODO:
* Backport this to `flatcar-4722`
* Update the documentation