### PR TITLE
common.sh: Make `die` in a subshell actually stop everything immediately

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -161,8 +161,29 @@ die_notrace() {
   for line in "$@"; do
     error "${DIE_PREFIX}${line}"
   done
+
+  # `exit` only leaves the current shell. When die is reached inside a $(...)
+  # command substitution or other subshell, the parent keeps running with bad
+  # data and usually hits another die, so the same failure gets reported several
+  # times. BASHPID (unlike $$, which stays the top-level PID even in subshells)
+  # lets us detect that case and signal the main script so the whole run stops
+  # immediately. Passing 0 to kill terminates the whole process group.
+  [[ ${BASHPID:-$$} != $$ ]] && kill -s TERM 0
   exit 1
 }
+
+# When die fires inside a subshell it uses `kill -s TERM 0` to bring the whole
+# process group down (see die_notrace). Without a handler the main shell is
+# terminated by that signal and reports exit code 143. Trap SIGTERM in the
+# top-level shell so it exits with the conventional failure code 1 instead.
+# Subshells reset traps to their default, so they are unaffected and still die
+# immediately from the group signal.
+#
+# Only arm this in the real top-level shell (BASHPID == $$), and never clobber
+# an existing TERM trap. The latter keeps re-sourcing common.sh idempotent and
+# defers to any caller that installed its own handler first. Note that `trap -p`
+# reports the parent's traps even from a command substitution.
+[[ ${BASHPID:-$$} == $$ && -z $(trap -p TERM) ]] && trap 'exit 1' TERM
 
 # Simple version comparison routine
 # Note: not a true semver comparison and build revisions are ignored

--- a/sdk_container/src/third_party/coreos-overlay/coreos/config/env/sys-process/audit
+++ b/sdk_container/src/third_party/coreos-overlay/coreos/config/env/sys-process/audit
@@ -1,7 +1,12 @@
 # Do not install Gentoo-provided audit rules, we will install our own
 # in coreos-base/misc-files. Also skip installing legacy initscripts
 # stuff in /usr/libexec.
-audit_install_mask=" /etc/audit/audit.rules* /usr/libexec "
-INSTALL_MASK+="${audit_install_mask}"
-PKG_INSTALL_MASK+="${audit_install_mask}"
-unset audit_install_mask
+INSTALL_MASK+=" /etc/audit/audit.rules* /usr/libexec "
+
+cros_post_src_install_audit_flatcar_modifications() {
+    # Upstream installs its tmpfiles config file with unnecessarilly
+    # restrictive mode, relax it.
+    #
+    # https://github.com/linux-audit/audit-userspace/pull/547
+    fperms 0644 /usr/lib/tmpfiles.d/audit.conf
+}


### PR DESCRIPTION
Currently, it is more like a slow motion car crash where parent processes continue to execute, usually with bad data that triggers yet more `die` calls.

I had to pull in @krnowak's recent unmerged sys-process/audit permissions fix, as the error triggered by that issue became fatal with this change.

## How to use

Run some image build command that fails.

## Testing done


Before:
```
sdk@flatcar-sdk ~/trunk/src/scripts $ ./build_image --board=../../etc --output_root=/var/tmp --group=dev --getbinpkg
ERROR   setup_board: script called: setup_board '--board=../../etc' '--getbinpkgver=' '--regen_configs_only'
ERROR   setup_board: Backtrace:  (most recent call is last)
ERROR   setup_board:   file setup_board, line 190, called: get_board_arch '../../etc'
ERROR   setup_board:   file toolchain_util.sh, line 105, called: get_board_chost '../../etc'
ERROR   setup_board:   file toolchain_util.sh, line 116, called: die 'Unknown board '../../etc''
ERROR   setup_board: 
ERROR   setup_board: Error was:
ERROR   setup_board:   Unknown board '../../etc'
ERROR   setup_board: script called: setup_board '--board=../../etc' '--getbinpkgver=' '--regen_configs_only'
ERROR   setup_board: Backtrace:  (most recent call is last)
ERROR   setup_board:   file setup_board, line 190, called: get_board_arch '../../etc'
ERROR   setup_board:   file toolchain_util.sh, line 105, called: get_portage_arch 
ERROR   setup_board:   file toolchain_util.sh, line 60, called: die 'Unknown CHOST '''
ERROR   setup_board: 
ERROR   setup_board: Error was:
ERROR   setup_board:   Unknown CHOST ''
ERROR   setup_board: script called: setup_board '--board=../../etc' '--getbinpkgver=' '--regen_configs_only'
ERROR   setup_board: Backtrace:  (most recent call is last)
ERROR   setup_board:   file setup_board, line 190, called: die_err_trap 'BOARD_ARCH=$(get_board_arch "$BOARD")' '1'
ERROR   setup_board: 
ERROR   setup_board: Command failed:
ERROR   setup_board:   Command 'BOARD_ARCH=$(get_board_arch "$BOARD")' exited with nonzero code: 1
ERROR   setup_board:   (Note bash sometimes misreports "command not found" as exit code 1 instead of 127)
ERROR   build_image: script called: build_image '--board=../../etc' '--output_root=/var/tmp' '--group=dev' '--getbinpkg'
ERROR   build_image: Backtrace:  (most recent call is last)
ERROR   build_image:   file build_image, line 102, called: die_err_trap '"${SRC_ROOT}/scripts/setup_board" --board="${FLAGS_board}" --getbinpkgver="${FLAGS_getbinpkgver}" --regen_configs_only' '1'
ERROR   build_image: 
ERROR   build_image: Command failed:
ERROR   build_image:   Command '"${SRC_ROOT}/scripts/setup_board" --board="${FLAGS_board}" --getbinpkgver="${FLAGS_getbinpkgver}" --regen_configs_only' exited with nonzero code: 1
ERROR   build_image:   (Note bash sometimes misreports "command not found" as exit code 1 instead of 127)
```

After:
```
sdk@flatcar-sdk ~/trunk/src/scripts $ ./build_image --board=../../etc --output_root=/var/tmp --group=dev --getbinpkg
ERROR   setup_board: script called: setup_board '--board=../../etc' '--getbinpkgver=' '--regen_configs_only'
ERROR   setup_board: Backtrace:  (most recent call is last)
ERROR   setup_board:   file setup_board, line 190, called: get_board_arch '../../etc'
ERROR   setup_board:   file toolchain_util.sh, line 105, called: get_board_chost '../../etc'
ERROR   setup_board:   file toolchain_util.sh, line 116, called: die 'Unknown board '../../etc''
ERROR   setup_board: 
ERROR   setup_board: Error was:
ERROR   setup_board:   Unknown board '../../etc'
```

I've also run an SDK build under [Jenkins](https://jenkins.flatcar.org/job/container/job/sdk/148/cldsv/) on amd64 and arm64. It passed, apart from the flaky RAID 1 test.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update) -- N/A
- [x] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.