### PR TITLE
ci-automation: verify and cache SDK image archives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 # Flatcar SDK tarballs
 *.tar.bz2
 
+# Record of the container images loaded from the buildcache
+*.id.local
+
 # SDK container env passing helpers
 sdk_container/.env
 sdk_container/.sdkenv

--- a/ci-automation/ci_automation_common.sh
+++ b/ci-automation/ci_automation_common.sh
@@ -216,36 +216,75 @@ function docker_commit_to_buildcache() {
 }
 # --
 
+# Prints the name:tag the image is available under locally, or nothing
+# if it is not present.
+function local_image_name() {
+    local name="$1"
+    local version="$2"
+
+    if image_exists_locally "${name}" "${version}" ; then
+        echo "${name}:${version}"
+    elif image_exists_locally "${CONTAINER_REGISTRY}/${name}" "${version}" ; then
+        echo "${CONTAINER_REGISTRY}/${name}:${version}"
+    fi
+}
+# --
+
+# Prints the ID of a local image, cutting the "sha256:" prefix that is
+# present in Docker but not in Podman.
+function local_image_id() {
+    $docker image inspect "${1}" | jq -r '.[].Id' | sed 's/^sha256://'
+}
+# --
+
+# Prints the image ID published in the buildcache, or "not found".
+function buildcache_image_id() {
+    local name="$1"
+    local version="$2"
+    local id_file="${name}-${version}.id"
+
+    curl --fail --silent --show-error --location --retry-delay 1 \
+        --retry 60 --retry-connrefused --retry-max-time 60 --connect-timeout 20 \
+        "https://${BUILDCACHE_SERVER}/containers/${version}/${id_file}" \
+        || curl --fail --silent --show-error --location --retry-delay 1 \
+        --retry 60 --retry-connrefused --retry-max-time 60 --connect-timeout 20 \
+        "https://mirror.release.flatcar-linux.net/containers/${version}/${id_file}" \
+        || echo "not found"
+}
+# --
+
 function docker_image_from_buildcache() {
     local name="$1"
     local version="$2"
     local compr="${3:-zst}"
     local tgz="${name}-${version}.tar.${compr}"
-    local id_file="${name}-${version}.id"
-    local id_file_url="https://${BUILDCACHE_SERVER}/containers/${version}/${id_file}"
-    local id_file_url_release="https://mirror.release.flatcar-linux.net/containers/${version}/${id_file}"
+    # Holds "<published id> <local id>" of the last image we loaded from
+    # the buildcache.
+    local stamp_file="${name}-${version}.id.local"
+
+    local remote_id=""
+    remote_id=$(buildcache_image_id "${name}" "${version}")
 
     local local_image=""
-    if image_exists_locally "${name}" "${version}" ; then
-        local_image="${name}:${version}"
-    elif image_exists_locally "${CONTAINER_REGISTRY}/${name}" "${version}" ; then
-        local_image="${CONTAINER_REGISTRY}/${name}:${version}"
-    fi
+    local_image=$(local_image_name "${name}" "${version}")
 
     if [[ -n "${local_image}" ]] ; then
         local image_id=""
-        image_id=$($docker image inspect "${local_image}" | jq -r '.[].Id' | sed 's/^sha256://')
-        local remote_id=""
-        remote_id=$(curl --fail --silent --show-error --location --retry-delay 1 \
-                    --retry 60 --retry-connrefused --retry-max-time 60 --connect-timeout 20 \
-                    "${id_file_url}" \
-                    || curl --fail --silent --show-error --location --retry-delay 1 \
-                    --retry 60 --retry-connrefused --retry-max-time 60 --connect-timeout 20 \
-                    "${id_file_url_release}" \
-                    || echo "not found")
+        image_id=$(local_image_id "${local_image}")
         if [ "${image_id}" = "${remote_id}" ]; then
           echo "Local image is up-to-date" >&2
           return
+        fi
+        # docker load derives its own image ID, so a loaded image can
+        # differ from the published one while holding the exact same
+        # content. Compare the published ID against the one the local
+        # image was loaded from instead, and only trust that as long as
+        # the local image itself has not changed since.
+        local stamp=""
+        stamp=$(cat "${stamp_file}" 2>/dev/null) || true
+        if [[ "${stamp}" = "${remote_id} ${image_id}" ]] ; then
+            echo "Local image is up-to-date" >&2
+            return
         fi
         echo "Local image outdated, downloading..." >&2
     fi
@@ -270,6 +309,13 @@ function docker_image_from_buildcache() {
     zstd -d -c ${tgz} | $docker load
 
     rm "${tgz}"
+
+    rm -f "${stamp_file}"
+    local loaded_image=""
+    loaded_image=$(local_image_name "${name}" "${version}")
+    if [[ -n "${loaded_image}" && "${remote_id}" != "not found" ]] ; then
+        echo "${remote_id} $(local_image_id "${loaded_image}")" >"${stamp_file}"
+    fi
 }
 # --
 


### PR DESCRIPTION
Prepared revision: [48a1cb551a](https://github.com/satwiksps/scripts/commit/48a1cb551a3b1b4727970bcfe171860305930895) on `repair/pr-4171`. The original branch is preserved so this closed PR can be reopened; its Files changed tab still shows the old revision. The description below covers the prepared repair.

Classic Docker and containerd image stores can report different IDs for the same saved image, so the SDK fallback downloads it again for each new container ([Flatcar#2086](https://github.com/flatcar/Flatcar/issues/2086)). Cache the archive's published SHA-512 together with the loaded local image ID, and check both before reusing it.

Verify the archive against its existing HTTPS `.DIGESTS` metadata before loading it. Keep metadata and archive on the same mirror, propagate load failures, and write the cache only after the short and registry-qualified tags point to the verified image. Gzip fallback applies when the zstd download is unavailable.

## How to use

From the repository root, run `bash test-container-download.sh` with Bash, jq, zstd, tar, sha512sum and flock available. The tests use local archive fixtures and mock Docker and HTTP operations.

## Testing done

- `bash -n ci-automation/ci_automation_common.sh test-container-download.sh` — passed.
- `git diff --check` — passed.
- `bash test-container-download.sh` on Ubuntu 24.04 — all 12 cases passed with real archive tools and mocked Docker/HTTP operations.
- `bash .repair-validation/sdk-live.sh "$PWD" "$RUNNER_TEMP/sdk-live"` — passed with Docker 29.8.0, using separate classic `overlay2` and containerd image stores in both directions. Checks covered repeated loads, missing or replaced tags, changed digests, corrupt archives, an injected load failure, retry, gzip fallback and concurrent calls.
- `bash .repair-validation/sdk-podman.sh "$PWD" "$RUNNER_TEMP/sdk-podman"` — Podman 4.9.3 archives loaded into both Docker stores, ran the expected payload, and skipped a second download.

The same classic-store archive produced ID `cc11ef4f4d7a...` on its producer and `42d1cddbb377...` on the containerd-store consumer. Reverse-direction IDs also differed. Both tags ran the expected payload after loading. These integration checks use real engines and local archive fixtures; HTTP transport and registry fallback discovery are stubbed.

[Validation logs and artifacts](https://github.com/satwiksps/scripts/actions/runs/34735477956/job/103666024402). The additional integration scripts are on a separate validation branch; the helper and regression-test blobs match this PR. A full SDK or Flatcar image build has not been run.

AI assistance was used for investigation, implementation and regression tests.

- [x] Changelog entry added.
- [ ] Inspected CI output for image differences.
