### PR TITLE
fix: defer variable expansion in gc-sdk aliases

### DIFF
--- a/sdk_container/src/third_party/coreos-overlay/coreos-base/oem-gce/files/files/google-cloud-sdk.sh
+++ b/sdk_container/src/third_party/coreos-overlay/coreos-base/oem-gce/files/files/google-cloud-sdk.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-alias gcloud="(docker images google/cloud-sdk || docker pull google/cloud-sdk) > /dev/null;docker run -ti --rm --net=host -v $HOME/.config:/root/.config -v /var/run/docker.sock:/var/run/docker.sock google/cloud-sdk gcloud"
-alias gsutil="(docker images google/cloud-sdk || docker pull google/cloud-sdk) > /dev/null;docker run -ti --rm --net=host -v $HOME/.config:/root/.config google/cloud-sdk gsutil"
-alias python="(docker images python:2-slim || docker pull python:2-slim) > /dev/null;docker run -ti --rm --net=host -v $HOME/.config:/root/.config -v "$PWD":/usr/src/pyapp -w /usr/src/pyapp python:2-slim python"
-alias python3="(docker images python:3-slim || docker pull python:3-slim) > /dev/null;docker run -ti --rm --net=host -v $HOME/.config:/root/.config -v "$PWD":/usr/src/pyapp -w /usr/src/pyapp python:3-slim python"
+alias gcloud='(docker images google/cloud-sdk || docker pull google/cloud-sdk) > /dev/null;docker run -ti --rm --net=host -v "$HOME"/.config:/root/.config -v /var/run/docker.sock:/var/run/docker.sock google/cloud-sdk gcloud'
+alias gsutil='(docker images google/cloud-sdk || docker pull google/cloud-sdk) > /dev/null;docker run -ti --rm --net=host -v "$HOME"/.config:/root/.config google/cloud-sdk gsutil'
+alias python='(docker images python:2-slim || docker pull python:2-slim) > /dev/null;docker run -ti --rm --net=host -v "$HOME"/.config:/root/.config -v "$PWD":/usr/src/pyapp -w /usr/src/pyapp python:2-slim python'
+alias python3='(docker images python:3-slim || docker pull python:3-slim) > /dev/null;docker run -ti --rm --net=host -v "$HOME"/.config:/root/.config -v "$PWD":/usr/src/pyapp -w /usr/src/pyapp python:3-slim python'


### PR DESCRIPTION

# FIX
Wrap aliases in single quotes to evaluate $PWD and $HOME at execution time rather than when the script is sourced.

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done


- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
