### PR TITLE
systemd: backport dm-verity mapper naming fix for sysext

### DIFF
--- a/changelog/bugfixes/2026-07-25-sysext-refresh-verity-warnings.md
+++ b/changelog/bugfixes/2026-07-25-sysext-refresh-verity-warnings.md
@@ -1,0 +1,1 @@
+- Fixed noisy `systemd-sysext refresh` `device-mapper: reload ioctl ... Invalid argument` warnings by backporting an upstream `systemd` dm-verity mapper naming fix for loop-backed extension images.

--- a/sdk_container/src/third_party/portage-stable/sys-apps/systemd/files/systemd-259.4-dissect-image-include-diskseq-in-dm-names.patch
+++ b/sdk_container/src/third_party/portage-stable/sys-apps/systemd/files/systemd-259.4-dissect-image-include-diskseq-in-dm-names.patch
@@ -1,0 +1,158 @@
+From 15e9fbc76983a278ea55ecb762a9572e03b838c5 Mon Sep 17 00:00:00 2001
+From: Yu Watanabe <watanabe.yu+github@gmail.com>
+Date: Thu, 17 Jul 2025 10:43:53 +0900
+Subject: [PATCH] dissect-image: include diskseq in DM names, to avoid any
+ name clashes
+
+When multiple loop devices are attached to the same backing image path,
+reusing mapper names derived only from the partition node can cause
+dm-verity activation attempts to collide. Include the loop disk sequence
+number in generated mapper names when available so concurrent or repeated
+image dissection uses distinct device-mapper names.
+---
+ src/shared/dissect-image.c | 42 +++++++++++++++++++++++++++++---------
+ 1 file changed, 32 insertions(+), 10 deletions(-)
+
+diff --git a/src/shared/dissect-image.c b/src/shared/dissect-image.c
+index c01d6e02e1..fdffce4e99 100644
+--- a/src/shared/dissect-image.c
++++ b/src/shared/dissect-image.c
+@@ -69,6 +69,7 @@
+ #include "runtime-scope.h"
+ #include "siphash24.h"
+ #include "stat-util.h"
++#include "stdio-util.h"
+ #include "string-util.h"
+ #include "strv.h"
+ #include "time-util.h"
+@@ -2951,8 +2952,15 @@ static int decrypted_image_new(DecryptedImage **ret) {
+         return 0;
+ }
+ 
++static uint64_t dissected_image_diskseq(const DissectedImage *di) {
++        assert(di);
++
++        return di->loop ? di->loop->diskseq : 0;
++}
++
+ static int make_dm_name_and_node(
+                 const char *base,
++                uint64_t diskseq,
+                 const char *suffix,
+                 char **ret_name,
+                 char **ret_node) {
+@@ -2962,7 +2970,11 @@ static int make_dm_name_and_node(
+         assert(ret_name);
+         assert(ret_node);
+ 
+-        _cleanup_free_ char *name = strjoin(base, suffix);
++        _cleanup_free_ char *name = NULL;
++        if (diskseq != 0)
++                name = asprintf_safe("%s-%" PRIu64 "%s", base, diskseq, suffix);
++        else
++                name = strjoin(base, suffix);
+         if (!name)
+                 return -ENOMEM;
+         if (!filename_is_valid(name))
+@@ -2980,6 +2992,7 @@ static int make_dm_name_and_node(
+ 
+ static int make_dm_name_and_node_from_node(
+                 const char *original_node,
++                uint64_t diskseq,
+                 const char *suffix,
+                 char **ret_name,
+                 char **ret_node) {
+@@ -2993,10 +3006,11 @@ static int make_dm_name_and_node_from_node(
+         if (r < 0)
+                 return r;
+ 
+-        return make_dm_name_and_node(base, suffix, ret_name, ret_node);
++        return make_dm_name_and_node(base, diskseq, suffix, ret_name, ret_node);
+ }
+ 
+ static int decrypt_partition(
++                DissectedImage *di,
+                 DissectedPartition *m,
+                 const char *passphrase,
+                 DissectImageFlags flags,
+@@ -3008,6 +3022,7 @@ static int decrypt_partition(
+         _cleanup_close_ int fd = -EBADF;
+         int r;
+ 
++        assert(di);
+         assert(m);
+         assert(d);
+ 
+@@ -3027,7 +3042,7 @@ static int decrypt_partition(
+         if (r < 0)
+                 return r;
+ 
+-        r = make_dm_name_and_node_from_node(m->node, "-decrypted", &name, &node);
++        r = make_dm_name_and_node_from_node(m->node, dissected_image_diskseq(di), "-decrypted", &name, &node);
+         if (r < 0)
+                 return r;
+ 
+@@ -3351,6 +3366,7 @@ static usec_t verity_timeout(void) {
+ }
+ 
+ static int verity_partition(
++                DissectedImage *di,
+                 PartitionDesignator designator,
+                 DissectedPartition *m, /* data partition */
+                 DissectedPartition *v, /* verity partition */
+@@ -3365,6 +3381,7 @@ static int verity_partition(
+         _cleanup_close_ int mount_node_fd = -EBADF;
+         int r;
+ 
++        assert(di);
+         assert(m);
+         assert(v || (verity && verity->data_path));
+ 
+@@ -3401,9 +3418,9 @@ static int verity_partition(
+                 if (!root_hash_encoded)
+                         return -ENOMEM;
+ 
+-                r = make_dm_name_and_node(root_hash_encoded, "-verity", &name, &node);
++                r = make_dm_name_and_node(root_hash_encoded, /* diskseq= */ 0, "-verity", &name, &node);
+         } else
+-                r = make_dm_name_and_node_from_node(m->node, "-verity", &name, &node);
++                r = make_dm_name_and_node_from_node(m->node, dissected_image_diskseq(di), "-verity", &name, &node);
+         if (r < 0)
+                 return r;
+ 
+@@ -3534,7 +3551,16 @@ static int verity_partition(
+                  */
+                 sym_crypt_free(cd);
+                 cd = NULL;
+-                return verity_partition(designator, m, v, root, verity, flags & ~DISSECT_IMAGE_VERITY_SHARE, policy_flags, d);
++                return verity_partition(
++                                di,
++                                designator,
++                                m,
++                                v,
++                                root,
++                                verity,
++                                flags & ~DISSECT_IMAGE_VERITY_SHARE,
++                                policy_flags,
++                                d);
+         }
+ 
+         return log_debug_errno(SYNTHETIC_ERRNO(EBUSY), "All attempts to activate verity device %s failed.", name);
+@@ -3605,13 +3631,13 @@ int dissected_image_decrypt(
+ 
+                 PartitionPolicyFlags fl = image_policy_get_exhaustively(policy, i);
+ 
+-                r = decrypt_partition(p, passphrase, flags, fl, d);
++                r = decrypt_partition(m, p, passphrase, flags, fl, d);
+                 if (r < 0)
+                         return r;
+ 
+                 k = partition_verity_hash_of(i);
+                 if (k >= 0) {
+-                        r = verity_partition(i, p, m->partitions + k, root, verity, flags, fl, d);
++                        r = verity_partition(m, i, p, m->partitions + k, root, verity, flags, fl, d);
+                         if (r < 0)
+                                 return r;
+                 }
+-- 
+2.50.1

--- a/sdk_container/src/third_party/portage-stable/sys-apps/systemd/systemd-259.4-r2.ebuild
+++ b/sdk_container/src/third_party/portage-stable/sys-apps/systemd/systemd-259.4-r2.ebuild
@@ -280,6 +280,7 @@ src_unpack() {
 
 src_prepare() {
 	local PATCHES=(
+		"${FILESDIR}/systemd-259.4-dissect-image-include-diskseq-in-dm-names.patch"
 		"${FILESDIR}/systemd-260-mips.patch"
 	)
 


### PR DESCRIPTION
## Summary
Backport the upstream `systemd` dm-verity mapper naming fix that includes the loop `diskseq` in generated device-mapper names for dissected images.

## Why
`systemd-sysext refresh` on Flatcar Alpha `4722.0.0` and Beta `4694.1.0` emits repeated warnings like:

```text
device-mapper: reload ioctl on loop4p1-verity (...) failed: Invalid argument
```

The upstream fix avoids mapper name collisions when loop-backed extension images are dissected repeatedly or concurrently. The issue log shows repeated reuse of `loopNp1-verity` names and device numbers during sysext refresh, which matches this failure mode.

Fixes flatcar/Flatcar#2187.

## Testing
- Not run locally; this is a focused backport of upstream commit `15e9fbc76983` into the `systemd-259.4-r2` ebuild.
