### PR TITLE
sdk_lib: add GPG signature verification for SDK downloads

### DIFF
--- a/sdk_lib/sdk_util.sh
+++ b/sdk_lib/sdk_util.sh
@@ -24,7 +24,7 @@ sdk_download_tarball() {
     local server url suffix
     local -a suffixes
 
-    suffixes=('' '.DIGESTS') # TODO(marineam): download .asc
+    suffixes=('' '.DIGESTS' '.DIGESTS.asc')
     for server in "${FLATCAR_SDK_SERVERS[@]}"; do
         url="${server}/sdk/${FLATCAR_SDK_ARCH}/${FLATCAR_SDK_VERSION}/${FLATCAR_SDK_TARBALL}"
         info "URL: ${url}"
@@ -72,11 +72,16 @@ _sdk_check_downloads() {
 
 sdk_verify_digests() {
     if [[ ! -f "${FLATCAR_SDK_TARBALL_PATH}" || \
-          ! -f "${FLATCAR_SDK_TARBALL_PATH}.DIGESTS" ]]; then
+          ! -f "${FLATCAR_SDK_TARBALL_PATH}.DIGESTS" || \
+          ! -f "${FLATCAR_SDK_TARBALL_PATH}.DIGESTS.asc" ]]; then
         return 1
     fi
 
-    # TODO(marineam): Add gpg signature verification too.
+    info "Verifying GPG signature of the DIGESTS file..."
+    if ! gpg --verify "${FLATCAR_SDK_TARBALL_PATH}.DIGESTS.asc" "${FLATCAR_SDK_TARBALL_PATH}.DIGESTS"; then
+        error "GPG signature verification failed! The SDK artifact may be compromised."
+        return 1
+    fi
 
     verify_digests "${FLATCAR_SDK_TARBALL_PATH}" || return 1
 }


### PR DESCRIPTION
While looking through the SDK download logic in `sdk_util.sh`, I noticed there was a `TODO` left behind about downloading the `.asc` files and verifying the GPG signatures. 

Right now, we only download the `.DIGESTS` file and use it to check the tarball's integrity. While that's great for catching corrupted downloads, it leaves the build pipeline vulnerable to a compromised mirror or a MitM attack, since a bad actor could easily swap out both the tarball and the digests file with malicious versions.

This PR addresses that by finishing up the TODO. I updated the script to grab the `.DIGESTS.asc` file alongside the tarball, and added a `gpg --verify` step before we actually trust the hashes. This ensures the SDK artifacts are authentic and helps lock down our supply chain security.