### PR TITLE
image_changes: update PATH variable

### DIFF
--- a/ci-automation/image_changes.sh
+++ b/ci-automation/image_changes.sh
@@ -78,7 +78,7 @@ function ricj_callback() {
     )
     show_changes_env+=(
         # Provide a python3 command for the CVE DB parsing
-        "PATH=${PATH}:${PWD}/ci-automation/python-bin"
+        "PATH=${PWD}/ci-automation/python-bin:${PATH}"
         # Override the default locations of repositories.
         "SCRIPTS_REPO=."
         "COREOS_OVERLAY_REPO=../coreos-overlay"


### PR DESCRIPTION
For some reasons, the '#!/usr/bin/env python3' command of the 'show-fixed-kernel-cves.py' started to resolve
'python3' before reaching the 'ci-automation/python-bin' PATH location.

So 'feedparser' was not installed, so it was failing.

I guess we shipped some Python updates providing 'python3' resolution, or we stopped masked some Python related stuffs into the SDK.

Flipping the 'ci-automation/python-bin' should fix the issue and it should not have any side-effects as this is scopped only on the 'show-changes' script call.

