### PR TITLE
build_library: use smaller rootfs for Akamai

### DIFF
--- a/build_library/vm_image_util.sh
+++ b/build_library/vm_image_util.sh
@@ -230,7 +230,6 @@ IMG_kubevirt_OEM_SYSEXT=kubevirt
 IMG_kubevirt_DISK_EXTENSION=qcow2
 
 ## akamai (Linode)
-IMG_akamai_DISK_LAYOUT=vm
 IMG_akamai_OEM_SYSEXT=akamai
 
 # proxmoxve


### PR DESCRIPTION
This was working fine until Linode enforced the size limit (i.e 6Gb uncompressed image).

rootfs should expand to the available disk size anyway.


---
This partially reverts: https://github.com/flatcar/scripts/commit/f0c94a9107739fbb572f7b7568ac7c3f14ce6c21
```
$ find alpha-44* -type f -exec du --si {} +;
545M    alpha-4459/flatcar_production_akamai_image.bin.gz
4.8G    alpha-4459/flatcar_production_akamai_image.bin
544M    alpha-4487/flatcar_production_akamai_image.bin.gz
14G     alpha-4487/flatcar_production_akamai_image.bin
```

This creates a raw disk of `7.88Gib`:
```
$ fdisk -l ./flatcar_production_akamai_image.bin
Disk ./flatcar_production_akamai_image.bin: 7.88 GiB, 8455716864 bytes, 16515072 sectors
Units: sectors of 1 * 512 = 512 bytes
Sector size (logical/physical): 512 bytes / 512 bytes
I/O size (minimum/optimal): 512 bytes / 512 bytes
Disklabel type: gpt
Disk identifier: 00000000-0000-0000-0000-000000000001

Device                                    Start      End Sectors  Size Type
./flatcar_production_akamai_image.bin1     4096  2101247 2097152    1G EFI System
./flatcar_production_akamai_image.bin2  2101248  2105343    4096    2M BIOS boot
./flatcar_production_akamai_image.bin3  2105344  6299647 4194304    2G unknown
./flatcar_production_akamai_image.bin4  6299648 10493951 4194304    2G unknown
./flatcar_production_akamai_image.bin6 10493952 12591103 2097152    1G Linux filesystem
./flatcar_production_akamai_image.bin7 12591104 12722175  131072   64M unknown
./flatcar_production_akamai_image.bin9 12722176 16375807 3653632  1.7G unknown
```

It's not ideal, but we can't lower more.

- [ ] Changelog entries added in the respective `changelog/` directory (user-facing change, bug fix, security fix, update)
- [ ] Inspected CI output for image differences: `/boot` and `/usr` size, packages, list files for any missing binaries, kernel modules, config files, kernel modules, etc.
- [ ] CI: https://jenkins.flatcar.org/job/container/job/packages_all_arches/691/cldsv/

<!-- For coreos-overlay ebuild modifications that include a CROS_WORKON_COMMIT bump, did you bump too the ebuild revision ? -->
