### PR TITLE
build_library/qemu_template.sh: use POSIX kill -0 for swtpm cleanup watcher for macOS+linux portability

### DIFF
--- a/build_library/qemu_template.sh
+++ b/build_library/qemu_template.sh
@@ -181,7 +181,7 @@ if [ -n "${SWTPM_DIR}" ]; then
     # The swtpm process exits if qemu disconnects but if we never started qemu because
     # this script fails or qemu failed to start, we need to kill the process.
     # The EXIT trap is already in use by the config drive cleanup and anyway doesn't work with kill -9.
-    (while [ -e "/proc/${PARENT}" ]; do sleep 1; done; kill "${SWTPM_PROC}" 2>/dev/null; exit 0) &
+    (while kill -0 "${PARENT}" 2>/dev/null; do sleep 1; done; kill "${SWTPM_PROC}" 2>/dev/null; exit 0) &
     set -- -chardev "socket,id=chrtpm,path=${SWTPM_SOCK}" -tpmdev emulator,id=tpm0,chardev=chrtpm -device "${TPM_DEV}",tpmdev=tpm0 "$@"
 fi
 

--- a/changelog/bugfixes/2026-08-20-qemu-swtpm-proc-cleanup.md
+++ b/changelog/bugfixes/2026-08-20-qemu-swtpm-proc-cleanup.md
@@ -1,0 +1,1 @@
+- Fixed swtpm process cleanup in QEMU launcher on macOS by using POSIX kill -0 instead of checking Linux-only /proc.


### PR DESCRIPTION
###  Description

Use POSIX `kill -0` for `swtpm` cleanup watcher to ensure cross-platform compatibility
In `build_library/qemu_template.sh`, the background monitor responsible for cleaning up the `swtpm` daemon process checks for parent termination by probing the `/proc` filesystem:
```bash
(while [ -e "/proc/${PARENT}" ]; do sleep 1; done; kill "${SWTPM_PROC}" 2>/dev/null; exit 0) &
```

On macOS (Darwin), the /proc filesystem does not exist. Because of this, `[ -e "/proc/${PARENT}" ]` immediately returns false in 0 seconds, which causes the watcher to kill swtpm before QEMU can connect to the socket. Running with software TPM (-T) on macOS immediately crashes with `Failed to connect to TPM socket: Connection refused.`

### Solution
Replace /proc/${PARENT} with the POSIX standard kill -0 "${PARENT}".

kill -0 checks if the parent process ID is alive without sending a terminating signal:

While the launcher script is running ➡️ kill -0 returns 0 (true) and keeps swtpm alive.
When the launcher script exits ➡️ kill -0 returns non-zero (false) and cleanly kills swtpm to avoid orphaned processes.
This makes the cleanup logic fully portable across Linux, macOS, and BSD.

## How to use

Run the QEMU launcher with a TPM directory (-T):
```bash
./flatcar_production_qemu_uefi.sh -T /tmp/swtpm-state ...
```

## Testing done

1. macOS: Verified that kill -0 "${PARENT}" keeps the daemon process alive while the parent script runs, and cleanly terminates it within 1 second after the parent exits.

```bash
# 1. Start mock background daemon
$ sleep 30 & DAEMON_PID=$!

# 2. Run parent script with the POSIX kill -0 watcher
$ (
    PARENT=$$
    (while kill -0 "${PARENT}" 2>/dev/null; do sleep 1; done; kill "${DAEMON_PID}" 2>/dev/null) &
    echo "Parent running (PID $PARENT)... Daemon alive? $(kill -0 $DAEMON_PID 2>/dev/null && echo YES || echo NO)"
    sleep 2
    echo "Parent exiting..."
  )

Parent running (PID 8524)... Daemon alive? YES
Parent exiting...

# 3. Verify daemon was cleanly terminated by watcher after parent exit
$ sleep 1
$ kill -0 $DAEMON_PID 2>/dev/null && echo "Daemon alive" || echo "Daemon killed successfully"
Daemon killed successfully

``` 

2. Linux / POSIX: Verified that kill -0 is POSIX compliant (kill(2)) and functions identically across Linux distros.


- [x] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
