### PR TITLE
 fix(pkg_auto): guard against IndexError on empty free_form_lines in get_batches()

### DIFF
--- a/pkg_auto/impl/sort_packages_list.py
+++ b/pkg_auto/impl/sort_packages_list.py
@@ -106,7 +106,7 @@ class Reader:
                 pkg_lines += [line]
             else:
                 if pkg_lines:
-                    while not free_form_lines[-1]:
+                    while free_form_lines and not free_form_lines[-1]:
                         free_form_lines = free_form_lines[:-1]
                     batches += [Reader.CommentBatch(free_form_lines, pkg_lines)]
                     free_form_lines = []


### PR DESCRIPTION
## description
In `pkg_auto/impl/sort_packages_list.py`, the `get_batches()` method accessed
`free_form_lines[-1]` without checking if the list was non-empty first. When a
comment block contained package lines but no preceding free-form lines,
`free_form_lines` would be empty and the `while` condition would raise
`IndexError: list index out of range`.

Fix is a one-word guard added to the `while` condition:
`while free_form_lines and not free_form_lines[-1]:`

Fixes flatcar/Flatcar#2342.

## How to use

Review the single-line change in `pkg_auto/impl/sort_packages_list.py` line 109.
No setup required — the fix is self-evident from the diff.

## Testing done

Verified the fix by code reading. The guard `free_form_lines and` short-circuits
evaluation when the list is empty, preventing the IndexError.

python -m py_compile pkg_auto/impl/sort_packages_list.py

Output: `Exit code 0 (no syntax errors)`
- [ ] Changelog entries added in the respective `changelog/` directory
- [ ] Inspected CI output for image differences