### PR TITLE
ci-automation/gc: pass ORACLECLOUD* variables to mantle container

### DIFF
--- a/ci-automation/garbage_collect.sh
+++ b/ci-automation/garbage_collect.sh
@@ -265,6 +265,11 @@ function _garbage_collect_impl() {
       --env AKAMAI_TOKEN \
       --env STACKIT_SERVICE_ACCOUNT \
       --env STACKIT_PROJECT_ID \
+      --env ORACLECLOUD_TENANCY \
+      --env ORACLECLOUD_USER \
+      --env ORACLECLOUD_FINGERPRINT \
+      --env ORACLECLOUD_PRIVATE_KEY \
+      --env ORACLECLOUD_COMPARTMENT_ID \
       -w /work -v "$PWD":/work "${mantle_ref}" /work/ci-automation/garbage_collect_cloud.sh
 
     echo


### PR DESCRIPTION
Otherwise the variable is not present in the container:
```
 /work/ci-automation/garbage_collect_cloud.sh: line 28: ORACLECLOUD_TENANCY: unbound variable
```

Follow-up from: https://github.com/flatcar/scripts/pull/4143 (this does not need to be backported)