### PR TITLE
ci-automation: enable OCI testing

### DIFF
--- a/ci-automation/ci-config.env
+++ b/ci-automation/ci-config.env
@@ -166,3 +166,13 @@ STACKIT_IMAGE_NAME="flatcar_production_stackit_image.img"
 : ${STACKIT_arm64_INSTANCE_TYPE:="g1r.4d"}
 : ${STACKIT_arm64_LOCATION:="eu01-2"}
 : ${STACKIT_amd64_LOCATION:="eu01-2"}
+
+# -- OracleCloud --
+ORACLECLOUD_PARALLEL="${PARALLEL_TESTS:-1}"
+ORACLECLOUD_IMAGE_NAME="flatcar_production_oraclecloud_image.img"
+: ${ORACLECLOUD_SUBNET_ID:="ocid1.subnet.oc1.iad.aaaaaaaaafwj2g3ojrn7j2mlk4nnbaq27o4cxelrxstlaymm6ecs76xtb2aa"}
+: ${ORACLECLOUD_amd64_INSTANCE_TYPE:="VM.Standard3.Flex"}
+# TODO: Use actual values for ARM64
+: ${ORACLECLOUD_arm64_INSTANCE_TYPE:="g1r.4d"}
+: ${ORACLECLOUD_arm64_LOCATION:="YQPA:US-ASHBURN-AD-1"}
+: ${ORACLECLOUD_amd64_LOCATION:="YQPA:US-ASHBURN-AD-1"}

--- a/ci-automation/ci-config.env
+++ b/ci-automation/ci-config.env
@@ -166,3 +166,14 @@ STACKIT_IMAGE_NAME="flatcar_production_stackit_image.img"
 : ${STACKIT_arm64_INSTANCE_TYPE:="g1r.4d"}
 : ${STACKIT_arm64_LOCATION:="eu01-2"}
 : ${STACKIT_amd64_LOCATION:="eu01-2"}
+
+# -- OracleCloud --
+ORACLECLOUD_PARALLEL="${PARALLEL_TESTS:-1}"
+ORACLECLOUD_IMAGE_NAME="flatcar_production_oraclecloud_image.img"
+: ${ORACLECLOUD_SUBNET_ID:="ocid1.subnet.oc1.iad.aaaaaaaaafwj2g3ojrn7j2mlk4nnbaq27o4cxelrxstlaymm6ecs76xtb2aa"}
+: ${ORACLECLOUD_amd64_INSTANCE_TYPE:="VM.Standard3.Flex"}
+: ${ORACLECLOUD_arm64_INSTANCE_TYPE:="VM.Standard.A1.Flex"}
+: ${ORACLECLOUD_arm64_LOCATION:="YQPA:US-ASHBURN-AD-1"}
+: ${ORACLECLOUD_amd64_LOCATION:="YQPA:US-ASHBURN-AD-1"}
+: ${ORACLECLOUD_arm64_REGION:="us-ashburn-1"}
+: ${ORACLECLOUD_amd64_REGION:="us-ashburn-1"}

--- a/ci-automation/garbage_collect_cloud.sh
+++ b/ci-automation/garbage_collect_cloud.sh
@@ -25,3 +25,11 @@ for channel in alpha beta stable lts; do
       --aws-credentials="${aws_credentials_config_file}"
   done
 done
+oraclecloud_private_key_path=''
+secret_to_file oraclecloud_private_key_path "${ORACLECLOUD_PRIVATE_KEY}"
+timeout --signal=SIGQUIT 60m ore oraclecloud gc --duration 6h \
+  --oraclecloud-tenancy="${ORACLECLOUD_TENANCY}" \
+  --oraclecloud-user="${ORACLECLOUD_USER}" \
+  --oraclecloud-fingerprint="${ORACLECLOUD_FINGERPRINT}" \
+  --oraclecloud-private-key-path="${oraclecloud_private_key_path}" \
+  --oraclecloud-compartment-id="${ORACLECLOUD_COMPARTMENT_ID}"

--- a/ci-automation/garbage_collect_cloud.sh
+++ b/ci-automation/garbage_collect_cloud.sh
@@ -25,3 +25,9 @@ for channel in alpha beta stable lts; do
       --aws-credentials="${aws_credentials_config_file}"
   done
 done
+timeout --signal=SIGQUIT 60m ore oraclecloud gc --duration 6h \
+  --oraclecloud-tenancy="${ORACLECLOUD_TENANCY}" \
+  --oraclecloud-user="${ORACLECLOUD_USER}" \
+  --oraclecloud-fingerprint="${ORACLECLOUD_FINGERPRINT}" \
+  --oraclecloud-private-key="$(echo "${ORACLECLOUD_PRIVATE_KEY}" | base64 --decode)" \
+  --oraclecloud-compartment-id="${ORACLECLOUD_COMPARTMENT_ID}"

--- a/ci-automation/vendor-testing/oraclecloud.sh
+++ b/ci-automation/vendor-testing/oraclecloud.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Copyright (c) 2025 The Flatcar Maintainers.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+set -euo pipefail
+
+# Test execution script for OracleCloud vendor.
+# This script is supposed to run in the mantle container.
+
+source ci-automation/vendor_test.sh
+
+oraclecloud_instance_type_var="ORACLECLOUD_${CIA_ARCH}_INSTANCE_TYPE"
+oraclecloud_instance_type="${!oraclecloud_instance_type_var}"
+
+oraclecloud_location_var="ORACLECLOUD_${CIA_ARCH}_LOCATION"
+oraclecloud_location="${!oraclecloud_location_var}"
+
+oraclecloud_private_key_path=''
+secret_to_file oraclecloud_private_key_path "${ORACLECLOUD_PRIVATE_KEY}"
+
+copy_from_buildcache "images/${CIA_ARCH}/${CIA_VERNUM}/${ORACLECLOUD_IMAGE_NAME}" .
+
+kola_test_basename="ci-${CIA_VERNUM//[+.]/-}"
+
+# Upload the image on OracleCloud.
+IMAGE_ID=$(ore oraclecloud \
+  --oraclecloud-compartment-id="${ORACLECLOUD_COMPARTMENT_ID}" \
+  --oraclecloud-tenancy="${ORACLECLOUD_TENANCY}" \
+  --oraclecloud-user="${ORACLECLOUD_USER}" \
+  --oraclecloud-fingerprint="${ORACLECLOUD_FINGERPRINT}" \
+  --oraclecloud-private-key-path=<(echo "${ORACLECLOUD_PRIVATE_KEY}" | base64 --decode) \
+  create-image \
+  --oraclecloud-bucket="flatcar-ci-jenkins" \
+  --board "${CIA_ARCH}-usr" \
+  --name "${kola_test_basename}" \
+  --file="${ORACLECLOUD_IMAGE_NAME}"
+)
+
+set -x
+
+timeout --signal=SIGQUIT 2h kola run \
+  --board="${CIA_ARCH}-usr" \
+  --parallel="${ORACLECLOUD_PARALLEL}" \
+  --tapfile="${CIA_TAPFILE}" \
+  --channel="${CIA_CHANNEL}" \
+  --basename="${kola_test_basename}" \
+  --platform=oraclecloud \
+  --oraclecloud-tenancy="${ORACLECLOUD_TENANCY}" \
+  --oraclecloud-user="${ORACLECLOUD_USER}" \
+  --oraclecloud-fingerprint="${ORACLECLOUD_FINGERPRINT}" \
+  --oraclecloud-private-key-path="${oraclecloud_private_key_path}" \
+  --oraclecloud-image-id="${IMAGE_ID}" \
+  --oraclecloud-shape="${oraclecloud_instance_type}" \
+  --oraclecloud-subnet-id="${ORACLECLOUD_SUBNET_ID}" \
+  --oraclecloud-availability-domain="${oraclecloud_location}" \
+  --oraclecloud-compartment-id="${ORACLECLOUD_COMPARTMENT_ID}" \
+  --image-version "${CIA_VERNUM}" \
+  "${@}"
+
+set +x

--- a/ci-automation/vendor-testing/oraclecloud.sh
+++ b/ci-automation/vendor-testing/oraclecloud.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Copyright (c) 2026 The Flatcar Maintainers.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+set -euo pipefail
+
+# Test execution script for OracleCloud vendor.
+# This script is supposed to run in the mantle container.
+
+source ci-automation/vendor_test.sh
+
+oraclecloud_instance_type_var="ORACLECLOUD_${CIA_ARCH}_INSTANCE_TYPE"
+oraclecloud_instance_type="${!oraclecloud_instance_type_var}"
+
+oraclecloud_location_var="ORACLECLOUD_${CIA_ARCH}_LOCATION"
+oraclecloud_location="${!oraclecloud_location_var}"
+
+oraclecloud_region_var="ORACLECLOUD_${CIA_ARCH}_REGION"
+oraclecloud_region="${!oraclecloud_region_var}"
+
+copy_from_buildcache "images/${CIA_ARCH}/${CIA_VERNUM}/${ORACLECLOUD_IMAGE_NAME}" .
+
+kola_test_basename="ci-${CIA_VERNUM//[+.]/-}"
+
+# Upload the image on OracleCloud.
+IMAGE_ID=$(ore oraclecloud \
+  --oraclecloud-compartment-id="${ORACLECLOUD_COMPARTMENT_ID}" \
+  --oraclecloud-tenancy="${ORACLECLOUD_TENANCY}" \
+  --oraclecloud-user="${ORACLECLOUD_USER}" \
+  --oraclecloud-fingerprint="${ORACLECLOUD_FINGERPRINT}" \
+  --oraclecloud-private-key="$(echo "${ORACLECLOUD_PRIVATE_KEY}" | base64 --decode)" \
+  create-image \
+  --oraclecloud-bucket="flatcar-ci-jenkins" \
+  --board "${CIA_ARCH}-usr" \
+  --name "${kola_test_basename}" \
+  --file="${ORACLECLOUD_IMAGE_NAME}"
+)
+
+timeout --signal=SIGQUIT 2h kola run \
+  --board="${CIA_ARCH}-usr" \
+  --parallel="${ORACLECLOUD_PARALLEL}" \
+  --tapfile="${CIA_TAPFILE}" \
+  --channel="${CIA_CHANNEL}" \
+  --basename="${kola_test_basename}" \
+  --platform=oraclecloud \
+  --oraclecloud-tenancy="${ORACLECLOUD_TENANCY}" \
+  --oraclecloud-user="${ORACLECLOUD_USER}" \
+  --oraclecloud-fingerprint="${ORACLECLOUD_FINGERPRINT}" \
+  --oraclecloud-private-key="$(echo "${ORACLECLOUD_PRIVATE_KEY}" | base64 --decode)" \
+  --oraclecloud-image-id="${IMAGE_ID}" \
+  --oraclecloud-shape="${oraclecloud_instance_type}" \
+  --oraclecloud-subnet-id="${ORACLECLOUD_SUBNET_ID}" \
+  --oraclecloud-availability-domain="${oraclecloud_location}" \
+  --oraclecloud-compartment-id="${ORACLECLOUD_COMPARTMENT_ID}" \
+  --oraclecloud-region="${oraclecloud_region}" \
+  --image-version "${CIA_VERNUM}" \
+  "${@}"


### PR DESCRIPTION
In this PR, we enable OCI (OracleCloud Infrastructure) testing for Flatcar. Promoting OCI to "officially" supported platform.

## Testing done

* arm64: https://jenkins.flatcar.org/job/container/job/test/2339/
* amd64: https://jenkins.flatcar.org/job/container/job/test/2338/

---

- [x] ~Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)~
- [x] ~Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.~

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->

Needs:
* https://github.com/flatcar/mantle/pull/871