### PR TITLE
changelog: fix entries

### DIFF
--- a/changelog/updates/2026-07-06-weekly-updates.md
+++ b/changelog/updates/2026-07-06-weekly-updates.md
@@ -1,144 +1,83 @@
 - SDK: crossdev ([20260501](https://gitweb.gentoo.org/proj/crossdev.git/log/?h=20260501))
-- SDK: cryptography
-([48.0.0](https://raw.githubusercontent.com/pyca/cryptography/refs/tags/48.0.0/CHANGELOG.rst))
+- SDK: cryptography ([48.0.0](https://raw.githubusercontent.com/pyca/cryptography/refs/tags/48.0.0/CHANGELOG.rst))
 - SDK: docutils ([0.23](https://docutils.sourceforge.io/HISTORY.html#release-0-23-2026-05-27))
-- SDK: editables
-([0.6](https://raw.githubusercontent.com/pfmoore/editables/refs/tags/0.6/CHANGELOG.md))
+- SDK: editables ([0.6](https://raw.githubusercontent.com/pfmoore/editables/refs/tags/0.6/CHANGELOG.md))
 - SDK: gdbus-codegen ([2.88.2](https://gitlab.gnome.org/GNOME/glib/-/releases/2.88.2))
 - SDK: glib-utils ([2.88.2](https://gitlab.gnome.org/GNOME/glib/-/releases/2.88.2))
 - SDK: gobject-introspection-common ([1.86.0](https://gitlab.gnome.org/GNOME/gobject-introspection/-/releases/1.86.0))
 - SDK: hatchling ([1.30.1](https://github.com/pypa/hatch/releases/tag/hatchling-v1.30.1))
-- SDK: installer
-([1.0.1](https://github.com/pypa/installer/releases/tag/1.0.1) (includes
-[1.0.0](https://github.com/pypa/installer/releases/tag/1.0.0)))
+- SDK: installer ([1.0.1](https://github.com/pypa/installer/releases/tag/1.0.1) (includes [1.0.0](https://github.com/pypa/installer/releases/tag/1.0.0)))
 - SDK: maturin ([1.13.3](https://github.com/PyO3/maturin/releases/tag/v1.13.3))
-- SDK: meson ([1.11.1](https://mesonbuild.com/Release-notes-for-1-11-0.html)
-(includes [1.10.0](https://mesonbuild.com/Release-notes-for-1-10-0.html)))
+- SDK: meson ([1.11.1](https://mesonbuild.com/Release-notes-for-1-11-0.html) (includes [1.10.0](https://mesonbuild.com/Release-notes-for-1-10-0.html)))
 - SDK: nspr ([4.39](https://hg-edge.mozilla.org/projects/nspr/log/54e7c1b0803d151e142e30dc0d05f12e1ec67a13))
-- SDK: patchutils
-([0.4.5](https://github.com/twaugh/patchutils/releases/tag/0.4.5) (includes
-[0.4.4](https://github.com/twaugh/patchutils/releases/tag/0.4.4),
-[0.4.3](https://github.com/twaugh/patchutils/releases/tag/0.4.3)))
+- SDK: patchutils ([0.4.5](https://github.com/twaugh/patchutils/releases/tag/0.4.5) (includes [0.4.4](https://github.com/twaugh/patchutils/releases/tag/0.4.4), [0.4.3](https://github.com/twaugh/patchutils/releases/tag/0.4.3)))
 - SDK: pathspec ([1.1.1](https://raw.githubusercontent.com/cpburnz/python-pathspec/refs/tags/v1.1.1/CHANGES.rst))
 - SDK: perf (6.19.12)
 - SDK: perl ([5.42.2](https://perldoc.perl.org/perl5422delta))
 - SDK: poetry-core ([2.4.1](https://github.com/python-poetry/poetry-core/releases/tag/2.4.1))
-- SDK: rapidjson ([1.1.0_p20250205](TODO))
+- SDK: rapidjson (1.1.0_p20250205)
 - SDK: rhash ([1.4.6](https://github.com/rhash/RHash/releases/tag/v1.4.6))
-- SDK: rust ([1.95.0](https://blog.rust-lang.org/2026/04/16/Rust-1.95.0/)
-(includes [1.94.0](https://blog.rust-lang.org/2026/03/05/Rust-1.94.0/)))
+- SDK: rust ([1.95.0](https://blog.rust-lang.org/2026/04/16/Rust-1.95.0/) (includes [1.94.0](https://blog.rust-lang.org/2026/03/05/Rust-1.94.0/)))
 - SDK: tcl ([8.6.17](https://sourceforge.net/p/tcl/mailman/message/59221153/))
 - azure, dev, gce, sysext-python: ensurepip-pip ([26.1.2](https://raw.githubusercontent.com/pypa/pip/refs/tags/26.1.2/NEWS.rst))
 - base, dev: bind ([9.20.23](https://bind9.readthedocs.io/en/v9.20.23/notes.html#notes-for-bind-9-20-23))
 - base, dev: btrfs-progs ([7.0](https://github.com/kdave/btrfs-progs/releases/tag/v7.0))
 - base, dev: checkpolicy ([3.10](https://github.com/SELinuxProject/selinux/releases/tag/3.10))
-- base, dev: curl ([8.21.0](https://curl.se/ch/8.21.0.html) (includes
-[8.20.0](https://curl.se/ch/8.20.0.html)))
+- base, dev: curl ([8.21.0](https://curl.se/ch/8.21.0.html) (includes [8.20.0](https://curl.se/ch/8.20.0.html)))
 - base, dev: dracut ([111](https://github.com/dracut-ng/dracut/releases/tag/111))
 - base, dev: ethtool ([7.0](https://git.kernel.org/pub/scm/network/ethtool/ethtool.git/plain/NEWS?h=v7.0))
 - base, dev: expat ([2.8.2](https://blog.hartwork.org/posts/expat-2-8-2-released/))
 - base, dev: gcc ([15.3.0](https://gcc.gnu.org/gcc-15/changes.html))
 - base, dev: gentoo-functions ([1.7.7](https://gitweb.gentoo.org/proj/gentoo-functions.git/log/?h=gentoo-functions-1.7.7))
 - base, dev: git ([2.54.0](https://raw.githubusercontent.com/git/git/refs/tags/v2.54.0/Documentation/RelNotes/2.54.0.adoc))
-- base, dev: glib
-([2.88.2](https://gitlab.gnome.org/GNOME/glib/-/releases/2.88.2) (includes
-[2.88.1](https://gitlab.gnome.org/GNOME/glib/-/releases/2.88.1),
-[2.88.0](https://gitlab.gnome.org/GNOME/glib/-/releases/2.88.0)))
+- base, dev: glib ([2.88.2](https://gitlab.gnome.org/GNOME/glib/-/releases/2.88.2) (includes [2.88.1](https://gitlab.gnome.org/GNOME/glib/-/releases/2.88.1), [2.88.0](https://gitlab.gnome.org/GNOME/glib/-/releases/2.88.0)))
 - base, dev: glibc ([2.43](https://sourceware.org/pipermail/libc-announce/2026/000052.html))
-- base, dev: gnupg
-([2.5.20](https://lists.gnupg.org/pipermail/gnupg-announce/2026q2/000505.html)
-(includes [2.5.19](https://lists.gnupg.org/pipermail/gnupg-announce/2026q2/000504.html)))
+- base, dev: gnupg ([2.5.20](https://lists.gnupg.org/pipermail/gnupg-announce/2026q2/000505.html) (includes [2.5.19](https://lists.gnupg.org/pipermail/gnupg-announce/2026q2/000504.html)))
 - base, dev: iproute2 ([7.0.0](https://lwn.net/Articles/1067497/))
 - base, dev: kbd ([2.10.0](https://github.com/legionus/kbd/releases/tag/v2.10.0))
 - base, dev: libgpg-error ([1.60](https://dev.gnupg.org/T8112.html))
 - base, dev: libksba ([1.8.0](https://dev.gnupg.org/T8253.html))
 - base, dev: libmd ([1.2.0](https://git.hadrons.org/cgit/libmd.git/log/?h=1.2.0))
 - base, dev: libselinux ([3.10](https://github.com/SELinuxProject/selinux/releases/tag/3.10))
-- base, dev: libsepol
-([3.10](https://github.com/SELinuxProject/selinux/releases/tag/3.10))
+- base, dev: libsepol ([3.10](https://github.com/SELinuxProject/selinux/releases/tag/3.10))
 - base, dev: libunistring ([1.4.2](https://gitweb.git.savannah.gnu.org/gitweb/?p=libunistring.git;a=blob;f=NEWS;h=e97ee06e03d6fea559665306c82f02e09725893a;hb=7dee51196310a703972a94843ecaf92decce6f82))
-- base, dev: libuv
-([1.52.1](https://github.com/libuv/libuv/releases/tag/v1.52.1) (includes
-[1.52.0](https://github.com/libuv/libuv/releases/tag/v1.52.0)))
+- base, dev: libuv ([1.52.1](https://github.com/libuv/libuv/releases/tag/v1.52.1) (includes [1.52.0](https://github.com/libuv/libuv/releases/tag/v1.52.0)))
 - base, dev: mit-krb5 ([1.22.2](https://web.mit.edu/kerberos/krb5-1.22/krb5-1.22.2.html))
 - base, dev: openldap ([2.6.13](https://www.openldap.org/software/release/changes_lts.html))
 - base, dev: qemu-guest-agent ([10.2.2](https://wiki.qemu.org/ChangeLog/10.2#Guest_agent))
 - base, dev: rsync ([3.4.4](https://github.com/RsyncProject/rsync/releases/tag/v3.4.4))
 - base, dev: sed ([4.10](https://lists.gnu.org/archive/html/info-gnu/2026-04/msg00009.html))
-- base, dev: selinux-base
-([2.20260312_p1](https://github.com/SELinuxProject/refpolicy/releases/tag/RELEASE_2_20260312)
-(includes
-[2.20250923](https://github.com/SELinuxProject/refpolicy/releases/tag/RELEASE_2_20250923)))
+- base, dev: selinux-base ([2.20260312_p1](https://github.com/SELinuxProject/refpolicy/releases/tag/RELEASE_2_20260312) (includes [2.20250923](https://github.com/SELinuxProject/refpolicy/releases/tag/RELEASE_2_20250923)))
 - base, dev: selinux-base-policy ([2.20260312_p1](https://github.com/SELinuxProject/refpolicy/releases/tag/RELEASE_2_20260312))
-- base, dev: selinux-container
-([2.20260312_p1](https://github.com/SELinuxProject/refpolicy/releases/tag/RELEASE_2_20260312)
-(includes
-[2.20250923](https://github.com/SELinuxProject/refpolicy/releases/tag/RELEASE_2_20250923)))
-- base, dev: selinux-dbus
-([2.20260312_p1](https://github.com/SELinuxProject/refpolicy/releases/tag/RELEASE_2_20260312)
-(includes
-[2.20250923](https://github.com/SELinuxProject/refpolicy/releases/tag/RELEASE_2_20250923)))
-- base, dev: selinux-policykit
-([2.20260312_p1](https://github.com/SELinuxProject/refpolicy/releases/tag/RELEASE_2_20260312)
-(includes
-[2.20250923](https://github.com/SELinuxProject/refpolicy/releases/tag/RELEASE_2_20250923)))
-- base, dev: selinux-sssd
-([2.20260312_p1](https://github.com/SELinuxProject/refpolicy/releases/tag/RELEASE_2_20260312)
-(includes
-[2.20250923](https://github.com/SELinuxProject/refpolicy/releases/tag/RELEASE_2_20250923)))
-- base, dev: selinux-unconfined
-([2.20260312_p1](https://github.com/SELinuxProject/refpolicy/releases/tag/RELEASE_2_20260312)
-(includes
-[2.20250923](https://github.com/SELinuxProject/refpolicy/releases/tag/RELEASE_2_20250923)))
+- base, dev: selinux-container ([2.20260312_p1](https://github.com/SELinuxProject/refpolicy/releases/tag/RELEASE_2_20260312) (includes [2.20250923](https://github.com/SELinuxProject/refpolicy/releases/tag/RELEASE_2_20250923)))
+- base, dev: selinux-dbus ([2.20260312_p1](https://github.com/SELinuxProject/refpolicy/releases/tag/RELEASE_2_20260312) (includes [2.20250923](https://github.com/SELinuxProject/refpolicy/releases/tag/RELEASE_2_20250923)))
+- base, dev: selinux-policykit ([2.20260312_p1](https://github.com/SELinuxProject/refpolicy/releases/tag/RELEASE_2_20260312) (includes [2.20250923](https://github.com/SELinuxProject/refpolicy/releases/tag/RELEASE_2_20250923)))
+- base, dev: selinux-sssd ([2.20260312_p1](https://github.com/SELinuxProject/refpolicy/releases/tag/RELEASE_2_20260312) (includes [2.20250923](https://github.com/SELinuxProject/refpolicy/releases/tag/RELEASE_2_20250923)))
+- base, dev: selinux-unconfined ([2.20260312_p1](https://github.com/SELinuxProject/refpolicy/releases/tag/RELEASE_2_20260312) (includes [2.20250923](https://github.com/SELinuxProject/refpolicy/releases/tag/RELEASE_2_20250923)))
 - base, dev: semodule-utils ([3.10](https://github.com/SELinuxProject/selinux/releases/tag/3.10))
 - base, dev: sqlite ([3.53.1](https://sqlite.org/releaselog/3_53_1.html))
 - base, dev: strace ([7.0](https://github.com/strace/strace/releases/tag/v7.0))
 - base, dev: talloc ([2.4.4](https://gitlab.com/samba-team/samba/-/commit/51d05da70e8461834396d361eead807127751b76))
 - base, dev: tdb ([1.4.15](https://gitlab.com/samba-team/samba/-/commit/c05d12c4fefa0272fb06a040ff8ba2b03ab42fb3))
 - base, dev: timezone-data ([2026b](https://lists.iana.org/hyperkitty/list/tz@iana.org/thread/VX2Z3CBO6KHTYZNBBKFFWM7ZCI6TVCXP/))
-- base, dev: xfsprogs
-([7.0.1](https://web.git.kernel.org/pub/scm/fs/xfs/xfsprogs-dev.git/plain/doc/CHANGES?h=v7.0.1)
-(includes
-[7.0.0](https://web.git.kernel.org/pub/scm/fs/xfs/xfsprogs-dev.git/plain/doc/CHANGES?h=v7.0.0)))
+- base, dev: xfsprogs ([7.0.1](https://web.git.kernel.org/pub/scm/fs/xfs/xfsprogs-dev.git/plain/doc/CHANGES?h=v7.0.1) (includes [7.0.0](https://web.git.kernel.org/pub/scm/fs/xfs/xfsprogs-dev.git/plain/doc/CHANGES?h=v7.0.0)))
 - dev: eselect ([1.4.32](https://gitweb.gentoo.org/proj/eselect.git/plain/NEWS?id=1ff2aea90d6cd2bb93019deb40d3c7c7a0b5c36f))
 - dev: gdb ([17.2](https://sourceware.org/pipermail/gdb-announce/2026/000148.html))
 - dev: getuto ([2.0](https://github.com/projg2/getuto/commits/getuto-2.0/))
 - dev: i2c-tools ([4.4](https://git.kernel.org/pub/scm/utils/i2c-tools/i2c-tools.git/tree/CHANGES?h=v4.4))
 - dev: portage ([3.0.81.1](https://gitweb.gentoo.org/proj/portage.git/plain/NEWS?h=portage-3.0.81.1))
-- sysext-docker: docker
-([29.1.3](https://github.com/moby/moby/releases/tag/docker-v29.1.3) (includes
-[29.1.2](https://github.com/moby/moby/releases/tag/docker-v29.1.2),
-[29.1.1](https://github.com/moby/moby/releases/tag/docker-v29.1.1),
-[29.1.0](https://github.com/moby/moby/releases/tag/docker-v29.1.0),
-[29.0.0](https://github.com/moby/moby/releases/tag/docker-v29.0.0)))
-- sysext-incus: incus
-([7.2](https://discuss.linuxcontainers.org/t/incus-7-2-has-been-released/26879)
-(includes
-[7.0](https://discuss.linuxcontainers.org/t/incus-7-0-lts-has-been-released/26641)))
+- sysext-docker: docker ([29.1.3](https://github.com/moby/moby/releases/tag/docker-v29.1.3) (includes [29.1.2](https://github.com/moby/moby/releases/tag/docker-v29.1.2), [29.1.1](https://github.com/moby/moby/releases/tag/docker-v29.1.1), [29.1.0](https://github.com/moby/moby/releases/tag/docker-v29.1.0), [29.0.0](https://github.com/moby/moby/releases/tag/docker-v29.0.0)))
+- sysext-incus: incus ([7.2](https://discuss.linuxcontainers.org/t/incus-7-2-has-been-released/26879) (includes [7.0](https://discuss.linuxcontainers.org/t/incus-7-0-lts-has-been-released/26641)))
 - sysext-incus: lxc ([7.0.0](https://discuss.linuxcontainers.org/t/lxc-7-0-lts-has-been-released/26612))
 - sysext-incus: lxcfs ([7.0.0](https://discuss.linuxcontainers.org/t/lxcfs-7-0-lts-has-been-released/26607))
-- sysext-podman: aardvark-dns
-([2.0.0](https://github.com/containers/aardvark-dns/releases/tag/v2.0.0)
-(includes
-[1.17.1](https://github.com/containers/aardvark-dns/releases/tag/v1.17.1)))
-- sysext-podman: conmon
-([2.2.1](https://github.com/containers/conmon/releases/tag/v2.2.1) (includes
-[2.2.0](https://github.com/containers/conmon/releases/tag/v2.2.0)))
-- sysext-podman: crun
-([1.28](https://github.com/containers/crun/releases/tag/1.28))
-- sysext-podman: netavark
-([2.0.0](https://github.com/containers/netavark/releases/tag/v2.0.0) (includes
-[1.17.2](https://github.com/containers/netavark/releases/tag/v1.17.2)))
+- sysext-podman: aardvark-dns ([2.0.0](https://github.com/containers/aardvark-dns/releases/tag/v2.0.0) (includes [1.17.1](https://github.com/containers/aardvark-dns/releases/tag/v1.17.1)))
+- sysext-podman: conmon ([2.2.1](https://github.com/containers/conmon/releases/tag/v2.2.1) (includes [2.2.0](https://github.com/containers/conmon/releases/tag/v2.2.0)))
+- sysext-podman: crun ([1.28](https://github.com/containers/crun/releases/tag/1.28))
+- sysext-podman: netavark ([2.0.0](https://github.com/containers/netavark/releases/tag/v2.0.0) (includes [1.17.2](https://github.com/containers/netavark/releases/tag/v1.17.2)))
 - sysext-podman: passt ([2026.05.26](https://archives.passt.top/passt-user/20260527093624.6349111e@elisabeth/T/#u))
-- sysext-podman: podman
-([6.0.0](https://github.com/podman-container-tools/podman/releases/tag/v6.0.0)
-(includes
-[5.8.0](https://github.com/podman-container-tools/podman/releases/tag/v5.8.0)))
+- sysext-podman: podman ([6.0.0](https://github.com/podman-container-tools/podman/releases/tag/v6.0.0) (includes [5.8.0](https://github.com/podman-container-tools/podman/releases/tag/v5.8.0)))
 - sysext-python: distlib ([0.4.1](https://raw.githubusercontent.com/pypa/distlib/refs/tags/0.4.1/CHANGES.rst))
-- sysext-python: idna ([3.18](https://github.com/kjd/idna/releases/tag/v3.18)
-(includes [3.17](https://github.com/kjd/idna/releases/tag/v3.17),
-[3.16](https://github.com/kjd/idna/releases/tag/v3.16),
-[3.15](https://github.com/kjd/idna/releases/tag/v3.15)))
+- sysext-python: idna ([3.18](https://github.com/kjd/idna/releases/tag/v3.18) (includes [3.17](https://github.com/kjd/idna/releases/tag/v3.17), [3.16](https://github.com/kjd/idna/releases/tag/v3.16), [3.15](https://github.com/kjd/idna/releases/tag/v3.15)))
 - sysext-python: jaraco-functools ([4.5.0](https://raw.githubusercontent.com/jaraco/jaraco.functools/refs/tags/v4.5.0/NEWS.rst))
 - sysext-python: markdown-it-py ([4.2.0](https://github.com/executablebooks/markdown-it-py/releases/tag/v4.2.0))
 - sysext-python: more-itertools ([11.1.0](https://github.com/more-itertools/more-itertools/releases/tag/v11.1.0))


### PR DESCRIPTION
For unknown reasons, the lines were breaked so changelog generation was bad-tripping over. (See: https://jenkins.flatcar.org/job/container/job/image_changes/810/console)

I removed a 'rapidjson' entry as well, as there is no real changelog for it.
