### PR TITLE
docs: fix typos in PREFIX.md and ci-automation README

### DIFF
--- a/PREFIX.md
+++ b/PREFIX.md
@@ -4,7 +4,7 @@
 
 ## Path to stabilisation TODO list
 
-Before prefix build support are considered stable, the below must be implemented:
+Before prefix build support is considered stable, the below must be implemented:
 1. Integrate `cb-bootstrap` with the Flatcar SDK.
    Currently, `setup_prefix` uses cross-boss' `cb-bootstrap` to set up the prefix environment.
    Bootstrapping must be fully integrated with the Flatcar SDK before prefix builds are considered stable.
@@ -51,7 +51,7 @@ Cross-boss location can be customised via the `--cross_boss_root` option to `set
 ## Quick-start guide
 
 For working with a prefix, you will need to agree on:
-1. A name for the prefix. Should be a single word and is used for generating protage wrappers.
+1. A name for the prefix. Should be a single word and is used for generating portage wrappers.
 2. A prefix directory where applications and libraries will live on the target system.
    For use with systemd-sysext this should be a path below `/usr` or `/opt`.
 

--- a/ci-automation/README.md
+++ b/ci-automation/README.md
@@ -19,7 +19,7 @@ Please refer to the individual scripts for prerequisites, input parameters, and 
 
 The build pipeline can be used to build everything from scratch, including the SDK (starting from 1. below) or to build a new OS image (starting from 3.).
 "From scratch" builds (i.e. builds which include a new SDK) are usually only done for the `main` branch (`main` can be considered `alpha-next`).
-Release / maintenance branches in the majority of cases do note build a new SDK but start with the OS image build.
+Release / maintenance branches in the majority of cases do not build a new SDK but start with the OS image build.
 Release branches usually use the SDK introduced when the new major version was branched off `main` throughout the lifetime of the major version; i.e. release `stable-MMMM.mm.pp` would use `SDK-MMMM.0.0`.
 
 To reproduce any given build step, follow this pattern:
@@ -165,5 +165,5 @@ It is recommended to stop firewalling on the host the tests are run on (for exam
 
 * `QEMU_IMAGE_NAME` - file name of the QEmu image to fetch from bincache.
 * `QEMU_PARALLEL` - Number of parallel test cases to run.
-                  Note that test cases may involve launching mutliple QEmu VMs (network testing etc.).
-                  Tests are memory bound, not CPU bound; e.g. `20` is a sensible value for a 6 core / 12 threads systwem w/ 32 GB RAM.
+                  Note that test cases may involve launching multiple QEmu VMs (network testing etc.).
+                  Tests are memory bound, not CPU bound; e.g. `20` is a sensible value for a 6 core / 12 threads system w/ 32 GB RAM.


### PR DESCRIPTION
## Why

Two small English mistakes in `PREFIX.md` and `ci-automation/README.md`: a subject-verb agreement error, a "protage" -> "portage" typo, a "do note" -> "do not" typo, and two misspellings ("mutliple" -> "multiple", "systwem" -> "system").

## Overview

- `PREFIX.md`: fixed "are considered stable" -> "is considered stable", "protage wrappers" -> "portage wrappers".
- `ci-automation/README.md`: fixed "do note build" -> "do not build", "mutliple QEmu VMs" -> "multiple QEmu VMs", "12 threads systwem" -> "12 threads system".

No code changes, docs only.

## Testing

Read-through only; these are prose corrections in Markdown files.
