### PR TITLE
sysext/containerd: read drop-ins from /etc/containerd/conf.d

### DIFF
--- a/changelog/changes/2026-07-24-containerd-dropin-config.md
+++ b/changelog/changes/2026-07-24-containerd-dropin-config.md
@@ -1,0 +1,1 @@
+- Added support for containerd drop-in configuration in `/etc/containerd/conf.d/*.toml`, so settings can be adjusted without replacing the shipped config ([scripts#4150](https://github.com/flatcar/scripts/pull/4150))

--- a/sdk_container/src/third_party/coreos-overlay/coreos/sysext/containerd/usr/share/containerd/config-cgroupfs.toml
+++ b/sdk_container/src/third_party/coreos-overlay/coreos/sysext/containerd/usr/share/containerd/config-cgroupfs.toml
@@ -1,5 +1,8 @@
 version = 2
 
+# drop-in configuration, takes precedence over the settings below
+imports = ["/etc/containerd/conf.d/*.toml"]
+
 # persistent data location
 root = "/var/lib/containerd"
 # runtime state information

--- a/sdk_container/src/third_party/coreos-overlay/coreos/sysext/containerd/usr/share/containerd/config.toml
+++ b/sdk_container/src/third_party/coreos-overlay/coreos/sysext/containerd/usr/share/containerd/config.toml
@@ -1,5 +1,8 @@
 version = 2
 
+# drop-in configuration, takes precedence over the settings below
+imports = ["/etc/containerd/conf.d/*.toml"]
+
 # persistent data location
 root = "/var/lib/containerd"
 # runtime state information


### PR DESCRIPTION
Changing containerd settings currently means copying the default config. That copy can miss updates to the defaults later.

This change makes both shipped configs read `/etc/containerd/conf.d/*.toml`, so users can keep their own settings in separate files.

Fixes flatcar/Flatcar#1127.

## How to use

Create `/etc/containerd/conf.d/50-log.toml` with these contents, then restart containerd:

```toml
version = 2
[plugins."io.containerd.grpc.v1.cri"]
max_container_log_line_size = 65536
```

Use `version = 2` to match the shipped configs. Files are read in filename order. Lists are combined, and some empty or zero values do not replace existing settings. A missing or empty directory leaves the settings unchanged. If you use your own main config, add the imports line there too.

## Testing done

```sh
python3 .repair-validation/containerd-probes.py "$PWD" \
  "$RUNNER_TEMP/containerd-bin/bin/containerd" "$RUNNER_TEMP/containerd-probes"
bash .repair-validation/flatcar-vm.sh "$PWD" "$RUNNER_TEMP/flatcar-vm"
git diff --check
```

- All 22 Linux config checks passed with containerd 2.3.4.
- Both configs passed service tests on Flatcar 4790.0.0 with containerd 2.2.5. Tests covered missing and empty directories, overrides, invalid config and recovery.
- Docker and CRI containers ran successfully. The CRI container exited with code 0, and the running service used the requested log limit.
- `git diff --check` passed.

[Test logs and scripts](https://github.com/satwiksps/scripts/actions/runs/34735870584). The tests used the same config files as this PR. The VM used a published Flatcar image, cgroup v2, SELinux permissive mode and host networking. SELinux enforcing mode, CNI, Kubernetes and a custom OS build were not tested. The test scripts are on a separate branch.

- [x] Changelog entry added.
- [ ] Inspected CI output for image differences.

AI helped with the investigation, code change and tests.
