### PR TITLE
sysexts: Drop some more cruft from sysext images

### DIFF
--- a/build_library/sysext_mangle_flatcar-incus
+++ b/build_library/sysext_mangle_flatcar-incus
@@ -5,7 +5,7 @@ rootfs="${1}"
 
 pushd "${rootfs}"
 
-rm -rf ./usr/{lib/debug,lib64/pkgconfig,include}/
+rm -rf ./usr/{lib/debug,lib64/pkgconfig,include,lib64/cmake}/
 
 pushd ./usr/lib/systemd/system
 mkdir -p "multi-user.target.d"

--- a/sdk_container/src/third_party/coreos-overlay/coreos-base/oem-ami/files/manglefs.sh
+++ b/sdk_container/src/third_party/coreos-overlay/coreos-base/oem-ami/files/manglefs.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -euo pipefail
+
+rootfs="${1}"
+
+rm -rf "${rootfs}/usr/lib/debug"

--- a/sdk_container/src/third_party/coreos-overlay/coreos-base/oem-gce/files/manglefs.sh
+++ b/sdk_container/src/third_party/coreos-overlay/coreos-base/oem-gce/files/manglefs.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 
 rootfs=${1}
 
+rm -rf "${rootfs}/usr/lib/debug"
+
 # Remove test stuff from python - it's quite large.
 for p in "${rootfs}"/usr/lib/python*; do
     if [[ ! -d ${p} ]]; then


### PR DESCRIPTION
GCE and AMI OEM images still had debug directories. Incus is about to get an update where two packages (blake3 and xdelta) are installing some cmake stuff.

CI: https://jenkins.flatcar.org/job/container/job/packages_all_arches/543/