### PR TITLE
fix: inner loop variable in ci-automation

### DIFF
--- a/ci-automation/ci_automation_common.sh
+++ b/ci-automation/ci_automation_common.sh
@@ -472,6 +472,7 @@ function list_files() {
     # rest of the parameters are files or directories to list
     local -n files="${files_variable_name}"
     local file
+    local tmp_file
     local tmp_files
     local pattern=''
 
@@ -491,11 +492,11 @@ function list_files() {
             files+=( "${tmp_files[@]}" )
             continue
         fi
-        for file in "${tmp_files[@]}"; do
-            if [[ "${file}" =~ ${pattern} ]]; then
+        for tmp_file in "${tmp_files[@]}"; do
+            if [[ "${tmp_file}" =~ ${pattern} ]]; then
                 continue
             fi
-            files+=( "${file}" )
+            files+=( "${tmp_file}" )
         done
     done
 }


### PR DESCRIPTION
# Fix

Renamed the inner loop iterator from `file` to `tmp_file`. 

## How to use

[ describe what reviewers need to do in order to validate this PR ]

## Testing done

[Describe the testing you have done before submitting this PR. Please include both the commands you issued as well as the output you got.]

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

