### PR TITLE
changelog: Add entries for bubblewrap

### DIFF
--- a/changelog/security/2026-09-08-weekly-updates.md
+++ b/changelog/security/2026-09-08-weekly-updates.md
@@ -1,3 +1,4 @@
+- bubblewrap ([CVE-2026-87766](https://www.cve.org/CVERecord?id=CVE-2026-87766))
 - docker ([CVE-2026-46680](https://www.cve.org/CVERecord?id=CVE-2026-46680))
 - etcd ([CVE-2025-22869](https://www.cve.org/CVERecord?id=CVE-2025-22869), [CVE-2025-30204](https://www.cve.org/CVERecord?id=CVE-2025-30204), [CVE-2026-33186](https://www.cve.org/CVERecord?id=CVE-2026-33186), [CVE-2026-73500](https://www.cve.org/CVERecord?id=CVE-2026-73500))
 - expat ([CVE-2026-66046](https://www.cve.org/CVERecord?id=CVE-2026-66046), [CVE-2026-76641](https://www.cve.org/CVERecord?id=CVE-2026-76641), [CVE-2026-76956](https://www.cve.org/CVERecord?id=CVE-2026-76956), [CVE-2026-76957](https://www.cve.org/CVERecord?id=CVE-2026-76957))

--- a/changelog/updates/2026-09-08-weekly-updates.md
+++ b/changelog/updates/2026-09-08-weekly-updates.md
@@ -1,3 +1,4 @@
+- SDK: bubblewrap ([0.12.0](https://github.com/containers/bubblewrap/releases/tag/v0.12.0))
 - SDK: rust ([1.97.1](https://blog.rust-lang.org/2026/07/16/Rust-1.97.1/) (includes [1.97.0](https://blog.rust-lang.org/2026/07/09/Rust-1.97.0/)))
 - azure, dev, gce, sysext-python: python ([3.13.15](https://docs.python.org/release/3.13.15/whatsnew/changelog.html#python-3-13-15-final))
 - base, dev: btrfs-progs ([7.1](https://github.com/kdave/btrfs-progs/releases/tag/v7.1))


### PR DESCRIPTION
Bubblewrap got updated in https://github.com/flatcar/scripts/pull/4263, but forgot to add a changelog entry for it. Normally I wouldn't do it, because it's a part of the SDK, but it came with a security fix. Thus let's mention it in the changelog.

Closes https://github.com/flatcar/Flatcar/issues/2417.
