### PR TITLE
ci-automation: Drop unused Azure credential references

### DIFF
--- a/ci-automation/garbage_collect.sh
+++ b/ci-automation/garbage_collect.sh
@@ -256,7 +256,6 @@ function _garbage_collect_impl() {
     local mantle_ref
     mantle_ref=$(cat sdk_container/.repo/manifests/mantle-container)
     docker run --pull always --rm --net host \
-      --env AZURE_AUTH_CREDENTIALS --env AZURE_PROFILE \
       --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY \
       --env AWS_CREDENTIALS \
       --env DIGITALOCEAN_TOKEN_JSON \

--- a/ci-automation/release.sh
+++ b/ci-automation/release.sh
@@ -44,7 +44,7 @@
 #   4. REGISTRY_PASSWORD. Environment variable. The password to use for Docker registry login.
 #        Defaults to nothing if not set - in such case, SDK container will not be pushed.
 #
-#   5. Cloud credentials as secrets via the environment variables AZURE_PROFILE, AZURE_AUTH_CREDENTIALS,
+#   5. Cloud credentials as secrets via the environment variables
 #      AWS_CREDENTIALS, AWS_MARKETPLACE_CREDENTIALS, AWS_MARKETPLACE_ARN, AWS_CLOUDFORMATION_CREDENTIALS,
 #      GCP_JSON_KEY, GOOGLE_RELEASE_CREDENTIALS.
 #
@@ -79,10 +79,6 @@ function _inside_mantle() {
     source sdk_container/.env
     CHANNEL="$(get_git_channel)"
     VERSION="${FLATCAR_VERSION}"
-    azure_profile_config_file=""
-    secret_to_file azure_profile_config_file "${AZURE_PROFILE}"
-    azure_auth_config_file=""
-    secret_to_file azure_auth_config_file "${AZURE_AUTH_CREDENTIALS}"
     aws_credentials_config_file=""
     secret_to_file aws_credentials_config_file "${AWS_CREDENTIALS}"
     aws_marketplace_credentials_file=""


### PR DESCRIPTION
These haven't been used since we switched to managed identities in bacf710f2fe52be7b0da3ac25874540653ba3fc0. I'm doing this so that I can drop the credentials from Jenkins. I can't really test it, but it seems trivial enough.