### PR TITLE
ci-automation: Report missing Azure product and plan lookups

### DIFF
--- a/ci-automation/release/azure_marketplace_publish.py
+++ b/ci-automation/release/azure_marketplace_publish.py
@@ -117,8 +117,15 @@ def get_product_durable_id(access_token, offer):
         url=f"https://graph.microsoft.com/rp/product-ingestion/product?externalId={offer}",
         headers={"Authorization": f"Bearer {access_token}"},
     )
+    resp.raise_for_status()
 
-    return resp.json().get("value", [])[0].get("id")
+    # An unknown externalId comes back as an empty list rather than an error, so
+    # report the offer here instead of letting the index raise further down.
+    values = resp.json().get("value", [])
+    if not values:
+        raise ValueError(f"no product found for offer externalId={offer}")
+
+    return values[0].get("id")
 
 
 def get_plan_durable_id(access_token, product_durable_id, plan):
@@ -126,8 +133,15 @@ def get_plan_durable_id(access_token, product_durable_id, plan):
         url=f"https://graph.microsoft.com/rp/product-ingestion/plan?product={product_durable_id}&externalId={plan}",
         headers={"Authorization": f"Bearer {access_token}"},
     )
+    resp.raise_for_status()
 
-    return resp.json().get("value", [])[0].get("id")
+    values = resp.json().get("value", [])
+    if not values:
+        raise ValueError(
+            f"no plan found for externalId={plan} under product {product_durable_id}"
+        )
+
+    return values[0].get("id")
 
 
 def get_image_versions(access_token, product_durable_id, plan_durable_id, corevm=False):


### PR DESCRIPTION
# Fix

`get_product_durable_id` and `get_plan_durable_id` in
`ci-automation/release/azure_marketplace_publish.py` index the product-ingestion response
with `[0]` straight after `.get("value", [])`:

```python
return resp.json().get("value", [])[0].get("id")
```

The `.get("value", [])` default anticipates a missing key, but the index runs either way, so
a response with no results fails with a bare `IndexError: list index out of range`. During a
release publish that means an operator gets a traceback instead of a message saying which
offer or plan was not found.

This checks the list before indexing and raises with the `externalId` that was looked up. It
also calls `raise_for_status()`, so an HTTP error is reported as a request failure rather
than reaching the same line as an empty body.

`get_image_versions()` a few lines below already uses the safe `.get` form, so this brings
the two lookups in line with the rest of the file.

Reported in https://github.com/flatcar/Flatcar/issues/2309.

## How to use

No change in behaviour on the success path — the functions return the same durable id as
before. The difference is only visible when a lookup comes back empty or the request fails,
where the script now stops with a named error instead of an `IndexError`.

Reviewers may want to confirm the choice of raising over returning `None`: the caller does
`product_durable_id.split("/")[1]` immediately afterwards, so returning `None` would move the
failure one line down rather than remove it. Happy to switch to a `logging.error` and
`continue` in the caller loop instead, matching the `generate_az_sas_url` case, if that fits
better.

## Testing done

I do not have Azure marketplace credentials, so the script has not been run against the live
Microsoft product-ingestion API. Instead I loaded the two patched functions directly and
stubbed only `requests` and the azure SDK, so the logic under test is the shipped logic:

```
PASS  empty product list: ValueError: no product found for offer externalId=flatcar-container-linux-free
PASS  missing value key:  ValueError: no product found for offer externalId=does-not-exist
PASS  empty plan list:    ValueError: no plan found for externalId=stable under product product/123
PASS  http 500:           HTTPError: 500 Server Error
PASS  populated product:  'product/abc123'
PASS  populated plan:     'plan/def456'

6/6 checks passed
```

The first three cases are what raised `IndexError` before:

```
$ python -c "{'value': []}.get('value', [])[0].get('id')"
IndexError: list index out of range
```

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)

  Not added — `changelog/README.md` says entries should only contain information relevant to
  end users, and this is internal release automation. Happy to add one if you would rather
  have it recorded.

- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.

  Not applicable — no image content is touched.

---

An LLM was used in producing this change.
