### PR TITLE
Bump python to 3.13

### DIFF
--- a/changelog/security/2026-08-26-python-bump.md
+++ b/changelog/security/2026-08-26-python-bump.md
@@ -1,0 +1,1 @@
+- python ([CVE-2026-1502](https://www.cve.org/CVERecord/?id=CVE-2026-1502), [CVE-2026-6100](https://www.cve.org/CVERecord/?id=CVE-2026-6100))

--- a/changelog/updates/2026-08-26-python-bump.md
+++ b/changelog/updates/2026-08-26-python-bump.md
@@ -1,0 +1,1 @@
+- python ([3.13.14](https://www.python.org/downloads/release/python-31314/))

--- a/sdk_container/src/third_party/coreos-overlay/profiles/coreos/base/make.defaults
+++ b/sdk_container/src/third_party/coreos-overlay/profiles/coreos/base/make.defaults
@@ -18,13 +18,13 @@ USE_EXPAND="${USE_EXPAND} GO_VERSION"
 
 USE="${USE} -cracklib -cups -tcpd -berkdb"
 
-# Use Python 3.12 as the default version.
-PYTHON_SINGLE_TARGET="-pypy3_11 -python3_11 python3_12 -python3_13 -python3_14 -python3_15 -python3_13t -python3_14t -python3_15t"
-PYTHON_TARGETS="-pypy3_11 -python3_11 python3_12 -python3_13 -python3_14 -python3_15 -python3_13t -python3_14t -python3_15t"
+# Use Python 3.13 as the default version.
+PYTHON_SINGLE_TARGET="-python3_12 python3_13 -python3_14 -python3_15 -python3_14t -python3_15t"
+PYTHON_TARGETS="-python3_12 python3_13 -python3_14 -python3_15 -python3_14t -python3_15t"
 
 # Same as above, but for bootstrapping.
-BOOTSTRAP_USE="${BOOTSTRAP_USE} -python_single_target_pypy3_11 -python_single_target_python3_11 python_single_target_python3_12 -python_single_target_python3_13 -python_single_target_python3_14 -python_single_target_python3_15 -python_single_target_python3_13t -python_single_target_python3_14t -python_single_target_python3_15t"
-BOOTSTRAP_USE="${BOOTSTRAP_USE} -python_targets_pypy3_11 -python_targets_python3_11 python_targets_python3_12 -python_targets_python3_13 -python_targets_python3_14 -python_targets_python3_15 -python_targets_python3_13t -python_targets_python3_14t -python_targets_python3_15t"
+BOOTSTRAP_USE="${BOOTSTRAP_USE} -python_single_target_python3_12 python_single_target_python3_13 -python_single_target_python3_14 -python_single_target_python3_15 -python_single_target_python3_14t -python_single_target_python3_15t"
+BOOTSTRAP_USE="${BOOTSTRAP_USE} -python_targets_python3_12 python_targets_python3_13 -python_targets_python3_14 -python_targets_python3_15 -python_targets_python3_14t -python_targets_python3_15t"
 
 
 # Never install cron or cron jobs

--- a/sdk_container/src/third_party/coreos-overlay/profiles/coreos/base/package.mask
+++ b/sdk_container/src/third_party/coreos-overlay/profiles/coreos/base/package.mask
@@ -17,8 +17,8 @@
 # Do not install python versions that were "disabled" in
 # PYTHON_TARGETS. For some reason emerge still insists on installing
 # those as a dependency for some packages.
-<dev-lang/python-3.12
->=dev-lang/python-3.13
+<dev-lang/python-3.13
+>=dev-lang/python-3.14
 
 # We are using RedHat patches for grub, so until they rebase them on
 # top of 2.14, we are locked out of the update.

--- a/sdk_container/src/third_party/coreos-overlay/profiles/coreos/targets/sdk/transition/make.defaults
+++ b/sdk_container/src/third_party/coreos-overlay/profiles/coreos/targets/sdk/transition/make.defaults
@@ -1,9 +1,9 @@
 # Override python settings
 
-# Use Python 3.12 as the default version, allow python 3.11 for a transition.
-PYTHON_SINGLE_TARGET="-pypy3_11 -python3_11 python3_12 -python3_13 -python3_14 -python3_13t -python3_14t"
-PYTHON_TARGETS="-pypy3_11 python3_11 python3_12 -python3_13 -python3_14 -python3_13t -python3_14t"
+# Use Python 3.13 as the default version, allow python 3.12 for a transition.
+PYTHON_SINGLE_TARGET="-python3_12 python3_13 -python3_14 -python3_15 -python3_14t -python3_15t"
+PYTHON_TARGETS="python3_12 python3_13 -python3_14 -python3_15 -python3_14t -python3_15t"
 
 # Same as above, but for bootstrapping.
-BOOTSTRAP_USE="${BOOTSTRAP_USE} -python_single_target_pypy3_11 -python_single_target_python3_11 python_single_target_python3_12 -python_single_target_python3_13 -python_single_target_python3_14  -python_single_target_python3_13t -python_single_target_python3_14t"
-BOOTSTRAP_USE="${BOOTSTRAP_USE} -python_targets_pypy3_11 python_targets_python3_11 python_targets_python3_12 -python_targets_python3_13 -python_targets_python3_14 -python_targets_python3_13t -python_targets_python3_14t"
+BOOTSTRAP_USE="${BOOTSTRAP_USE} -python_single_target_python3_12 python_single_target_python3_13 -python_single_target_python3_14 -python_single_target_python3_15 -python_single_target_python3_14t -python_single_target_python3_15t"
+BOOTSTRAP_USE="${BOOTSTRAP_USE} python_targets_python3_12 python_targets_python3_13 -python_targets_python3_14 -python_targets_python3_15 -python_targets_python3_14t -python_targets_python3_15t"

--- a/sdk_container/src/third_party/coreos-overlay/profiles/coreos/targets/sdk/transition/package.unmask
+++ b/sdk_container/src/third_party/coreos-overlay/profiles/coreos/targets/sdk/transition/package.unmask
@@ -1,1 +1,1 @@
-=dev-lang/python-3.11*
+=dev-lang/python-3.12*


### PR DESCRIPTION
Partially addresses https://github.com/flatcar/Flatcar/issues/2081.

CI passed: https://jenkins.flatcar.org/job/container/job/sdk/174/cldsv/