### PR TITLE
Build sysext DDIs with a 4K sector size

### DIFF
--- a/build_sysext
+++ b/build_sysext
@@ -331,6 +331,7 @@ else
 fi
 
 systemd-repart \
+  --sector-size=4096 \
   --private-key="${SYSEXT_SIGNING_KEY_DIR}/sysexts.key" \
   --certificate="${SYSEXT_SIGNING_KEY_DIR}/sysexts.crt" \
   --make-ddi=sysext \


### PR DESCRIPTION
# Build sysext DDIs with a 4K sector size

systemd-repart's --make-ddi auto-sizes the image to the exact minimum.
Since systemd v261.2 the tail GPT reserve is (16KiB + one sector) and is
no longer rounded up, so with the default 512-byte sector the total
image size is not a multiple of 4096 which breaks update_engine's
delta_generator. Pass an explicit --sector-size=4096 so that repart
produces 4k-aligned sysexts.


## How to use 

Rebuild flatcar and check all sysexts (especially overlaybd) have sizes aligned to 4K

## Testing done

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.